### PR TITLE
Blend weights vertex formats

### DIFF
--- a/Components/RTShaderSystem/src/OgreShaderExHardwareSkinning.cpp
+++ b/Components/RTShaderSystem/src/OgreShaderExHardwareSkinning.cpp
@@ -476,11 +476,24 @@ bool HardwareSkinningFactory::extractSkeletonData(const Entity* pEntity, size_t 
             isValidData = true;
             switch (pDeclWeights->getType())
             {
-            case VET_FLOAT1: weightCount = 1; break;
-            case VET_FLOAT2: weightCount = 2; break;
-            case VET_FLOAT3: weightCount = 3; break;
-            case VET_FLOAT4: weightCount = 4; break;
-            default: isValidData = false; 
+            case VET_FLOAT1:
+                weightCount = 1;
+                break;
+            case VET_USHORT2_NORM:
+            case VET_FLOAT2:
+                weightCount = 2;
+                break;
+            case VET_FLOAT3:
+                weightCount = 3;
+                break;
+            case VET_USHORT4_NORM:
+            case VET_UBYTE4_NORM:
+            case VET_FLOAT4:
+                weightCount = 4;
+                break;
+            default:
+                isValidData = false;
+                break;
             }
         }
     }

--- a/OgreMain/include/OgreHardwareVertexBuffer.h
+++ b/OgreMain/include/OgreHardwareVertexBuffer.h
@@ -118,22 +118,24 @@ namespace Ogre {
         VET_FLOAT4 = 3,
         /// alias to more specific colour type - use the current rendersystem's colour packing
         VET_COLOUR = 4,
-        VET_SHORT1 = 5,
+        VET_SHORT1 = 5,  /// AVOID (see note below)
         VET_SHORT2 = 6,
-        VET_SHORT3 = 7,
+        VET_SHORT3 = 7,  /// AVOID (see note below)
         VET_SHORT4 = 8,
         VET_UBYTE4 = 9,
         /// D3D style compact colour
         VET_COLOUR_ARGB = 10,
         /// GL style compact colour
         VET_COLOUR_ABGR = 11,
+
+        // the following are not universally supported on all hardware:
         VET_DOUBLE1 = 12,
         VET_DOUBLE2 = 13,
         VET_DOUBLE3 = 14,
         VET_DOUBLE4 = 15,
-        VET_USHORT1 = 16,
+        VET_USHORT1 = 16,  /// AVOID (see note below)
         VET_USHORT2 = 17,
-        VET_USHORT3 = 18,
+        VET_USHORT3 = 18,  /// AVOID (see note below)
         VET_USHORT4 = 19,      
         VET_INT1 = 20,
         VET_INT2 = 21,
@@ -142,7 +144,21 @@ namespace Ogre {
         VET_UINT1 = 24,
         VET_UINT2 = 25,
         VET_UINT3 = 26,
-        VET_UINT4 = 27
+        VET_UINT4 = 27,
+        VET_BYTE4 = 28,  // signed bytes
+        // normalized types (range is either 0 to 1 or -1 to 1)
+        VET_BYTE4_NORM = 29,   // signed normalized bytes
+        VET_UBYTE4_NORM = 30,  // unsigned normalized bytes
+        VET_SHORT2_NORM = 31,  // signed normalized shorts
+        VET_SHORT4_NORM = 32,
+        VET_USHORT2_NORM = 33, // unsigned normalized shorts
+        VET_USHORT4_NORM = 34
+
+        // Note that SHORT1, SHORT3, USHORT1 and USHORT3 should never be used
+        // because they aren't supported on any known hardware -- their size
+        // is not a multiple of 4 bytes.
+        // These values should be removed when possible.  Try to avoid breaking the mesh
+        // serializer though.
     };
 
     /** This class declares the usage of a single vertex buffer as a component
@@ -187,14 +203,17 @@ namespace Ogre {
         size_t getSize(void) const;
         /// Utility method for helping to calculate offsets
         static size_t getTypeSize(VertexElementType etype);
-        /// Utility method which returns the count of values in a given type
+        /// Utility method which returns the count of values in a given type (result for colors may be counter-intuitive)
         static unsigned short getTypeCount(VertexElementType etype);
-        /** Simple converter function which will turn a single-value type into a
-            multi-value type based on a parameter.
+        /** Simple converter function which will return a type large enough to hold 'count' values
+            of the same type as the values in 'baseType'.  The 'baseType' parameter should have the
+            smallest count available.  The return type may have the count rounded up to the next multiple
+            of 4 bytes.  Byte types will always return a 4-count type, while short types will return either
+            a 2-count or 4-count type.
         */
         static VertexElementType multiplyTypeCount(VertexElementType baseType, unsigned short count);
-        /** Simple converter function which will a type into it's single-value
-            equivalent - makes switches on type easier.
+        /** Simple converter function which will turn a type into it's single-value (or lowest multiple-value)
+            equivalent - makes switches on type easier.  May give counter-intuitive results with bytes or shorts.
         */
         static VertexElementType getBaseType(VertexElementType multiType);
 

--- a/OgreMain/include/OgreHardwareVertexBuffer.h
+++ b/OgreMain/include/OgreHardwareVertexBuffer.h
@@ -109,7 +109,13 @@ namespace Ogre {
         VES_COUNT = 9
     };
 
-    /// Vertex element type, used to identify the base types of the vertex contents
+    /**
+     * Vertex element type, used to identify the base types of the vertex contents
+     *
+     * @note VET_SHORT1, VET_SHORT3, VET_USHORT1 and VET_USHORT3 should never be used
+     * because they aren't supported on any known hardware - they are unaligned as their size
+     * is not a multiple of 4 bytes. Therefore drivers usually must add padding on upload.
+     */
     enum VertexElementType
     {
         VET_FLOAT1 = 0,
@@ -118,9 +124,9 @@ namespace Ogre {
         VET_FLOAT4 = 3,
         /// alias to more specific colour type - use the current rendersystem's colour packing
         VET_COLOUR = 4,
-        VET_SHORT1 = 5,  /// AVOID (see note below)
+        VET_SHORT1 = 5,  /// @deprecated (see note)
         VET_SHORT2 = 6,
-        VET_SHORT3 = 7,  /// AVOID (see note below)
+        VET_SHORT3 = 7,  /// @deprecated (see note)
         VET_SHORT4 = 8,
         VET_UBYTE4 = 9,
         /// D3D style compact colour
@@ -133,10 +139,10 @@ namespace Ogre {
         VET_DOUBLE2 = 13,
         VET_DOUBLE3 = 14,
         VET_DOUBLE4 = 15,
-        VET_USHORT1 = 16,  /// AVOID (see note below)
+        VET_USHORT1 = 16,  /// @deprecated (see note)
         VET_USHORT2 = 17,
-        VET_USHORT3 = 18,  /// AVOID (see note below)
-        VET_USHORT4 = 19,      
+        VET_USHORT3 = 18,  /// @deprecated (see note)
+        VET_USHORT4 = 19,
         VET_INT1 = 20,
         VET_INT2 = 21,
         VET_INT3 = 22,
@@ -145,20 +151,13 @@ namespace Ogre {
         VET_UINT2 = 25,
         VET_UINT3 = 26,
         VET_UINT4 = 27,
-        VET_BYTE4 = 28,  // signed bytes
-        // normalized types (range is either 0 to 1 or -1 to 1)
-        VET_BYTE4_NORM = 29,   // signed normalized bytes
-        VET_UBYTE4_NORM = 30,  // unsigned normalized bytes
-        VET_SHORT2_NORM = 31,  // signed normalized shorts
+        VET_BYTE4 = 28,  /// signed bytes
+        VET_BYTE4_NORM = 29,   /// signed bytes (normalized to -1..1)
+        VET_UBYTE4_NORM = 30,  /// unsigned bytes (normalized to 0..1)
+        VET_SHORT2_NORM = 31,  /// signed shorts (normalized to -1..1)
         VET_SHORT4_NORM = 32,
-        VET_USHORT2_NORM = 33, // unsigned normalized shorts
+        VET_USHORT2_NORM = 33, /// unsigned shorts (normalized to 0..1)
         VET_USHORT4_NORM = 34
-
-        // Note that SHORT1, SHORT3, USHORT1 and USHORT3 should never be used
-        // because they aren't supported on any known hardware -- their size
-        // is not a multiple of 4 bytes.
-        // These values should be removed when possible.  Try to avoid breaking the mesh
-        // serializer though.
     };
 
     /** This class declares the usage of a single vertex buffer as a component

--- a/OgreMain/include/OgreMeshManager.h
+++ b/OgreMain/include/OgreMeshManager.h
@@ -403,13 +403,9 @@ namespace Ogre {
         @remarks
         This takes effect when meshes are loaded.  Default is VET_FLOAT1.
         Valid values are:
-        VET_UBYTE4:        8-bit blend weights.  Lowest memory cost but may have precision issues.  Shader must multiply incoming blend weights with 1/255.  No software skinning.
         VET_UBYTE4_NORM:   8-bit blend weights.  Lowest memory cost but may have precision issues.  Requires SM2.0+ vertex shader.  No software skinning.
-        VET_USHORT2:       16-bit blend weights.  Shader must multiply incoming blend weights with 1/65535.  No software skinning.
         VET_USHORT2_NORM:  16-bit blend weights.  Requires SM2.0+ vertex shader.  No software skinning.
-        VET_SHORT2:        15-bit blend weights.  Shader must multiply incoming blend weights with 1/32767.  No software skinning.
-        VET_SHORT2_NORM:   15-bit blend weights.  May work on platforms that do not support VET_USHORT2_NORM.  No software skinning.
-        VET_FLOAT1:        23-bit blend weights.  Highest memory cost.  Supports hardware and software skinning.
+        VET_FLOAT1:        32-bit blend weights.  Highest memory cost.  Supports hardware and software skinning.
         */
         void setBlendWeightsBaseElementType( VertexElementType vet );
 

--- a/OgreMain/include/OgreMeshManager.h
+++ b/OgreMain/include/OgreMeshManager.h
@@ -34,6 +34,7 @@ THE SOFTWARE.
 #include "OgreSingleton.h"
 #include "OgreVector3.h"
 #include "OgreHardwareBuffer.h"
+#include "OgreHardwareVertexBuffer.h"
 #include "OgrePatchSurface.h"
 #include "OgreHeaderPrefix.h"
 
@@ -392,6 +393,26 @@ namespace Ogre {
         /// @copydoc Singleton::getSingleton()
         static MeshManager* getSingletonPtr(void);
 
+        /** Gets the base element type used for blend weights in vertex buffers.
+        @remarks
+        See the remarks below for SetBlendWeightsBaseElementType().
+        */
+        VertexElementType getBlendWeightsBaseElementType() const;
+
+        /** sets the base element type used for blend weights in vertex buffers.
+        @remarks
+        This takes effect when meshes are loaded.  Default is VET_FLOAT1.
+        Valid values are:
+        VET_UBYTE4:        8-bit blend weights.  Lowest memory cost but may have precision issues.  Shader must multiply incoming blend weights with 1/255.  No software skinning.
+        VET_UBYTE4_NORM:   8-bit blend weights.  Lowest memory cost but may have precision issues.  Requires SM2.0+ vertex shader.  No software skinning.
+        VET_USHORT2:       16-bit blend weights.  Shader must multiply incoming blend weights with 1/65535.  No software skinning.
+        VET_USHORT2_NORM:  16-bit blend weights.  Requires SM2.0+ vertex shader.  No software skinning.
+        VET_SHORT2:        15-bit blend weights.  Shader must multiply incoming blend weights with 1/32767.  No software skinning.
+        VET_SHORT2_NORM:   15-bit blend weights.  May work on platforms that do not support VET_USHORT2_NORM.  No software skinning.
+        VET_FLOAT1:        23-bit blend weights.  Highest memory cost.  Supports hardware and software skinning.
+        */
+        void setBlendWeightsBaseElementType( VertexElementType vet );
+
         /** Gets the factor by which the bounding box of an entity is padded.
             Default is 0.01
         */
@@ -468,6 +489,9 @@ namespace Ogre {
         void loadManualCurvedPlane(Mesh* pMesh, MeshBuildParams& params);
         /** Utility method for manual loading a curved illusion plane */
         void loadManualCurvedIllusionPlane(Mesh* pMesh, MeshBuildParams& params);
+
+        // element type for blend weights in vertex buffer (VET_UBYTE4, VET_USHORT1, or VET_FLOAT1)
+        VertexElementType mBlendWeightsBaseElementType;
 
         bool mPrepAllMeshesForShadowVolumes;
     

--- a/OgreMain/src/OgreHardwareVertexBuffer.cpp
+++ b/OgreMain/src/OgreHardwareVertexBuffer.cpp
@@ -149,39 +149,38 @@ namespace Ogre {
         case VET_DOUBLE4:
             return sizeof(double)*4;
         case VET_SHORT1:
-            return sizeof(short);
-        case VET_SHORT2:
-            return sizeof(short)*2;
-        case VET_SHORT3:
-            return sizeof(short)*3;
-        case VET_SHORT4:
-            return sizeof(short)*4;
         case VET_USHORT1:
-            return sizeof(unsigned short);
+            return sizeof( short );
+        case VET_SHORT2:
+        case VET_SHORT2_NORM:
         case VET_USHORT2:
-            return sizeof(unsigned short)*2;
+        case VET_USHORT2_NORM:
+            return sizeof( short ) * 2;
+        case VET_SHORT3:
         case VET_USHORT3:
-            return sizeof(unsigned short)*3;
+            return sizeof( short ) * 3;
+        case VET_SHORT4:
+        case VET_SHORT4_NORM:
         case VET_USHORT4:
-            return sizeof(unsigned short)*4;
+        case VET_USHORT4_NORM:
+            return sizeof( short ) * 4;
         case VET_INT1:
-            return sizeof(int);
-        case VET_INT2:
-            return sizeof(int)*2;
-        case VET_INT3:
-            return sizeof(int)*3;
-        case VET_INT4:
-            return sizeof(int)*4;
         case VET_UINT1:
-            return sizeof(unsigned int);
+            return sizeof( int );
+        case VET_INT2:
         case VET_UINT2:
-            return sizeof(unsigned int)*2;
+            return sizeof( int ) * 2;
+        case VET_INT3:
         case VET_UINT3:
-            return sizeof(unsigned int)*3;
+            return sizeof( int ) * 3;
+        case VET_INT4:
         case VET_UINT4:
-            return sizeof(unsigned int)*4;
+            return sizeof( int ) * 4;
+        case VET_BYTE4:
+        case VET_BYTE4_NORM:
         case VET_UBYTE4:
-            return sizeof(unsigned char)*4;
+        case VET_UBYTE4_NORM:
+            return sizeof(char)*4;
         }
         return 0;
     }
@@ -202,7 +201,9 @@ namespace Ogre {
             return 1;
         case VET_FLOAT2:
         case VET_SHORT2:
+        case VET_SHORT2_NORM:
         case VET_USHORT2:
+        case VET_USHORT2_NORM:
         case VET_UINT2:
         case VET_INT2:
         case VET_DOUBLE2:
@@ -216,11 +217,16 @@ namespace Ogre {
             return 3;
         case VET_FLOAT4:
         case VET_SHORT4:
+        case VET_SHORT4_NORM:
         case VET_USHORT4:
+        case VET_USHORT4_NORM:
         case VET_UINT4:
         case VET_INT4:
         case VET_DOUBLE4:
+        case VET_BYTE4:
         case VET_UBYTE4:
+        case VET_BYTE4_NORM:
+        case VET_UBYTE4_NORM:
             return 4;
         }
         OGRE_EXCEPT(Exception::ERR_INVALIDPARAMS, "Invalid type", 
@@ -230,38 +236,56 @@ namespace Ogre {
     VertexElementType VertexElement::multiplyTypeCount(VertexElementType baseType, 
         unsigned short count)
     {
+        if ( count < 1 || count > 4 )
+        {
+            OGRE_EXCEPT( Exception::ERR_INVALIDPARAMS, "Count out of range",
+                "VertexElement::multiplyTypeCount" );
+        }
         switch (baseType)
         {
         case VET_FLOAT1:
-            switch(count)
-            {
-            case 1:
-                return VET_FLOAT1;
-            case 2:
-                return VET_FLOAT2;
-            case 3:
-                return VET_FLOAT3;
-            case 4:
-                return VET_FLOAT4;
-            default:
-                break;
-            }
-            break;
+        case VET_DOUBLE1:
+        case VET_INT1:
+        case VET_UINT1:
+            // evil enumeration arithmetic
+            return static_cast<VertexElementType>( baseType + count - 1 );
+
         case VET_SHORT1:
-            switch(count)
+        case VET_SHORT2:
+            if ( count <= 2 )
             {
-            case 1:
-                return VET_SHORT1;
-            case 2:
                 return VET_SHORT2;
-            case 3:
-                return VET_SHORT3;
-            case 4:
-                return VET_SHORT4;
-            default:
-                break;
             }
-            break;
+            return VET_SHORT4;
+
+        case VET_USHORT1:
+        case VET_USHORT2:
+            if ( count <= 2 )
+            {
+                return VET_USHORT2;
+            }
+            return VET_USHORT4;
+
+        case VET_SHORT2_NORM:
+            if ( count <= 2 )
+            {
+                return VET_SHORT2_NORM;
+            }
+            return VET_SHORT4_NORM;
+
+        case VET_USHORT2_NORM:
+            if ( count <= 2 )
+            {
+                return VET_USHORT2_NORM;
+            }
+            return VET_USHORT4_NORM;
+
+        case VET_BYTE4:
+        case VET_BYTE4_NORM:
+        case VET_UBYTE4:
+        case VET_UBYTE4_NORM:
+            return baseType;
+
         default:
             break;
         }
@@ -359,8 +383,20 @@ namespace Ogre {
             case VET_USHORT3:
             case VET_USHORT4:
                 return VET_USHORT1;
+            case VET_SHORT2_NORM:
+            case VET_SHORT4_NORM:
+                return VET_SHORT2_NORM;
+            case VET_USHORT2_NORM:
+            case VET_USHORT4_NORM:
+                return VET_USHORT2_NORM;
+            case VET_BYTE4:
+                return VET_BYTE4;
+            case VET_BYTE4_NORM:
+                return VET_BYTE4_NORM;
             case VET_UBYTE4:
                 return VET_UBYTE4;
+            case VET_UBYTE4_NORM:
+                return VET_UBYTE4_NORM;
         };
         // To keep compiler happy
         return VET_FLOAT1;

--- a/OgreMain/src/OgreHardwareVertexBuffer.cpp
+++ b/OgreMain/src/OgreHardwareVertexBuffer.cpp
@@ -236,11 +236,8 @@ namespace Ogre {
     VertexElementType VertexElement::multiplyTypeCount(VertexElementType baseType, 
         unsigned short count)
     {
-        if ( count < 1 || count > 4 )
-        {
-            OGRE_EXCEPT( Exception::ERR_INVALIDPARAMS, "Count out of range",
-                "VertexElement::multiplyTypeCount" );
-        }
+        OgreAssert(count > 0 && count < 5, "Count out of range");
+
         switch (baseType)
         {
         case VET_FLOAT1:

--- a/OgreMain/src/OgreMesh.cpp
+++ b/OgreMain/src/OgreMesh.cpp
@@ -861,17 +861,17 @@ namespace Ogre {
         // keeping a switch out of the loop
         switch ( weightsBaseType )
         {
+            default:
+            	OgreAssert(false, "Invalid BlendWeightsBaseElementType");
+            	break;
             case VET_FLOAT1:
                 break;
-            case VET_UBYTE4:
             case VET_UBYTE4_NORM:
                 maxIntWt = 0xff;
                 break;
-            case VET_USHORT2:
             case VET_USHORT2_NORM:
                 maxIntWt = 0xffff;
                 break;
-            case VET_SHORT2:
             case VET_SHORT2_NORM:
                 maxIntWt = 0x7fff;
                 break;
@@ -938,7 +938,7 @@ namespace Ogre {
                 }
 
                 // now write the weights
-                if ( weightsBaseType == VET_UBYTE4 || weightsBaseType == VET_UBYTE4_NORM )
+                if ( weightsBaseType == VET_UBYTE4_NORM )
                 {
                     // write out the weights as bytes
                     unsigned char* pWeight;

--- a/OgreMain/src/OgreMeshManager.cpp
+++ b/OgreMain/src/OgreMeshManager.cpp
@@ -54,6 +54,7 @@ namespace Ogre
     MeshManager::MeshManager():
     mBoundsPaddingFactor(0.01), mListener(0)
     {
+        mBlendWeightsBaseElementType = VET_FLOAT1;
         mPrepAllMeshesForShadowVolumes = false;
 
         mLoadOrder = 350.0f;
@@ -965,7 +966,34 @@ namespace Ogre
         return mPrepAllMeshesForShadowVolumes;
     }
     //-----------------------------------------------------------------------
-    Real MeshManager::getBoundsPaddingFactor(void)
+    VertexElementType MeshManager::getBlendWeightsBaseElementType() const
+    {
+        return mBlendWeightsBaseElementType;
+    }
+    //-----------------------------------------------------------------------
+    void MeshManager::setBlendWeightsBaseElementType( VertexElementType vet )
+    {
+        switch ( vet )
+        {
+            case VET_UBYTE4:
+            case VET_UBYTE4_NORM:
+            case VET_USHORT2:
+            case VET_USHORT2_NORM:
+            case VET_SHORT2:
+            case VET_SHORT2_NORM:
+            case VET_FLOAT1:
+                mBlendWeightsBaseElementType = vet;
+                break;
+            default:
+                OGRE_EXCEPT( Exception::ERR_INVALIDPARAMS,
+                    "Unsupported setting for setBlendWeightsBaseElementType",
+                    "MeshManager::setBlendWeightsBaseElementType"
+                    );
+                break;
+        }
+    }
+    //-----------------------------------------------------------------------
+    Real MeshManager::getBoundsPaddingFactor( void )
     {
         return mBoundsPaddingFactor;
     }

--- a/OgreMain/src/OgreMeshManager.cpp
+++ b/OgreMain/src/OgreMeshManager.cpp
@@ -975,20 +975,13 @@ namespace Ogre
     {
         switch ( vet )
         {
-            case VET_UBYTE4:
             case VET_UBYTE4_NORM:
-            case VET_USHORT2:
             case VET_USHORT2_NORM:
-            case VET_SHORT2:
-            case VET_SHORT2_NORM:
             case VET_FLOAT1:
                 mBlendWeightsBaseElementType = vet;
                 break;
             default:
-                OGRE_EXCEPT( Exception::ERR_INVALIDPARAMS,
-                    "Unsupported setting for setBlendWeightsBaseElementType",
-                    "MeshManager::setBlendWeightsBaseElementType"
-                    );
+                OgreAssert(false, "Unsupported BlendWeightsBaseElementType");
                 break;
         }
     }

--- a/RenderSystems/Direct3D11/src/OgreD3D11Mappings.cpp
+++ b/RenderSystems/Direct3D11/src/OgreD3D11Mappings.cpp
@@ -302,6 +302,10 @@ namespace Ogre
             return DXGI_FORMAT_R16G16_SINT;
         case VET_SHORT4:
             return DXGI_FORMAT_R16G16B16A16_SINT;
+        case VET_SHORT2_NORM:
+            return DXGI_FORMAT_R16G16_SNORM;
+        case VET_SHORT4_NORM:
+            return DXGI_FORMAT_R16G16B16A16_SNORM;
 
         // Unsigned short
         case VET_USHORT1:
@@ -310,6 +314,10 @@ namespace Ogre
             return DXGI_FORMAT_R16G16_UINT;
         case VET_USHORT4:
             return DXGI_FORMAT_R16G16B16A16_UINT;
+        case VET_USHORT2_NORM:
+            return DXGI_FORMAT_R16G16_UNORM;
+        case VET_USHORT4_NORM:
+            return DXGI_FORMAT_R16G16B16A16_UNORM;
 
         // Signed int
         case VET_INT1:
@@ -330,9 +338,15 @@ namespace Ogre
             return DXGI_FORMAT_R32G32B32_UINT;
         case VET_UINT4:
             return DXGI_FORMAT_R32G32B32A32_UINT;
-
+            
+        case VET_BYTE4:
+            return DXGI_FORMAT_R8G8B8A8_SINT;
+        case VET_BYTE4_NORM:
+            return DXGI_FORMAT_R8G8B8A8_SNORM;
         case VET_UBYTE4:
             return DXGI_FORMAT_R8G8B8A8_UINT;
+        case VET_UBYTE4_NORM:
+            return DXGI_FORMAT_R8G8B8A8_UNORM;
         }
         // to keep compiler happy
         return DXGI_FORMAT_R32G32B32_FLOAT;

--- a/RenderSystems/Direct3D9/src/OgreD3D9Mappings.cpp
+++ b/RenderSystems/Direct3D9/src/OgreD3D9Mappings.cpp
@@ -546,28 +546,35 @@ namespace Ogre
         case VET_COLOUR_ABGR:
         case VET_COLOUR_ARGB:
             return D3DDECLTYPE_D3DCOLOR;
-            break;
         case VET_FLOAT1:
             return D3DDECLTYPE_FLOAT1;
-            break;
         case VET_FLOAT2:
             return D3DDECLTYPE_FLOAT2;
-            break;
         case VET_FLOAT3:
             return D3DDECLTYPE_FLOAT3;
-            break;
         case VET_FLOAT4:
             return D3DDECLTYPE_FLOAT4;
-            break;
         case VET_SHORT2:
             return D3DDECLTYPE_SHORT2;
-            break;
         case VET_SHORT4:
             return D3DDECLTYPE_SHORT4;
-            break;
         case VET_UBYTE4:
             return D3DDECLTYPE_UBYTE4;
-            break;
+        case VET_UBYTE4_NORM:
+            // valid only with vertex shaders >= 2.0
+            return D3DDECLTYPE_UBYTE4N;
+        case VET_SHORT2_NORM:
+            // valid only with vertex shaders >= 2.0
+            return D3DDECLTYPE_SHORT2N;
+        case VET_SHORT4_NORM:
+            // valid only with vertex shaders >= 2.0
+            return D3DDECLTYPE_SHORT4N;
+        case VET_USHORT2_NORM:
+            // valid only with vertex shaders >= 2.0
+            return D3DDECLTYPE_USHORT2N;
+        case VET_USHORT4_NORM:
+            // valid only with vertex shaders >= 2.0
+            return D3DDECLTYPE_USHORT4N;
         }
         // to keep compiler happy
         return D3DDECLTYPE_FLOAT3;

--- a/RenderSystems/GL/src/OgreGLHardwareBufferManager.cpp
+++ b/RenderSystems/GL/src/OgreGLHardwareBufferManager.cpp
@@ -150,12 +150,21 @@ namespace Ogre {
             case VET_SHORT2:
             case VET_SHORT3:
             case VET_SHORT4:
+            case VET_SHORT2_NORM:
+            case VET_SHORT4_NORM:
                 return GL_SHORT;
             case VET_COLOUR:
             case VET_COLOUR_ABGR:
             case VET_COLOUR_ARGB:
             case VET_UBYTE4:
+            case VET_UBYTE4_NORM:
                 return GL_UNSIGNED_BYTE;
+            case VET_BYTE4:
+            case VET_BYTE4_NORM:
+                return GL_BYTE;
+            case VET_USHORT2_NORM:
+            case VET_USHORT4_NORM:
+                return GL_UNSIGNED_SHORT;
             default:
                 return 0;
         };

--- a/RenderSystems/GL/src/OgreGLRenderSystem.cpp
+++ b/RenderSystems/GL/src/OgreGLRenderSystem.cpp
@@ -3618,6 +3618,13 @@ namespace Ogre {
                 typeCount = 4;
                 normalised = GL_TRUE;
                 break;
+            case VET_UBYTE4_NORM:
+            case VET_SHORT2_NORM:
+            case VET_USHORT2_NORM:
+            case VET_SHORT4_NORM:
+            case VET_USHORT4_NORM:
+                normalised = GL_TRUE;
+                break;
             default:
                 break;
             };

--- a/RenderSystems/GL3Plus/src/OgreGL3PlusHardwareBufferManager.cpp
+++ b/RenderSystems/GL3Plus/src/OgreGL3PlusHardwareBufferManager.cpp
@@ -194,17 +194,25 @@ namespace Ogre {
         case VET_SHORT2:
         case VET_SHORT3:
         case VET_SHORT4:
+        case VET_SHORT2_NORM:
+        case VET_SHORT4_NORM:
             return GL_SHORT;
         case VET_USHORT1:
         case VET_USHORT2:
         case VET_USHORT3:
         case VET_USHORT4:
+        case VET_USHORT2_NORM:
+        case VET_USHORT4_NORM:
             return GL_UNSIGNED_SHORT;
         case VET_COLOUR:
         case VET_COLOUR_ABGR:
         case VET_COLOUR_ARGB:
         case VET_UBYTE4:
+        case VET_UBYTE4_NORM:
             return GL_UNSIGNED_BYTE;
+        case VET_BYTE4:
+        case VET_BYTE4_NORM:
+            return GL_BYTE;
         };
 
         OgreAssert(false, "unknown Vertex Element Type");

--- a/RenderSystems/GL3Plus/src/OgreGL3PlusRenderSystem.cpp
+++ b/RenderSystems/GL3Plus/src/OgreGL3PlusRenderSystem.cpp
@@ -2666,6 +2666,13 @@ namespace Ogre {
                 typeCount = 4;
                 normalised = GL_TRUE;
                 break;
+            case VET_UBYTE4_NORM:
+            case VET_SHORT2_NORM:
+            case VET_USHORT2_NORM:
+            case VET_SHORT4_NORM:
+            case VET_USHORT4_NORM:
+                normalised = GL_TRUE;
+                break;
             default:
                 break;
             };

--- a/RenderSystems/GLES2/src/OgreGLES2HardwareBufferManager.cpp
+++ b/RenderSystems/GLES2/src/OgreGLES2HardwareBufferManager.cpp
@@ -150,12 +150,18 @@ namespace Ogre {
             case VET_SHORT2:
             case VET_SHORT3:
             case VET_SHORT4:
+            case VET_SHORT2_NORM:
+            case VET_SHORT4_NORM:
                 return GL_SHORT;
             case VET_COLOUR:
             case VET_COLOUR_ABGR:
             case VET_COLOUR_ARGB:
             case VET_UBYTE4:
+            case VET_UBYTE4_NORM:
                 return GL_UNSIGNED_BYTE;
+            case VET_BYTE4:
+            case VET_BYTE4_NORM:
+                return GL_BYTE;
             case VET_INT1:
             case VET_INT2:
             case VET_INT3:
@@ -174,6 +180,8 @@ namespace Ogre {
             case VET_USHORT2:
             case VET_USHORT3:
             case VET_USHORT4:
+            case VET_USHORT2_NORM:
+            case VET_USHORT4_NORM:
 #if OGRE_NO_GLES3_SUPPORT == 0
                 return GL_UNSIGNED_SHORT;
 #endif

--- a/RenderSystems/GLES2/src/OgreGLES2RenderSystem.cpp
+++ b/RenderSystems/GLES2/src/OgreGLES2RenderSystem.cpp
@@ -2263,6 +2263,13 @@ namespace Ogre {
                     typeCount = 4;
                     normalised = GL_TRUE;
                     break;
+                case VET_UBYTE4_NORM:
+                case VET_SHORT2_NORM:
+                case VET_USHORT2_NORM:
+                case VET_SHORT4_NORM:
+                case VET_USHORT4_NORM:
+                    normalised = GL_TRUE;
+                    break;
                 default:
                     break;
             };

--- a/Samples/Media/RTShaderLib/GLSL/DualQuaternionSkinning_ShadowFourWeights.glsl
+++ b/Samples/Media/RTShaderLib/GLSL/DualQuaternionSkinning_ShadowFourWeights.glsl
@@ -1,10 +1,10 @@
 #version 120
 
-mat2x4 blendTwoWeightsAntipod(vec4 blendWgt, vec4 blendIdx, mat4x2 dualQuaternions[24]);
-vec3 calculateBlendPosition(vec4 position, mat2x4 blendDQ);
+mat2x4 blendFourWeightsAntipod(vec4 blendWgt, vec4 blendIdx, vec4 dualQuaternions[48]);
+vec3 calculateBlendPosition(vec3 position, mat2x4 blendDQ);
 
-uniform mat4x2 worldDualQuaternion2x4Array[24];
-uniform mat4x4 viewProjectionMatrix;
+uniform vec4 worldDualQuaternion2x4Array[48];
+uniform mat4 viewProjectionMatrix;
 uniform vec4   ambient;
 
 attribute vec4 vertex;
@@ -16,12 +16,12 @@ varying vec4 colour;
 //Shadow caster pass
 void main()
 {
-	mat2x4 blendDQ = blendTwoWeightsAntipod(blendWeights, blendIndices, worldDualQuaternion2x4Array);
+	mat2x4 blendDQ = blendFourWeightsAntipod(blendWeights, blendIndices, worldDualQuaternion2x4Array);
 
 	float len = length(blendDQ[0]);
 	blendDQ /= len;
 
-	vec3 blendPosition = calculateBlendPosition(vertex, blendDQ);
+	vec3 blendPosition = calculateBlendPosition(vertex.xyz, blendDQ);
 
 	// view / projection
 	gl_Position = viewProjectionMatrix * vec4(blendPosition, 1.0);

--- a/Samples/Media/RTShaderLib/GLSL/DualQuaternionSkinning_ShadowOneWeight.glsl
+++ b/Samples/Media/RTShaderLib/GLSL/DualQuaternionSkinning_ShadowOneWeight.glsl
@@ -1,8 +1,8 @@
 #version 120
 
-vec3 calculateBlendPosition(vec4 position, mat2x4 blendDQ);
+vec3 calculateBlendPosition(vec3 position, mat2x4 blendDQ);
 
-uniform mat4x2 worldDualQuaternion2x4Array[24];
+uniform vec4 worldDualQuaternion2x4Array[48];
 uniform mat4x4 viewProjectionMatrix;
 uniform vec4   ambient;
 
@@ -15,12 +15,14 @@ varying vec4 colour;
 //Shadow caster pass
 void main()
 {
-	mat2x4 blendDQ = blendWeights.x * worldDualQuaternion2x4Array[blendIndices.x];
+	mat2x4 dq0 = mat2x4(worldDualQuaternion2x4Array[int(blendIndices.x) * 2], 
+	                    worldDualQuaternion2x4Array[int(blendIndices.x) * 2 + 1]);
+	mat2x4 blendDQ = blendWeights.x * dq0;
 
 	float len = length(blendDQ[0]);
 	blendDQ /= len;
 
-	vec3 blendPosition = calculateBlendPosition(vertex, blendDQ);
+	vec3 blendPosition = calculateBlendPosition(vertex.xyz, blendDQ);
 
 	// view / projection
 	gl_Position = viewProjectionMatrix * vec4(blendPosition, 1.0);

--- a/Samples/Media/RTShaderLib/GLSL/DualQuaternionSkinning_ShadowThreeWeights.glsl
+++ b/Samples/Media/RTShaderLib/GLSL/DualQuaternionSkinning_ShadowThreeWeights.glsl
@@ -1,9 +1,9 @@
 #version 120
 
-mat2x4 blendTwoWeightsAntipod(vec4 blendWgt, vec4 blendIdx, vec4 dualQuaternions[24]);
+mat2x4 blendThreeWeightsAntipod(vec4 blendWgt, vec4 blendIdx, vec4 dualQuaternions[48]);
 vec3 calculateBlendPosition(vec3 position, mat2x4 blendDQ);
 
-uniform vec4 worldDualQuaternion2x4Array[24];
+uniform vec4 worldDualQuaternion2x4Array[48];
 uniform mat4x4 viewProjectionMatrix;
 uniform vec4   ambient;
 
@@ -16,7 +16,7 @@ varying vec4 colour;
 //Shadow caster pass
 void main()
 {
-	mat2x4 blendDQ = blendTwoWeightsAntipod(blendWeights, blendIndices, worldDualQuaternion2x4Array);
+	mat2x4 blendDQ = blendThreeWeightsAntipod(blendWeights, blendIndices, worldDualQuaternion2x4Array);
 
 	float len = length(blendDQ[0]);
 	blendDQ /= len;

--- a/Samples/Media/RTShaderLib/GLSL/DualQuaternion_Common.glsl
+++ b/Samples/Media/RTShaderLib/GLSL/DualQuaternion_Common.glsl
@@ -53,11 +53,11 @@ mat2x4 blendTwoWeightsAntipod(vec4 blendWgt, vec4 blendIdx, vec4 dualQuaternions
 	return blendDQ;
 }
 
-mat2x4 blendThreeWeightsAntipod(vec4 blendWgt, vec4 blendIdx, mat2x4 dualQuaternions[24])
+mat2x4 blendThreeWeightsAntipod(vec4 blendWgt, vec4 blendIdx, vec4 dualQuaternions[48])
 {
-	mat2x4 dq0 = dualQuaternions[int(blendIdx.x)];
-	mat2x4 dq1 = dualQuaternions[int(blendIdx.y)];
-	mat2x4 dq2 = dualQuaternions[int(blendIdx.z)];
+	mat2x4 dq0 = mat2x4(dualQuaternions[int(blendIdx.x) * 2], dualQuaternions[int(blendIdx.x) * 2 + 1]);
+	mat2x4 dq1 = mat2x4(dualQuaternions[int(blendIdx.y) * 2], dualQuaternions[int(blendIdx.y) * 2 + 1]);
+	mat2x4 dq2 = mat2x4(dualQuaternions[int(blendIdx.z) * 2], dualQuaternions[int(blendIdx.z) * 2 + 1]);
 
 	//Accurate antipodality handling. For speed increase, remove the following line, 
 	//though, the results will only be valid for rotations less than 180 degrees.
@@ -71,12 +71,12 @@ mat2x4 blendThreeWeightsAntipod(vec4 blendWgt, vec4 blendIdx, mat2x4 dualQuatern
 	return blendDQ;
 }
 
-mat2x4 blendFourWeightsAntipod(vec4 blendWgt, vec4 blendIdx, mat2x4 dualQuaternions[24])
+mat2x4 blendFourWeightsAntipod(vec4 blendWgt, vec4 blendIdx, vec4 dualQuaternions[48])
 {
-	mat2x4 dq0 = dualQuaternions[int(blendIdx.x)];
-	mat2x4 dq1 = dualQuaternions[int(blendIdx.y)];
-	mat2x4 dq2 = dualQuaternions[int(blendIdx.z)];
-	mat2x4 dq3 = dualQuaternions[int(blendIdx.w)];
+	mat2x4 dq0 = mat2x4(dualQuaternions[int(blendIdx.x) * 2], dualQuaternions[int(blendIdx.x) * 2 + 1]);
+	mat2x4 dq1 = mat2x4(dualQuaternions[int(blendIdx.y) * 2], dualQuaternions[int(blendIdx.y) * 2 + 1]);
+	mat2x4 dq2 = mat2x4(dualQuaternions[int(blendIdx.z) * 2], dualQuaternions[int(blendIdx.z) * 2 + 1]);
+	mat2x4 dq3 = mat2x4(dualQuaternions[int(blendIdx.w) * 2], dualQuaternions[int(blendIdx.w) * 2 + 1]);
 
 	//Accurate antipodality handling. For speed increase, remove the following line, 
 	//though, the results will only be valid for rotations less than 180 degrees.


### PR DESCRIPTION
original PR: https://bitbucket.org/sinbad/ogre/pull-requests/400

Allow users to opt for storing blend weights as bytes or shorts (or floats as they have been). This can reduce the vertex buffer storage for skinned meshes substantially. When using the newly added normalized vertex element types, skinning shaders can be used without changes.

Tested with DX11 and DX9.

I can't seem to find where in the GL rendersystems the mapping from VertexElementType values to GL types takes place. Perhaps someone who knows that code could handle that part.
