### PR TITLE
Nonvirtual scene

### DIFF
--- a/OgreMain/include/OgreNode.h
+++ b/OgreMain/include/OgreNode.h
@@ -191,7 +191,7 @@ namespace Ogre {
             to update it's complete transformation based on it's parents
             derived transform.
         */
-        virtual void _updateFromParent(void) const;
+        void _updateFromParent(void) const;
 
         /** Class-specific implementation of _updateFromParent.
         @remarks
@@ -245,15 +245,15 @@ namespace Ogre {
         virtual ~Node();  
 
         /** Returns the name of the node. */
-        const String& getName(void) const;
+        const String& getName(void) const { return mName; }
 
         /** Gets this node's parent (NULL if this is the root).
         */
-        virtual Node* getParent(void) const;
+        Node* getParent(void) const { return mParent; }
 
         /** Returns a quaternion representing the nodes orientation.
         */
-        virtual const Quaternion & getOrientation() const;
+        const Quaternion & getOrientation() const { return mOrientation; }
 
         /** Sets the orientation of this node via a quaternion.
         @remarks
@@ -268,7 +268,7 @@ namespace Ogre {
         @par
             Note that rotations are oriented around the node's origin.
         */
-        virtual void setOrientation( const Quaternion& q );
+        void setOrientation( const Quaternion& q );
 
         /** Sets the orientation of this node via quaternion parameters.
         @remarks
@@ -283,7 +283,7 @@ namespace Ogre {
         @par
             Note that rotations are oriented around the node's origin.
         */
-        virtual void setOrientation( Real w, Real x, Real y, Real z);
+        void setOrientation( Real w, Real x, Real y, Real z);
 
         /** Resets the nodes orientation (local axes as world axes, no rotation).
         @remarks
@@ -298,19 +298,19 @@ namespace Ogre {
         @par
             Note that rotations are oriented around the node's origin.
         */
-        virtual void resetOrientation(void);
+        void resetOrientation(void);
 
         /** Sets the position of the node relative to it's parent.
         */
-        virtual void setPosition(const Vector3& pos);
+        void setPosition(const Vector3& pos);
 
         /** Sets the position of the node relative to it's parent.
         */
-        virtual void setPosition(Real x, Real y, Real z);
+        void setPosition(Real x, Real y, Real z);
 
         /** Gets the position of the node relative to it's parent.
         */
-        virtual const Vector3 & getPosition(void) const;
+        const Vector3 & getPosition(void) const { return mPosition; }
 
         /** Sets the scaling factor applied to this node.
         @remarks
@@ -324,7 +324,7 @@ namespace Ogre {
         @par
             Note that like rotations, scalings are oriented around the node's origin.
         */
-        virtual void setScale(const Vector3& scale);
+        void setScale(const Vector3& scale);
 
         /** Sets the scaling factor applied to this node.
         @remarks
@@ -338,11 +338,11 @@ namespace Ogre {
         @par
             Note that like rotations, scalings are oriented around the node's origin.
         */
-        virtual void setScale(Real x, Real y, Real z);
+        void setScale(Real x, Real y, Real z);
 
         /** Gets the scaling factor of this node.
         */
-        virtual const Vector3 & getScale(void) const;
+        const Vector3& getScale(void) const { return mScale; }
 
         /** Tells the node whether it should inherit orientation from it's parent node.
         @remarks
@@ -357,7 +357,7 @@ namespace Ogre {
         @param inherit If true, this node's orientation will be affected by its parent's orientation.
             If false, it will not be affected.
         */
-        virtual void setInheritOrientation(bool inherit);
+        void setInheritOrientation(bool inherit);
 
         /** Returns true if this node is affected by orientation applied to the parent node. 
         @remarks
@@ -372,7 +372,7 @@ namespace Ogre {
         @remarks
             See setInheritOrientation for more info.
         */
-        virtual bool getInheritOrientation(void) const;
+        bool getInheritOrientation(void) const { return mInheritOrientation; }
 
         /** Tells the node whether it should inherit scaling factors from it's parent node.
         @remarks
@@ -386,13 +386,13 @@ namespace Ogre {
         @param inherit If true, this node's scale will be affected by its parent's scale. If false,
             it will not be affected.
         */
-        virtual void setInheritScale(bool inherit);
+        void setInheritScale(bool inherit);
 
         /** Returns true if this node is affected by scaling factors applied to the parent node. 
         @remarks
             See setInheritScale for more info.
         */
-        virtual bool getInheritScale(void) const;
+        bool getInheritScale(void) const { return mInheritScale; }
 
         /** Scales the node, combining it's current scale with the passed in scaling factor. 
         @remarks
@@ -403,7 +403,7 @@ namespace Ogre {
         @par
             Note that like rotations, scalings are oriented around the node's origin.
         */
-        virtual void scale(const Vector3& scale);
+        void scale(const Vector3& scale);
 
         /** Scales the node, combining it's current scale with the passed in scaling factor. 
         @remarks
@@ -414,7 +414,7 @@ namespace Ogre {
         @par
             Note that like rotations, scalings are oriented around the node's origin.
         */
-        virtual void scale(Real x, Real y, Real z);
+        void scale(Real x, Real y, Real z);
 
         /** Moves the node along the Cartesian axes.
         @par
@@ -425,7 +425,7 @@ namespace Ogre {
         @param relativeTo
             The space which this transform is relative to.
         */
-        virtual void translate(const Vector3& d, TransformSpace relativeTo = TS_PARENT);
+        void translate(const Vector3& d, TransformSpace relativeTo = TS_PARENT);
         /** Moves the node along the Cartesian axes.
         @par
             This method moves the node by the supplied vector along the
@@ -439,7 +439,7 @@ namespace Ogre {
         @param relativeTo
             The space which this transform is relative to.
         */
-        virtual void translate(Real x, Real y, Real z, TransformSpace relativeTo = TS_PARENT);
+        void translate(Real x, Real y, Real z, TransformSpace relativeTo = TS_PARENT);
         /** Moves the node along arbitrary axes.
         @remarks
             This method translates the node by a vector which is relative to
@@ -459,7 +459,7 @@ namespace Ogre {
         @param relativeTo
             The space which this transform is relative to.
         */
-        virtual void translate(const Matrix3& axes, const Vector3& move, TransformSpace relativeTo = TS_PARENT);
+        void translate(const Matrix3& axes, const Vector3& move, TransformSpace relativeTo = TS_PARENT);
         /** Moves the node along arbitrary axes.
         @remarks
             This method translates the node by a vector which is relative to
@@ -483,7 +483,7 @@ namespace Ogre {
         @param relativeTo
             The space which this transform is relative to.
         */
-        virtual void translate(const Matrix3& axes, Real x, Real y, Real z, TransformSpace relativeTo = TS_PARENT);
+        void translate(const Matrix3& axes, Real x, Real y, Real z, TransformSpace relativeTo = TS_PARENT);
 
         /** Rotate the node around the Z-axis.
         */
@@ -499,15 +499,15 @@ namespace Ogre {
 
         /** Rotate the node around an arbitrary axis.
         */
-        virtual void rotate(const Vector3& axis, const Radian& angle, TransformSpace relativeTo = TS_LOCAL);
+        void rotate(const Vector3& axis, const Radian& angle, TransformSpace relativeTo = TS_LOCAL);
 
         /** Rotate the node around an aritrary axis using a Quarternion.
         */
-        virtual void rotate(const Quaternion& q, TransformSpace relativeTo = TS_LOCAL);
+        void rotate(const Quaternion& q, TransformSpace relativeTo = TS_LOCAL);
 
         /** Gets a matrix whose columns are the local axes based on
             the nodes orientation relative to it's parent. */
-        virtual Matrix3 getLocalAxes(void) const;
+        Matrix3 getLocalAxes(void) const;
 
         /** Creates an unnamed new Node as a child of this node.
         @param translate
@@ -515,7 +515,7 @@ namespace Ogre {
         @param rotate
             Initial rotation relative to parent
         */
-        Node* createChild(
+        virtual Node* createChild(
             const Vector3& translate = Vector3::ZERO, 
             const Quaternion& rotate = Quaternion::IDENTITY );
 
@@ -528,27 +528,27 @@ namespace Ogre {
         @param rotate
             Initial rotation relative to parent
         */
-        Node* createChild(const String& name, const Vector3& translate = Vector3::ZERO, const Quaternion& rotate = Quaternion::IDENTITY);
+        virtual Node* createChild(const String& name, const Vector3& translate = Vector3::ZERO, const Quaternion& rotate = Quaternion::IDENTITY);
 
         /** Adds a (precreated) child scene node to this node. If it is attached to another node,
             it must be detached first.
         @param child The Node which is to become a child node of this one
         */
-        virtual void addChild(Node* child);
+        void addChild(Node* child);
 
         /** Reports the number of child nodes under this one.
         */
-        virtual unsigned short numChildren(void) const;
+        uint16 numChildren(void) const { return static_cast< uint16 >( mChildren.size() ); }
 
         /** Gets a pointer to a child node.
         @remarks
             There is an alternate getChild method which returns a named child.
         */
-        virtual Node* getChild(unsigned short index) const;    
+        Node* getChild(unsigned short index) const;
 
         /** Gets a pointer to a named child node.
         */
-        virtual Node* getChild(const String& name) const;
+        Node* getChild(const String& name) const;
 
         /** Retrieves an iterator for efficiently looping through all children of this node.
         @remarks
@@ -560,7 +560,7 @@ namespace Ogre {
             store up changes for later. Note that calling methods on returned items in 
             the iterator IS allowed and does not invalidate the iterator.
         */
-        virtual ChildNodeIterator getChildIterator(void);
+        ChildNodeIterator getChildIterator(void);
 
         /** Retrieves an iterator for efficiently looping through all children of this node.
         @remarks
@@ -572,7 +572,7 @@ namespace Ogre {
             store up changes for later. Note that calling methods on returned items in 
             the iterator IS allowed and does not invalidate the iterator.
         */
-        virtual ConstChildNodeIterator getChildIterator(void) const;
+        ConstChildNodeIterator getChildIterator(void) const;
 
         /** Drops the specified child from this node. 
         @remarks
@@ -606,26 +606,26 @@ namespace Ogre {
         @remarks 
             It's advisable to use the local setPosition if possible
         */
-        virtual void _setDerivedPosition(const Vector3& pos);
+        void _setDerivedPosition(const Vector3& pos);
 
         /** Sets the final world orientation of the node directly.
         @remarks 
             It's advisable to use the local setOrientation if possible, this simply does
             the conversion for you.
         */
-        virtual void _setDerivedOrientation(const Quaternion& q);
+        void _setDerivedOrientation(const Quaternion& q);
 
         /** Gets the orientation of the node as derived from all parents.
         */
-        virtual const Quaternion & _getDerivedOrientation(void) const;
+        const Quaternion & _getDerivedOrientation(void) const;
 
         /** Gets the position of the node as derived from all parents.
         */
-        virtual const Vector3 & _getDerivedPosition(void) const;
+        const Vector3 & _getDerivedPosition(void) const;
 
         /** Gets the scaling factor of the node as derived from all parents.
         */
-        virtual const Vector3 & _getDerivedScale(void) const;
+        const Vector3 & _getDerivedScale(void) const;
 
         /** Gets the full transformation matrix for this node.
         @remarks
@@ -636,7 +636,7 @@ namespace Ogre {
             derived transforms have been updated before calling this method.
             Applications using Ogre should just use the relative transforms.
         */
-        virtual const Matrix4& _getFullTransform(void) const;
+        const Matrix4& _getFullTransform(void) const;
 
         /** Internal method to update the Node.
         @note
@@ -657,11 +657,11 @@ namespace Ogre {
             Note for size and performance reasons only one listener per node is
             allowed.
         */
-        virtual void setListener(Listener* listener) { mListener = listener; }
+        void setListener(Listener* listener) { mListener = listener; }
         
         /** Gets the current listener for this Node.
         */
-        virtual Listener* getListener(void) const { return mListener; }
+        Listener* getListener(void) const { return mListener; }
         
 
         /** Sets the current transform of this node to be the 'initial state' ie that
@@ -674,46 +674,46 @@ namespace Ogre {
         @par
             If you never call this method, the initial state is the identity transform, ie do nothing.
         */
-        virtual void setInitialState(void);
+        void setInitialState(void);
 
         /** Resets the position / orientation / scale of this node to it's initial state, see setInitialState for more info. */
-        virtual void resetToInitialState(void);
+        void resetToInitialState(void);
 
         /** Gets the initial position of this node, see setInitialState for more info. 
         @remarks
             Also resets the cumulative animation weight used for blending.
         */
-        virtual const Vector3& getInitialPosition(void) const;
+        const Vector3& getInitialPosition(void) const { return mInitialPosition; }
         
         /** Gets the local position, relative to this node, of the given world-space position */
-        virtual Vector3 convertWorldToLocalPosition( const Vector3 &worldPos );
+        Vector3 convertWorldToLocalPosition( const Vector3 &worldPos );
 
         /** Gets the world position of a point in the node local space
             useful for simple transforms that don't require a child node.*/
-        virtual Vector3 convertLocalToWorldPosition( const Vector3 &localPos );
+        Vector3 convertLocalToWorldPosition( const Vector3 &localPos );
 
         /** Gets the local direction, relative to this node, of the given world-space direction */
-        virtual Vector3 convertWorldToLocalDirection( const Vector3 &worldDir, bool useScale );
+        Vector3 convertWorldToLocalDirection( const Vector3 &worldDir, bool useScale );
 
         /** Gets the world direction of a point in the node local space
             useful for simple transforms that don't require a child node.*/
-        virtual Vector3 convertLocalToWorldDirection( const Vector3 &localDir, bool useScale );
+        Vector3 convertLocalToWorldDirection( const Vector3 &localDir, bool useScale );
 
         /** Gets the local orientation, relative to this node, of the given world-space orientation */
-        virtual Quaternion convertWorldToLocalOrientation( const Quaternion &worldOrientation );
+        Quaternion convertWorldToLocalOrientation( const Quaternion &worldOrientation );
 
         /** Gets the world orientation of an orientation in the node local space
             useful for simple transforms that don't require a child node.*/
-        virtual Quaternion convertLocalToWorldOrientation( const Quaternion &localOrientation );
+        Quaternion convertLocalToWorldOrientation( const Quaternion &localOrientation );
 
         /** Gets the initial orientation of this node, see setInitialState for more info. */
-        virtual const Quaternion& getInitialOrientation(void) const;
+        const Quaternion& getInitialOrientation(void) const { return mInitialOrientation; }
 
         /** Gets the initial position of this node, see setInitialState for more info. */
-        virtual const Vector3& getInitialScale(void) const;
+        const Vector3& getInitialScale(void) const { return mInitialScale; }
 
         /** Helper function, get the squared view depth.  */
-        virtual Real getSquaredViewDepth(const Camera* cam) const;
+        Real getSquaredViewDepth(const Camera* cam) const;
 
         /** To be called in the event of transform changes to this node that require it's recalculation.
         @remarks
@@ -727,12 +727,12 @@ namespace Ogre {
         @param forceParentUpdate Even if the node thinks it has already told it's
             parent, tell it anyway
         */
-        virtual void requestUpdate(Node* child, bool forceParentUpdate = false);
+        void requestUpdate(Node* child, bool forceParentUpdate = false);
         /** Called by children to notify their parent that they no longer need an update. */
-        virtual void cancelUpdate(Node* child);
+        void cancelUpdate(Node* child);
 
         /** Get a debug renderable for rendering the Node.  */
-        virtual DebugRenderable* getDebugRenderable(Real scaling);
+        DebugRenderable* getDebugRenderable(Real scaling);
 
         /** Queue a 'needUpdate' call to a node safely.
         @remarks
@@ -753,12 +753,12 @@ namespace Ogre {
             this Node. This can be a pointer back to one of your own
             classes for instance.
         */
-        OGRE_DEPRECATED virtual void setUserAny(const Any& anything) { getUserObjectBindings().setUserAny(anything); }
+        OGRE_DEPRECATED void setUserAny(const Any& anything) { getUserObjectBindings().setUserAny(anything); }
 
         /** @deprecated use UserObjectBindings::getUserAny via getUserObjectBindings() instead.
             Retrieves the custom user value associated with this object.
         */
-        OGRE_DEPRECATED virtual const Any& getUserAny(void) const { return getUserObjectBindings().getUserAny(); }
+        OGRE_DEPRECATED const Any& getUserAny(void) const { return getUserObjectBindings().getUserAny(); }
 
         /** Return an instance of user objects binding associated with this class.
             You can use it to associate one or more custom objects with this class instance.

--- a/OgreMain/include/OgreSceneNode.h
+++ b/OgreMain/include/OgreSceneNode.h
@@ -127,18 +127,18 @@ namespace Ogre {
 
         /** Reports the number of objects attached to this node.
         */
-        virtual unsigned short numAttachedObjects(void) const;
+        unsigned short numAttachedObjects(void) const;
 
         /** Retrieves a pointer to an attached object.
         @remarks Retrieves by index, see alternate version to retrieve by name. The index
         of an object may change as other objects are added / removed.
         */
-        virtual MovableObject* getAttachedObject(unsigned short index);
+        MovableObject* getAttachedObject(unsigned short index);
 
         /** Retrieves a pointer to an attached object.
         @remarks Retrieves by object name, see alternate version to retrieve by index.
         */
-        virtual MovableObject* getAttachedObject(const String& name);
+        MovableObject* getAttachedObject(const String& name);
 
         /** Detaches the indexed object from this scene node.
         @remarks
@@ -159,13 +159,13 @@ namespace Ogre {
         /** Determines whether this node is in the scene graph, i.e.
             whether it's ultimate ancestor is the root scene node.
         */
-        virtual bool isInSceneGraph(void) const { return mIsInSceneGraph; }
+        bool isInSceneGraph(void) const { return mIsInSceneGraph; }
 
         /** Notifies this SceneNode that it is the root scene node. 
         @remarks
             Only SceneManager should call this!
         */
-        virtual void _notifyRootNode(void) { mIsInSceneGraph = true; }
+        void _notifyRootNode(void) { mIsInSceneGraph = true; }
             
 
         /** Internal method to update the Node.
@@ -180,7 +180,7 @@ namespace Ogre {
                     so the child should retrieve the parent's transform and combine it with its own
                     even if it hasn't changed itself.
         */
-        virtual void _update(bool updateChildren, bool parentHasChanged);
+        void _update(bool updateChildren, bool parentHasChanged);
 
         /** Tells the SceneNode to update the world bound info it stores.
         */
@@ -204,7 +204,7 @@ namespace Ogre {
                 displayNodes If true, the nodes themselves are rendered as a set of 3 axes as well
                     as the objects being rendered. For debugging purposes.
         */
-        virtual void _findVisibleObjects(Camera* cam, RenderQueue* queue, 
+        void _findVisibleObjects(Camera* cam, RenderQueue* queue,
             VisibleObjectsBoundsInfo* visibleBounds, 
             bool includeChildren = true, bool displayNodes = false, bool onlyShadowCasters = false);
 
@@ -213,7 +213,7 @@ namespace Ogre {
             Recommended only if you are extending a SceneManager, because the bounding box returned
             from this method is only up to date after the SceneManager has called _update.
         */
-        virtual const AxisAlignedBox& _getWorldAABB(void) const;
+        const AxisAlignedBox& _getWorldAABB(void) const { return mWorldAABB; }
 
         /** Retrieves an iterator which can be used to efficiently step through the objects 
             attached to this node.
@@ -225,7 +225,9 @@ namespace Ogre {
             until the end, or retrieve a new iterator after making the change. Making changes to
             the object returned through the iterator is OK though.
         */
-        virtual ObjectIterator getAttachedObjectIterator(void);
+        ObjectIterator getAttachedObjectIterator(void) {
+            return ObjectIterator(mObjectsByName.begin(), mObjectsByName.end());
+        }
         /** Retrieves an iterator which can be used to efficiently step through the objects 
             attached to this node.
         @remarks
@@ -236,7 +238,9 @@ namespace Ogre {
             until the end, or retrieve a new iterator after making the change. Making changes to
             the object returned through the iterator is OK though.
         */
-        virtual ConstObjectIterator getAttachedObjectIterator(void) const;
+        ConstObjectIterator getAttachedObjectIterator(void) const {
+            return ConstObjectIterator(mObjectsByName.begin(), mObjectsByName.end());
+        }
 
         /** Gets the creator of this scene node. 
         @remarks
@@ -255,7 +259,7 @@ namespace Ogre {
             detaching it from it's parent. Note that any objects attached to
             the nodes will be detached but will not themselves be destroyed.
         */
-        virtual void removeAndDestroyChild(const String& name);
+        void removeAndDestroyChild(const String& name);
 
         /** This method removes and destroys the child and all of its children.
         @remarks
@@ -267,7 +271,7 @@ namespace Ogre {
             detaching it from it's parent. Note that any objects attached to
             the nodes will be detached but will not themselves be destroyed.
         */
-        virtual void removeAndDestroyChild(unsigned short index);
+        void removeAndDestroyChild(unsigned short index);
 
         /** Removes and destroys all children of this node.
         @remarks
@@ -275,24 +279,24 @@ namespace Ogre {
             them from the scene graph. Note that all objects attached to this
             node will be detached but will not be destroyed.
         */
-        virtual void removeAndDestroyAllChildren(void);
+        void removeAndDestroyAllChildren(void);
 
         /** Allows the showing of the node's bounding box.
         @remarks
             Use this to show or hide the bounding box of the node.
         */
-        virtual void showBoundingBox(bool bShow);
+        void showBoundingBox(bool bShow) { mShowBoundingBox = bShow; }
 
         /** Allows the overriding of the node's bounding box
             over the SceneManager's bounding box setting.
         @remarks
             Use this to override the bounding box setting of the node.
         */
-        virtual void hideBoundingBox(bool bHide);
+        void hideBoundingBox(bool bHide) { mHideBoundingBox = bHide; }
 
         /** Add the bounding box to the rendering queue.
         */
-        virtual void _addBoundingBoxToQueue(RenderQueue* queue);
+        void _addBoundingBoxToQueue(RenderQueue* queue);
 
         /** This allows scene managers to determine if the node's bounding box
             should be added to the rendering queue.
@@ -301,7 +305,7 @@ namespace Ogre {
             check this flag and then use _addBoundingBoxToQueue to add the bounding box
             wireframe.
         */
-        virtual bool getShowBoundingBox() const;
+        bool getShowBoundingBox() const { return mShowBoundingBox; }
 
         /** Creates an unnamed new SceneNode as a child of this node.
         @param
@@ -340,7 +344,7 @@ namespace Ogre {
             this SceneNode's centre.
         @param lightMask The mask with which to include / exclude lights
         */
-        virtual void findLights(LightList& destList, Real radius, uint32 lightMask = 0xFFFFFFFF) const;
+        void findLights(LightList& destList, Real radius, uint32 lightMask = 0xFFFFFFFF) const;
 
         /** Tells the node whether to yaw around it's own local Y axis or a fixed axis of choice.
         @remarks
@@ -356,11 +360,11 @@ namespace Ogre {
         @param
         fixedAxis The axis to use if the first parameter is true.
         */
-        virtual void setFixedYawAxis( bool useFixed, const Vector3& fixedAxis = Vector3::UNIT_Y );
+        void setFixedYawAxis( bool useFixed, const Vector3& fixedAxis = Vector3::UNIT_Y );
 
         /** Rotate the node around the Y-axis.
         */
-        virtual void yaw(const Radian& angle, TransformSpace relativeTo = TS_LOCAL);
+        void yaw(const Radian& angle, TransformSpace relativeTo = TS_LOCAL);
         /** Sets the node's direction vector ie it's local -z.
         @remarks
         Note that the 'up' vector for the orientation will automatically be 
@@ -371,7 +375,7 @@ namespace Ogre {
         @param localDirectionVector The vector which normally describes the natural
         direction of the node, usually -Z
         */
-        virtual void setDirection(Real x, Real y, Real z, 
+        void setDirection(Real x, Real y, Real z,
             TransformSpace relativeTo = TS_LOCAL, 
             const Vector3& localDirectionVector = Vector3::NEGATIVE_UNIT_Z);
 
@@ -385,7 +389,7 @@ namespace Ogre {
         @param localDirectionVector The vector which normally describes the natural
         direction of the node, usually -Z
         */
-        virtual void setDirection(const Vector3& vec, TransformSpace relativeTo = TS_LOCAL, 
+        void setDirection(const Vector3& vec, TransformSpace relativeTo = TS_LOCAL,
             const Vector3& localDirectionVector = Vector3::NEGATIVE_UNIT_Z);
         /** Points the local -Z direction of this node at a point in space.
         @param targetPoint A vector specifying the look at point.
@@ -393,7 +397,7 @@ namespace Ogre {
         @param localDirectionVector The vector which normally describes the natural
         direction of the node, usually -Z
         */
-        virtual void lookAt( const Vector3& targetPoint, TransformSpace relativeTo,
+        void lookAt( const Vector3& targetPoint, TransformSpace relativeTo,
             const Vector3& localDirectionVector = Vector3::NEGATIVE_UNIT_Z);
         /** Enables / disables automatic tracking of another SceneNode.
         @remarks
@@ -413,15 +417,15 @@ namespace Ogre {
         @param offset If supplied, this is the target point in local space of the target node
         instead of the origin of the target node. Good for fine tuning the look at point.
         */
-        virtual void setAutoTracking(bool enabled, SceneNode* const target = 0, 
+        void setAutoTracking(bool enabled, SceneNode* const target = 0,
             const Vector3& localDirectionVector = Vector3::NEGATIVE_UNIT_Z,
             const Vector3& offset = Vector3::ZERO);
         /** Get the auto tracking target for this node, if any. */
-        virtual SceneNode* getAutoTrackTarget(void) { return mAutoTrackTarget; }
+        SceneNode* getAutoTrackTarget(void) { return mAutoTrackTarget; }
         /** Get the auto tracking offset for this node, if the node is auto tracking. */
-        virtual const Vector3& getAutoTrackOffset(void) { return mAutoTrackOffset; }
+        const Vector3& getAutoTrackOffset(void) { return mAutoTrackOffset; }
         /** Get the auto tracking local direction for this node, if it is auto tracking. */
-        virtual const Vector3& getAutoTrackLocalDirection(void) { return mAutoTrackLocalDirection; }
+        const Vector3& getAutoTrackLocalDirection(void) { return mAutoTrackLocalDirection; }
         /** Internal method used by OGRE to update auto-tracking cameras. */
         void _autoTrack(void);
         /** Gets the parent of this SceneNode. */
@@ -434,7 +438,7 @@ namespace Ogre {
         @param visible Whether the objects are to be made visible or invisible
         @param cascade If true, this setting cascades into child nodes too.
         */
-        virtual void setVisible(bool visible, bool cascade = true);
+        void setVisible(bool visible, bool cascade = true);
         /** Inverts the visibility of all objects attached to this node.
         @remarks    
         This is a shortcut to calling setVisible(!isVisible()) on the objects attached
@@ -442,7 +446,7 @@ namespace Ogre {
         nodes. 
         @param cascade If true, this setting cascades into child nodes too.
         */
-        virtual void flipVisibility(bool cascade = true);
+        void flipVisibility(bool cascade = true);
 
         /** Tells all objects attached to this node whether to display their
             debug information or not.
@@ -453,10 +457,10 @@ namespace Ogre {
         @param enabled Whether the objects are to display debug info or not
         @param cascade If true, this setting cascades into child nodes too.
         */
-        virtual void setDebugDisplayEnabled(bool enabled, bool cascade = true);
+        void setDebugDisplayEnabled(bool enabled, bool cascade = true);
 
         /// As Node::getDebugRenderable, except scaling is automatically determined
-        virtual DebugRenderable* getDebugRenderable();
+        DebugRenderable* getDebugRenderable();
 
         /// @copydoc Node::getDebugRenderable
         using Node::getDebugRenderable;

--- a/OgreMain/src/OgreNode.cpp
+++ b/OgreMain/src/OgreNode.cpp
@@ -134,11 +134,6 @@ namespace Ogre {
         }
 
     }
-    //-----------------------------------------------------------------------
-    Node* Node::getParent(void) const
-    {
-        return mParent;
-    }
 
     //-----------------------------------------------------------------------
     void Node::setParent(Node* parent)
@@ -350,11 +345,6 @@ namespace Ogre {
 
     }
     //-----------------------------------------------------------------------
-    unsigned short Node::numChildren(void) const
-    {
-        return static_cast< unsigned short >( mChildren.size() );
-    }
-    //-----------------------------------------------------------------------
     Node* Node::getChild(unsigned short index) const
     {
         if( index < mChildren.size() )
@@ -408,16 +398,11 @@ namespace Ogre {
         }
         return child;
     }
-    //-----------------------------------------------------------------------
-    const Quaternion& Node::getOrientation() const
-    {
-        return mOrientation;
-    }
 
     //-----------------------------------------------------------------------
     void Node::setOrientation( const Quaternion & q )
     {
-        assert(!q.isNaN() && "Invalid orientation supplied as parameter");
+        OgreAssert(!q.isNaN(), "Invalid orientation supplied as parameter");
         mOrientation = q;
         mOrientation.normalise();
         needUpdate();
@@ -450,11 +435,6 @@ namespace Ogre {
         setPosition(v);
     }
 
-    //-----------------------------------------------------------------------
-    const Vector3 & Node::getPosition(void) const
-    {
-        return mPosition;
-    }
     //-----------------------------------------------------------------------
     Matrix3 Node::getLocalAxes(void) const
     {
@@ -702,11 +682,7 @@ namespace Ogre {
     {
         setScale(Vector3(x, y, z));
     }
-    //-----------------------------------------------------------------------
-    const Vector3 & Node::getScale(void) const
-    {
-        return mScale;
-    }
+
     //-----------------------------------------------------------------------
     void Node::setInheritOrientation(bool inherit)
     {
@@ -714,20 +690,10 @@ namespace Ogre {
         needUpdate();
     }
     //-----------------------------------------------------------------------
-    bool Node::getInheritOrientation(void) const
-    {
-        return mInheritOrientation;
-    }
-    //-----------------------------------------------------------------------
     void Node::setInheritScale(bool inherit)
     {
         mInheritScale = inherit;
         needUpdate();
-    }
-    //-----------------------------------------------------------------------
-    bool Node::getInheritScale(void) const
-    {
-        return mInheritScale;
     }
     //-----------------------------------------------------------------------
     void Node::scale(const Vector3& inScale)
@@ -746,11 +712,6 @@ namespace Ogre {
 
     }
     //-----------------------------------------------------------------------
-    const String& Node::getName(void) const
-    {
-        return mName;
-    }
-    //-----------------------------------------------------------------------
     void Node::setInitialState(void)
     {
         mInitialPosition = mPosition;
@@ -765,22 +726,6 @@ namespace Ogre {
         mScale = mInitialScale;
 
         needUpdate();
-    }
-    //-----------------------------------------------------------------------
-    const Vector3& Node::getInitialPosition(void) const
-    {
-        return mInitialPosition;
-    }
-    //-----------------------------------------------------------------------
-    const Quaternion& Node::getInitialOrientation(void) const
-    {
-        return mInitialOrientation;
-
-    }
-    //-----------------------------------------------------------------------
-    const Vector3& Node::getInitialScale(void) const
-    {
-        return mInitialScale;
     }
     //-----------------------------------------------------------------------
     Node* Node::getChild(const String& name) const

--- a/OgreMain/src/OgreSceneNode.cpp
+++ b/OgreMain/src/OgreSceneNode.cpp
@@ -336,18 +336,6 @@ namespace Ogre {
         queue->addRenderable(mWireBoundingBox);
     }
 
-    void SceneNode::showBoundingBox(bool bShow) {
-        mShowBoundingBox = bShow;
-    }
-
-    bool SceneNode::getShowBoundingBox() const {
-        return mShowBoundingBox;
-    }
-
-    void SceneNode::hideBoundingBox(bool bHide) {
-        mHideBoundingBox = bHide;
-    }
-
     //-----------------------------------------------------------------------
     void SceneNode::updateFromParentImpl(void) const
     {
@@ -372,21 +360,6 @@ namespace Ogre {
     {
         assert(mCreator);
         return mCreator->createSceneNode(name);
-    }
-    //-----------------------------------------------------------------------
-    const AxisAlignedBox& SceneNode::_getWorldAABB(void) const
-    {
-        return mWorldAABB;
-    }
-    //-----------------------------------------------------------------------
-    SceneNode::ObjectIterator SceneNode::getAttachedObjectIterator(void)
-    {
-        return ObjectIterator(mObjectsByName.begin(), mObjectsByName.end());
-    }
-    //-----------------------------------------------------------------------
-    SceneNode::ConstObjectIterator SceneNode::getAttachedObjectIterator(void) const
-    {
-        return ConstObjectIterator(mObjectsByName.begin(), mObjectsByName.end());
     }
     //-----------------------------------------------------------------------
     void SceneNode::removeAndDestroyChild(const String& name)


### PR DESCRIPTION
this is safe as we are the only ones deriving from Node via SceneNode
and Bone: 
![](https://ogrecave.github.io/ogre/api/1.10/class_ogre_1_1_node__inherit__graph.svg)