### PR TITLE
Fix codec registration. In Ogre::Root::Root, image codec registration…

### DIFF
--- a/OgreMain/src/OgreRoot.cpp
+++ b/OgreMain/src/OgreRoot.cpp
@@ -229,24 +229,6 @@ namespace Ogre {
         ArchiveManager::getSingleton().addArchiveFactory( mEmbeddedZipArchiveFactory );
 #   endif
 
-#if OGRE_NO_DDS_CODEC == 0
-        // Register image codecs
-        DDSCodec::startup();
-#endif
-#if OGRE_NO_FREEIMAGE == 0
-        // Register image codecs
-        FreeImageCodec::startup();
-#endif
-#if OGRE_NO_PVRTC_CODEC == 0
-        PVRTCCodec::startup();
-#endif
-#if OGRE_NO_ETC_CODEC == 0
-        ETCCodec::startup();
-#endif
-#if OGRE_NO_STBI_CODEC == 0
-        STBIImageCodec::startup();
-#endif
-
         mHighLevelGpuProgramManager = OGRE_NEW HighLevelGpuProgramManager();
 
         mExternalTextureSourceManager = OGRE_NEW ExternalTextureSourceManager();
@@ -271,8 +253,27 @@ namespace Ogre {
         addMovableObjectFactory(mRibbonTrailFactory);
 
         // Load plugins
-        if (!pluginFileName.empty())
+        if (!pluginFileName.empty()) {
             loadPlugins(pluginFileName);
+        }
+
+#if OGRE_NO_DDS_CODEC == 0
+        // Register image codecs
+        DDSCodec::startup();
+#endif
+#if OGRE_NO_FREEIMAGE == 0
+        // Register image codecs
+        FreeImageCodec::startup();
+#endif
+#if OGRE_NO_PVRTC_CODEC == 0
+        PVRTCCodec::startup();
+#endif
+#if OGRE_NO_ETC_CODEC == 0
+        ETCCodec::startup();
+#endif
+#if OGRE_NO_STBI_CODEC == 0
+        STBIImageCodec::startup();
+#endif
 
         LogManager::getSingleton().logMessage("*-*-* OGRE Initialising");
         msg = "*-*-* Version " + mVersion;


### PR DESCRIPTION
While porting from v1-9 to v2-0, I ran into a problem where any png file wouldn't be loaded correctly by Ogre. A call to Ogre::Codec::getCodec would throw a OGRE EXCEPTION(5:ItemIdentityException): Can not find codec for 'png' image format.

I isolated the problem by debugging the Ogre::Root::Root constructor: getCodec("png") worked after registering the FreeImage codecs, but would fail after loading the plugins. Moving the image codec registration after loading the plugins solved the issue. In case other people are affected, here's a pull-request.