### PR TITLE
Correction of EXP and LOG operations on Quaternions.

### DIFF
--- a/OgreMain/src/OgreQuaternion.cpp
+++ b/OgreMain/src/OgreQuaternion.cpp
@@ -376,10 +376,10 @@ namespace Ogre {
 
         if ( Math::Abs(w) < 1.0 )
         {
-			// According to Neil Dantam, atan2 has the best stability.
-			// http://www.neil.dantam.name/note/dantam-quaternion.pdf
-			Real fNormV = Math::Sqrt(x*x + y*y + z*z);
-			Radian fAngle ( Math::ATan2(fNormV, w) );
+            // According to Neil Dantam, atan2 has the best stability.
+            // http://www.neil.dantam.name/note/dantam-quaternion.pdf
+            Real fNormV = Math::Sqrt(x*x + y*y + z*z);
+            Radian fAngle ( Math::ATan2(fNormV, w) );
 
             Real fSin = Math::Sin(fAngle);
             if ( Math::Abs(fSin) >= msEpsilon )

--- a/OgreMain/src/OgreQuaternion.cpp
+++ b/OgreMain/src/OgreQuaternion.cpp
@@ -338,27 +338,28 @@ namespace Ogre {
     Quaternion Quaternion::Exp () const
     {
         // If q = A*(x*i+y*j+z*k) where (x,y,z) is unit length, then
-        // exp(q) = cos(A)+sin(A)*(x*i+y*j+z*k).  If sin(A) is near zero,
-        // use exp(q) = cos(A)+A*(x*i+y*j+z*k) since A/sin(A) has limit 1.
+        // exp(q) = e^w(cos(A)+sin(A)*(x*i+y*j+z*k)).  If sin(A) is near zero,
+        // use exp(q) = e^w(cos(A)+(x*i+y*j+z*k)) since sin(A)/A has limit 1.
 
         Radian fAngle ( Math::Sqrt(x*x+y*y+z*z) );
         Real fSin = Math::Sin(fAngle);
+		Real fExpW = Math::Exp(w);
 
         Quaternion kResult;
-        kResult.w = Math::Cos(fAngle);
+        kResult.w = fExpW*Math::Cos(fAngle);
 
         if ( Math::Abs(fSin) >= msEpsilon )
         {
-            Real fCoeff = fSin/(fAngle.valueRadians());
+            Real fCoeff = fExpW*(fSin/(fAngle.valueRadians()));
             kResult.x = fCoeff*x;
             kResult.y = fCoeff*y;
             kResult.z = fCoeff*z;
         }
         else
         {
-            kResult.x = x;
-            kResult.y = y;
-            kResult.z = z;
+            kResult.x = fExpW*x;
+            kResult.y = fExpW*y;
+            kResult.z = fExpW*z;
         }
 
         return kResult;

--- a/OgreMain/src/OgreQuaternion.cpp
+++ b/OgreMain/src/OgreQuaternion.cpp
@@ -348,7 +348,7 @@ namespace Ogre {
         Quaternion kResult;
         kResult.w = fExpW*Math::Cos(fAngle);
 
-        if ( Math::Abs(fSin) >= msEpsilon )
+        if ( Math::Abs(fAngle.valueRadians()) >= msEpsilon )
         {
             Real fCoeff = fExpW*(fSin/(fAngle.valueRadians()));
             kResult.x = fCoeff*x;

--- a/OgreMain/src/OgreQuaternion.cpp
+++ b/OgreMain/src/OgreQuaternion.cpp
@@ -368,15 +368,19 @@ namespace Ogre {
     Quaternion Quaternion::Log () const
     {
         // If q = cos(A)+sin(A)*(x*i+y*j+z*k) where (x,y,z) is unit length, then
-        // log(q) = A*(x*i+y*j+z*k).  If sin(A) is near zero, use log(q) =
-        // sin(A)*(x*i+y*j+z*k) since sin(A)/A has limit 1.
+        // log(q) = (A/sin(A))*(x*i+y*j+z*k).  If sin(A) is near zero, use
+        // log(q) = (x*i+y*j+z*k) since A/sin(A) has limit 1.
 
         Quaternion kResult;
         kResult.w = 0.0;
 
         if ( Math::Abs(w) < 1.0 )
         {
-            Radian fAngle ( Math::ACos(w) );
+			// According to Neil Dantam, atan2 has the best stability.
+			// http://www.neil.dantam.name/note/dantam-quaternion.pdf
+			Real fNormV = Math::Sqrt(x*x + y*y + z*z);
+			Radian fAngle ( Math::ATan2(fNormV, w) );
+
             Real fSin = Math::Sin(fAngle);
             if ( Math::Abs(fSin) >= msEpsilon )
             {

--- a/Tests/OgreMain/src/QuaternionTests.cpp
+++ b/Tests/OgreMain/src/QuaternionTests.cpp
@@ -102,7 +102,7 @@ TEST(QuaternionTests,Exp)
     // Case a quaternion for which angle is 0 degrees.
     Quaternion quatA = Quaternion(1., 0., 0., 0.);
     Quaternion expQuatA = quatA.Exp();
-    EXPECT_NEAR(expQuatA.w, 2.71828, 1e-6);
+    EXPECT_NEAR(expQuatA.w, 2.71828182845905, 1e-6);
     EXPECT_NEAR(expQuatA.x, 0., 1e-6);
     EXPECT_NEAR(expQuatA.y, 0., 1e-6);
     EXPECT_NEAR(expQuatA.z, 0., 1e-6);
@@ -110,16 +110,16 @@ TEST(QuaternionTests,Exp)
     // Case of a common quaternion (no specific rotation).
     Quaternion quatB = Quaternion(0.2, 0.7, Ogre::Math::PI, 0.9);
     Quaternion expQuatB = quatB.Exp();
-    EXPECT_NEAR(expQuatB.w, -1.19693, 1e-6);
-    EXPECT_NEAR(expQuatB.x, -0.0509502, 1e-6);
-    EXPECT_NEAR(expQuatB.y, -0.228664, 1e-6);
-    EXPECT_NEAR(expQuatB.z, -0.0655073, 1e-6);
+    EXPECT_NEAR(expQuatB.w, -1.19693377635754, 1e-6);
+    EXPECT_NEAR(expQuatB.x, -0.05095014937169, 1e-6);
+    EXPECT_NEAR(expQuatB.y, -0.22866373566485, 1e-6);
+    EXPECT_NEAR(expQuatB.z, -0.06550733490645, 1e-6);
 
     // Normalised quaternion B.
     quatB.normalise() ;
     Quaternion expUnitQuatB = quatB.Exp();
-    EXPECT_NEAR(expUnitQuatB.w, 0.575155, 1e-6);
-    EXPECT_NEAR(expUnitQuatB.x, 0.18688, 1e-6);
-    EXPECT_NEAR(expUnitQuatB.y, 0.838715, 1e-6);
-    EXPECT_NEAR(expUnitQuatB.z, 0.240274, 1e-6);
+    EXPECT_NEAR(expUnitQuatB.w, 0.575155457731263, 1e-6);
+    EXPECT_NEAR(expUnitQuatB.x, 0.186879761760123, 1e-6);
+    EXPECT_NEAR(expUnitQuatB.y, 0.838714409500305, 1e-6);
+    EXPECT_NEAR(expUnitQuatB.z, 0.240273979405873, 1e-6);
 }

--- a/Tests/OgreMain/src/QuaternionTests.cpp
+++ b/Tests/OgreMain/src/QuaternionTests.cpp
@@ -132,8 +132,8 @@ TEST(QuaternionTests,Log)
     Quaternion quat(0.85, Ogre::Math::PI, 0.6, 0.2);
     quat.normalise() ;
     Quaternion logUnitQuat = quat.Log();
-    EXPECT_NEAR(quat.w, 0., 1e-6);
-    EXPECT_NEAR(quat.x, 1.28572906735070, 1e-6);
-    EXPECT_NEAR(quat.y, 0.24555616385496, 1e-6);
-    EXPECT_NEAR(quat.z, 0.08185205461832, 1e-6);
+    EXPECT_NEAR(logUnitQuat.w, 0., 1e-6);
+    EXPECT_NEAR(logUnitQuat.x, 1.28572906735070, 1e-6);
+    EXPECT_NEAR(logUnitQuat.y, 0.24555616385496, 1e-6);
+    EXPECT_NEAR(logUnitQuat.z, 0.08185205461832, 1e-6);
 }

--- a/Tests/OgreMain/src/QuaternionTests.cpp
+++ b/Tests/OgreMain/src/QuaternionTests.cpp
@@ -102,24 +102,24 @@ TEST(QuaternionTests,Exp)
     // Case a quaternion for which angle is 0 degrees.
     Quaternion quatA = Quaternion(1., 0., 0., 0.);
     Quaternion expQuatA = quatA.Exp();
-    EXPECT_NEAR(expQuatA.w, 2.71828, 1e-6)
-    EXPECT_NEAR(expQuatA.x, 0., 1e-6)
-    EXPECT_NEAR(expQuatA.y, 0., 1e-6)
-    EXPECT_NEAR(expQuatA.z, 0., 1e-6)
+    EXPECT_NEAR(expQuatA.w, 2.71828, 1e-6);
+    EXPECT_NEAR(expQuatA.x, 0., 1e-6);
+    EXPECT_NEAR(expQuatA.y, 0., 1e-6);
+    EXPECT_NEAR(expQuatA.z, 0., 1e-6);
 
     // Case of a common quaternion (no specific rotation).
     Quaternion quatB = Quaternion(0.2, 0.7, Ogre::Math::PI, 0.9);
     Quaternion expQuatB = quatB.Exp();
-    EXPECT_NEAR(expQuatB.w, -1.19693, 1e-6)
-    EXPECT_NEAR(expQuatB.x, -0.0509502, 1e-6)
-    EXPECT_NEAR(expQuatB.y, -0.228664, 1e-6)
-    EXPECT_NEAR(expQuatB.z, -0.0655073, 1e-6)
+    EXPECT_NEAR(expQuatB.w, -1.19693, 1e-6);
+    EXPECT_NEAR(expQuatB.x, -0.0509502, 1e-6);
+    EXPECT_NEAR(expQuatB.y, -0.228664, 1e-6);
+    EXPECT_NEAR(expQuatB.z, -0.0655073, 1e-6);
 
     // Normalised quaternion B.
     quatB.normalise() ;
     Quaternion expUnitQuatB = quatB.Exp();
-    EXPECT_NEAR(expUnitQuatB.w, 0.575155, 1e-6)
-    EXPECT_NEAR(expUnitQuatB.x, 0.18688, 1e-6)
-    EXPECT_NEAR(expUnitQuatB.y, 0.838715, 1e-6)
-    EXPECT_NEAR(expUnitQuatB.z, 0.240274, 1e-6)
+    EXPECT_NEAR(expUnitQuatB.w, 0.575155, 1e-6);
+    EXPECT_NEAR(expUnitQuatB.x, 0.18688, 1e-6);
+    EXPECT_NEAR(expUnitQuatB.y, 0.838715, 1e-6);
+    EXPECT_NEAR(expUnitQuatB.z, 0.240274, 1e-6);
 }

--- a/Tests/OgreMain/src/QuaternionTests.cpp
+++ b/Tests/OgreMain/src/QuaternionTests.cpp
@@ -100,7 +100,7 @@ TEST(QuaternionTests,Exp)
     /** Comparison values got from the Octave quaternion package. */
 
     // Case a quaternion for which angle is 0 degrees.
-    Quaternion quatA = Quaternion(1., 0., 0., 0.);
+    Quaternion quatA(1., 0., 0., 0.);
     Quaternion expQuatA = quatA.Exp();
     EXPECT_NEAR(expQuatA.w, 2.71828182845905, 1e-6);
     EXPECT_NEAR(expQuatA.x, 0., 1e-6);
@@ -108,7 +108,7 @@ TEST(QuaternionTests,Exp)
     EXPECT_NEAR(expQuatA.z, 0., 1e-6);
 
     // Case of a common quaternion (no specific rotation).
-    Quaternion quatB = Quaternion(0.2, 0.7, Ogre::Math::PI, 0.9);
+    Quaternion quatB(0.2, 0.7, Ogre::Math::PI, 0.9);
     Quaternion expQuatB = quatB.Exp();
     EXPECT_NEAR(expQuatB.w, -1.19693377635754, 1e-6);
     EXPECT_NEAR(expQuatB.x, -0.05095014937169, 1e-6);
@@ -122,4 +122,18 @@ TEST(QuaternionTests,Exp)
     EXPECT_NEAR(expUnitQuatB.x, 0.186879761760123, 1e-6);
     EXPECT_NEAR(expUnitQuatB.y, 0.838714409500305, 1e-6);
     EXPECT_NEAR(expUnitQuatB.z, 0.240273979405873, 1e-6);
+}
+
+TEST(QuaternionTests,Log)
+{
+    /** Comparison values got from the Octave quaternion package. */
+
+    // Case of a common quaternion (no specific rotation).
+    Quaternion quat(0.85, Ogre::Math::PI, 0.6, 0.2);
+    quat.normalise() ;
+    Quaternion logUnitQuat = quat.Log();
+    EXPECT_NEAR(quat.w, 0., 1e-6);
+    EXPECT_NEAR(quat.x, 1.28572906735070, 1e-6);
+    EXPECT_NEAR(quat.y, 0.24555616385496, 1e-6);
+    EXPECT_NEAR(quat.z, 0.08185205461832, 1e-6);
 }

--- a/Tests/OgreMain/src/QuaternionTests.cpp
+++ b/Tests/OgreMain/src/QuaternionTests.cpp
@@ -102,24 +102,24 @@ TEST(QuaternionTests,Exp)
     // Case a quaternion for which angle is 0 degrees.
     Quaternion quatA = Quaternion(1., 0., 0., 0.);
     Quaternion expQuatA = quatA.Exp();
-    EXPECT_DOUBLE_EQ(expQuatA.w, 2.71828);
-    EXPECT_DOUBLE_EQ(expQuatA.x, 0.);
-    EXPECT_DOUBLE_EQ(expQuatA.y, 0.);
-    EXPECT_DOUBLE_EQ(expQuatA.z, 0.);
+    EXPECT_NEAR(expQuatA.w, 2.71828, 1e-6)
+    EXPECT_NEAR(expQuatA.x, 0., 1e-6)
+    EXPECT_NEAR(expQuatA.y, 0., 1e-6)
+    EXPECT_NEAR(expQuatA.z, 0., 1e-6)
 
     // Case of a common quaternion (no specific rotation).
     Quaternion quatB = Quaternion(0.2, 0.7, Ogre::Math::PI, 0.9);
     Quaternion expQuatB = quatB.Exp();
-    EXPECT_DOUBLE_EQ(expQuatB.w, -1.19693);
-    EXPECT_DOUBLE_EQ(expQuatB.x, -0.0509502);
-    EXPECT_DOUBLE_EQ(expQuatB.y, -0.228664);
-    EXPECT_DOUBLE_EQ(expQuatB.z, -0.0655073);
+    EXPECT_NEAR(expQuatB.w, -1.19693, 1e-6)
+    EXPECT_NEAR(expQuatB.x, -0.0509502, 1e-6)
+    EXPECT_NEAR(expQuatB.y, -0.228664, 1e-6)
+    EXPECT_NEAR(expQuatB.z, -0.0655073, 1e-6)
 
     // Normalised quaternion B.
     quatB.normalise() ;
     Quaternion expUnitQuatB = quatB.Exp();
-    EXPECT_DOUBLE_EQ(expUnitQuatB.w, 0.575155);
-    EXPECT_DOUBLE_EQ(expUnitQuatB.x, 0.18688);
-    EXPECT_DOUBLE_EQ(expUnitQuatB.y, 0.838715);
-    EXPECT_DOUBLE_EQ(expUnitQuatB.z, 0.240274);
+    EXPECT_NEAR(expUnitQuatB.w, 0.575155, 1e-6)
+    EXPECT_NEAR(expUnitQuatB.x, 0.18688, 1e-6)
+    EXPECT_NEAR(expUnitQuatB.y, 0.838715, 1e-6)
+    EXPECT_NEAR(expUnitQuatB.z, 0.240274, 1e-6)
 }

--- a/Tests/OgreMain/src/QuaternionTests.cpp
+++ b/Tests/OgreMain/src/QuaternionTests.cpp
@@ -102,24 +102,24 @@ TEST(QuaternionTests,Exp)
     // Case a quaternion for which angle is 0 degrees.
     Quaternion quatA = Quaternion(1., 0., 0., 0.);
     Quaternion expQuatA = quatA.Exp();
-    EXPECT_EQ(expQuatA.w, 2.71828);
-    EXPECT_EQ(expQuatA.x, 0.);
-    EXPECT_EQ(expQuatA.y, 0.);
-    EXPECT_EQ(expQuatA.z, 0.);
+    EXPECT_DOUBLE_EQ(expQuatA.w, 2.71828);
+    EXPECT_DOUBLE_EQ(expQuatA.x, 0.);
+    EXPECT_DOUBLE_EQ(expQuatA.y, 0.);
+    EXPECT_DOUBLE_EQ(expQuatA.z, 0.);
 
     // Case of a common quaternion (no specific rotation).
     Quaternion quatB = Quaternion(0.2, 0.7, Ogre::Math::PI, 0.9);
     Quaternion expQuatB = quatB.Exp();
-    EXPECT_EQ(expQuatB.w, -1.19693);
-    EXPECT_EQ(expQuatB.x, -0.0509502);
-    EXPECT_EQ(expQuatB.y, -0.228664);
-    EXPECT_EQ(expQuatB.z, -0.0655073);
+    EXPECT_DOUBLE_EQ(expQuatB.w, -1.19693);
+    EXPECT_DOUBLE_EQ(expQuatB.x, -0.0509502);
+    EXPECT_DOUBLE_EQ(expQuatB.y, -0.228664);
+    EXPECT_DOUBLE_EQ(expQuatB.z, -0.0655073);
 
     // Normalised quaternion B.
     quatB.normalise() ;
     Quaternion expUnitQuatB = quatB.Exp();
-    EXPECT_EQ(expUnitQuatB.w, 0.575155);
-    EXPECT_EQ(expUnitQuatB.x, 0.18688);
-    EXPECT_EQ(expUnitQuatB.y, 0.838715);
-    EXPECT_EQ(expUnitQuatB.z, 0.240274);
+    EXPECT_DOUBLE_EQ(expUnitQuatB.w, 0.575155);
+    EXPECT_DOUBLE_EQ(expUnitQuatB.x, 0.18688);
+    EXPECT_DOUBLE_EQ(expUnitQuatB.y, 0.838715);
+    EXPECT_DOUBLE_EQ(expUnitQuatB.z, 0.240274);
 }

--- a/Tests/OgreMain/src/QuaternionTests.cpp
+++ b/Tests/OgreMain/src/QuaternionTests.cpp
@@ -102,32 +102,24 @@ TEST(QuaternionTests,Exp)
     // Case a quaternion for which angle is 0 degrees.
     Quaternion quatA = Quaternion(1., 0., 0., 0.);
     Quaternion expQuatA = quatA.Exp();
-    EXPECT_EQ(expQuatA.w, -2.71828182845905);
+    EXPECT_EQ(expQuatA.w, 2.71828);
     EXPECT_EQ(expQuatA.x, 0.);
     EXPECT_EQ(expQuatA.y, 0.);
     EXPECT_EQ(expQuatA.z, 0.);
 
-    // Normalised quaternion A.
-    quatA.normalise() ;
-    Quaternion expUnitQuatA = quatA.Exp();
-    EXPECT_EQ(expUnitQuatA.w, 0.784609252419620);
-    EXPECT_EQ(expUnitQuatA.x, 0.);
-    EXPECT_EQ(expUnitQuatA.y, 0.);
-    EXPECT_EQ(expUnitQuatA.z, 0.);
-
     // Case of a common quaternion (no specific rotation).
     Quaternion quatB = Quaternion(0.2, 0.7, Ogre::Math::PI, 0.9);
     Quaternion expQuatB = quatB.Exp();
-    EXPECT_EQ(expQuatB.w, -1.19693377635754);
-    EXPECT_EQ(expQuatB.x, -0.05095014937169);
-    EXPECT_EQ(expQuatB.y, -0.22866373566485);
-    EXPECT_EQ(expQuatB.z, -0.06550733490645);
+    EXPECT_EQ(expQuatB.w, -1.19693);
+    EXPECT_EQ(expQuatB.x, -0.0509502);
+    EXPECT_EQ(expQuatB.y, -0.228664);
+    EXPECT_EQ(expQuatB.z, -0.0655073);
 
     // Normalised quaternion B.
     quatB.normalise() ;
     Quaternion expUnitQuatB = quatB.Exp();
-    EXPECT_EQ(expUnitQuatB.w, 0.575155457731263);
-    EXPECT_EQ(expUnitQuatB.x, 0.186879761760123);
-    EXPECT_EQ(expUnitQuatB.y, 0.838714409500305);
-    EXPECT_EQ(expUnitQuatB.z, 0.240273979405873);
+    EXPECT_EQ(expUnitQuatB.w, 0.575155);
+    EXPECT_EQ(expUnitQuatB.x, 0.18688);
+    EXPECT_EQ(expUnitQuatB.y, 0.838715);
+    EXPECT_EQ(expUnitQuatB.z, 0.240274);
 }

--- a/Tests/OgreMain/src/QuaternionTests.cpp
+++ b/Tests/OgreMain/src/QuaternionTests.cpp
@@ -95,3 +95,39 @@ TEST(QuaternionTests,FromVectors)
     EXPECT_TRUE(to.normalisedCopy().positionEquals(from.getRotationTo(to) * from.normalisedCopy()));
 }
 
+TEST(QuaternionTests,Exp)
+{
+    /** Comparison values got from the Octave quaternion package. */
+
+    // Case a quaternion for which angle is 0 degrees.
+    Quaternion quatA = Quaternion(1., 0., 0., 0.);
+    Quaternion expQuatA = quatA.Exp();
+    EXPECT_EQ(expQuatA.w, -2.71828182845905);
+    EXPECT_EQ(expQuatA.x, 0.);
+    EXPECT_EQ(expQuatA.y, 0.);
+    EXPECT_EQ(expQuatA.z, 0.);
+
+    // Normalised quaternion A.
+    quatA.normalise() ;
+    Quaternion expUnitQuatA = quatA.Exp();
+    EXPECT_EQ(expUnitQuatA.w, 0.784609252419620);
+    EXPECT_EQ(expUnitQuatA.x, 0.);
+    EXPECT_EQ(expUnitQuatA.y, 0.);
+    EXPECT_EQ(expUnitQuatA.z, 0.);
+
+    // Case of a common quaternion (no specific rotation).
+    Quaternion quatB = Quaternion(0.2, 0.7, Ogre::Math::PI, 0.9);
+    Quaternion expQuatB = quatB.Exp();
+    EXPECT_EQ(expQuatB.w, -1.19693377635754);
+    EXPECT_EQ(expQuatB.x, -0.05095014937169);
+    EXPECT_EQ(expQuatB.y, -0.22866373566485);
+    EXPECT_EQ(expQuatB.z, -0.06550733490645);
+
+    // Normalised quaternion B.
+    quatB.normalise() ;
+    Quaternion expUnitQuatB = quatB.Exp();
+    EXPECT_EQ(expUnitQuatB.w, 0.575155457731263);
+    EXPECT_EQ(expUnitQuatB.x, 0.186879761760123);
+    EXPECT_EQ(expUnitQuatB.y, 0.838714409500305);
+    EXPECT_EQ(expUnitQuatB.z, 0.240273979405873);
+}


### PR DESCRIPTION
The exponential of a quaternion was incorrect, the results were different from what can be found with Matlab or Octave.

The logarithm computation is improved by using the atan2 form to compute the angle. As mentioned in "Quaternion Computation" by Neil Dantam, it is best for numerical stability.
http://www.neil.dantam.name/note/dantam-quaternion.pdf