### PR TITLE
GL*: change library order to correctly link against libGL

### DIFF
--- a/RenderSystems/GL/CMakeLists.txt
+++ b/RenderSystems/GL/CMakeLists.txt
@@ -77,7 +77,7 @@ add_definitions(-DGLEW_STATIC -DYY_NEVER_INTERACTIVE)
 #Note that in the next row SOURCE_FILES are added last. This is to prevent compilation problems of unity build found on Windows Visual Studio. 
 #In this situation any file added after the "glew.cpp" file, which belongs to the SOURCE_FILES package, does not compile
 ogre_add_library_to_folder(RenderSystems RenderSystem_GL ${OGRE_LIB_TYPE} ${HEADER_FILES} ${GLSL_SOURCE} ${ATIFS_SOURCE} ${NVPARSE_SOURCE} ${SOURCE_FILES})
-target_link_libraries(RenderSystem_GL OgreMain ${OPENGL_LIBRARIES} ${GLSUPPORT_LIBS})
+target_link_libraries(RenderSystem_GL OgreMain ${GLSUPPORT_LIBS} ${OPENGL_LIBRARIES})
 
 if (NOT OGRE_STATIC)
   set_target_properties(RenderSystem_GL PROPERTIES

--- a/RenderSystems/GL3Plus/CMakeLists.txt
+++ b/RenderSystems/GL3Plus/CMakeLists.txt
@@ -33,7 +33,7 @@ if(NOT APPLE)
 endif()
 
 ogre_add_library_to_folder(RenderSystems RenderSystem_GL3Plus ${OGRE_LIB_TYPE} ${HEADER_FILES} ${GLSL_SOURCE} ${SOURCE_FILES})
-target_link_libraries(RenderSystem_GL3Plus OgreMain ${OPENGL_LIBRARIES} ${GLSUPPORT_LIBS})
+target_link_libraries(RenderSystem_GL3Plus OgreMain ${GLSUPPORT_LIBS} ${OPENGL_LIBRARIES})
 
 if (OGRE_CONFIG_THREADS)
   target_link_libraries(RenderSystem_GL3Plus ${OGRE_THREAD_LIBRARIES})

--- a/RenderSystems/GLES2/CMakeLists.txt
+++ b/RenderSystems/GLES2/CMakeLists.txt
@@ -74,7 +74,7 @@ include_directories(
 )
 
 ogre_add_library_to_folder(RenderSystems RenderSystem_GLES2 ${OGRE_LIB_TYPE} ${HEADER_FILES} ${GLESW_HEADERS} ${KHR_HEADERS} ${PLATFORM_HEADERS} ${SOURCE_FILES} ${PLATFORM_SOURCES} SEPARATE ${GLSLES_FILES})
-target_link_libraries(RenderSystem_GLES2 OgreMain ${OPENGLES3_LIBRARIES} ${OPENGLES2_LIBRARIES} ${GLSUPPORT_LIBS})
+target_link_libraries(RenderSystem_GLES2 OgreMain ${GLSUPPORT_LIBS} ${OPENGLES3_LIBRARIES} ${OPENGLES2_LIBRARIES})
 
 if (NOT OGRE_STATIC)
   set_target_properties(RenderSystem_GLES2 PROPERTIES


### PR DESCRIPTION
fixes unresolved glX* symbols in GLSupport