### PR TITLE
LOD strategy: consider derived scale of the object

### DIFF
--- a/OgreMain/src/OgreDistanceLodStrategy.cpp
+++ b/OgreMain/src/OgreDistanceLodStrategy.cpp
@@ -170,7 +170,10 @@ namespace Ogre {
         // more computation (including a sqrt) so we approximate 
         // it with d^2 - r^2, which is good enough for determining 
         // LOD.
-        return movableObject->getParentNode()->getSquaredViewDepth(camera) - Math::Sqr(movableObject->getBoundingRadius());
+
+        const Vector3& scl = movableObject->getParentNode()->_getDerivedScale();
+        Real factor = std::max(std::max(scl.x, scl.y), scl.z);
+        return movableObject->getParentNode()->getSquaredViewDepth(camera) - Math::Sqr(movableObject->getBoundingRadius() * factor);
     }
     //-----------------------------------------------------------------------
 

--- a/OgreMain/src/OgrePixelCountLodStrategy.cpp
+++ b/OgreMain/src/OgrePixelCountLodStrategy.cpp
@@ -104,7 +104,9 @@ namespace Ogre {
         Real viewportArea = static_cast<Real>(viewport->getActualWidth() * viewport->getActualHeight());
 
         // Get area of unprojected circle with object bounding radius
-        Real boundingArea = Math::PI * Math::Sqr(movableObject->getBoundingRadius());
+        const Vector3& scl = movableObject->getParentNode()->_getDerivedScale();
+        Real factor = std::max(std::max(scl.x, scl.y), scl.z);
+        Real boundingArea = Math::PI * Math::Sqr(movableObject->getBoundingRadius() * factor);
 
         // Base computation on projection type
         switch (camera->getProjectionType())


### PR DESCRIPTION
When a mesh node is scaled the LOD strategy fail to compute the correct
distance / pixel ratio.