### PR TITLE
Renderbuffer reuse

### DIFF
--- a/RenderSystems/GL/src/OgreGLFBORenderTexture.cpp
+++ b/RenderSystems/GL/src/OgreGLFBORenderTexture.cpp
@@ -498,7 +498,7 @@ static const size_t depthBits[] =
         {
             RBFormat key(format, width, height, fsaa);
             RenderBufferMap::iterator it = mRenderBufferMap.find(key);
-            if(it != mRenderBufferMap.end() && (it->second.refcount == 0))
+            if(it != mRenderBufferMap.end())
             {
                 retval.buffer = it->second.buffer;
                 retval.zoffset = 0;

--- a/RenderSystems/GL3Plus/src/OgreGL3PlusFBORenderTexture.cpp
+++ b/RenderSystems/GL3Plus/src/OgreGL3PlusFBORenderTexture.cpp
@@ -506,7 +506,7 @@ namespace Ogre {
         {
             RBFormat key(format, width, height, fsaa);
             RenderBufferMap::iterator it = mRenderBufferMap.find(key);
-            if(it != mRenderBufferMap.end() && (it->second.refcount == 0))
+            if(it != mRenderBufferMap.end())
             {
                 retval.buffer = it->second.buffer;
                 retval.zoffset = 0;

--- a/RenderSystems/GLES2/src/OgreGLES2FBORenderTexture.cpp
+++ b/RenderSystems/GLES2/src/OgreGLES2FBORenderTexture.cpp
@@ -534,7 +534,7 @@ namespace Ogre {
         {
             RBFormat key(format, width, height, fsaa);
             RenderBufferMap::iterator it = mRenderBufferMap.find(key);
-            if(it != mRenderBufferMap.end() && (it->second.refcount == 0))
+            if(it != mRenderBufferMap.end())
             {
                 retval.buffer = it->second.buffer;
                 retval.zoffset = 0;

--- a/RenderSystems/GLSupport/include/OgreGLRenderTexture.h
+++ b/RenderSystems/GLSupport/include/OgreGLRenderTexture.h
@@ -73,11 +73,6 @@ namespace Ogre {
          */
         virtual RenderTexture *createRenderTexture(const String &name, const GLSurfaceDesc &target, bool writeGamma, uint fsaa) = 0;
 
-        /** Request the specify render buffer in case shared somewhere. Ignore
-            silently if surface.buffer is 0.
-        */
-        void requestRenderBuffer(const GLSurfaceDesc &surface);
-
         /** Release a render buffer. Ignore silently if surface.buffer is 0.
          */
         void releaseRenderBuffer(const GLSurfaceDesc &surface);

--- a/RenderSystems/GLSupport/src/OgreGLRenderTexture.cpp
+++ b/RenderSystems/GLSupport/src/OgreGLRenderTexture.cpp
@@ -94,21 +94,6 @@ namespace Ogre {
         return PF_A8R8G8B8;
     }
 
-    void GLRTTManager::requestRenderBuffer(const GLSurfaceDesc &surface)
-    {
-        if(surface.buffer == 0)
-            return;
-        RBFormat key(surface.buffer->getGLFormat(), surface.buffer->getWidth(), surface.buffer->getHeight(), surface.numSamples);
-        RenderBufferMap::iterator it = mRenderBufferMap.find(key);
-        assert(it != mRenderBufferMap.end());
-        if (it != mRenderBufferMap.end())   // Just in case
-        {
-            assert(it->second.buffer == surface.buffer);
-            // Increase refcount
-            ++it->second.refcount;
-        }
-    }
-
     void GLRTTManager::releaseRenderBuffer(const GLSurfaceDesc &surface)
     {
         if(surface.buffer == 0)


### PR DESCRIPTION
from: http://www.ogre3d.org/forums/viewtopic.php?f=25&t=92915

# expected
 each Ogre::Texture would have a unique resolve texture, but would share the same MSAA surface.
# issue
 1. existing renderbuffers with the same format to not reused. Instead, a new renderbuffer is created with the same format, which overwrites the element in the map that might have been there prior to the call. 
2. Thus, when the original renderbuffer with the same format is supposed to be released, the new renderbuffer is found instead, and deleted. 
3. With the wrong renderbuffer deleted, the memory error occurs when a texture is deleted which refers to the incorrectly deleted renderbuffer.
