### PR TITLE
GLSupport: remove barrier() - glFlush does not belong into GLContext

### DIFF
--- a/RenderSystems/GL/src/OgreGLRenderSystem.cpp
+++ b/RenderSystems/GL/src/OgreGLRenderSystem.cpp
@@ -58,6 +58,10 @@ THE SOFTWARE.
 
 #include "OgreGLPixelFormat.h"
 
+#if OGRE_PLATFORM == OGRE_PLATFORM_APPLE
+extern "C" void glFlushRenderAPPLE();
+#endif
+
 // Convenience macro from ARB_vertex_buffer_object spec
 #define VBO_BUFFER_OFFSET(i) ((char *)NULL + (i))
 
@@ -3348,7 +3352,10 @@ namespace Ogre {
         // It's ready for switching
         if (mCurrentContext!=context)
         {
-            mCurrentContext->barrier(); // ensure that gl resources created in the current context would be visible after context switching
+#if OGRE_PLATFORM == OGRE_PLATFORM_APPLE
+            // NSGLContext::makeCurrentContext does not flush automatically. everybody else does.
+            glFlushRenderAPPLE();
+#endif
             mCurrentContext->endCurrent();
             mCurrentContext = context;
         }

--- a/RenderSystems/GL3Plus/src/OgreGL3PlusRenderSystem.cpp
+++ b/RenderSystems/GL3Plus/src/OgreGL3PlusRenderSystem.cpp
@@ -61,6 +61,10 @@ Copyright (c) 2000-2014 Torus Knot Software Ltd
 #include "OgreGL3PlusPixelFormat.h"
 #include "OgreGL3PlusStateCacheManager.h"
 
+#if OGRE_PLATFORM == OGRE_PLATFORM_APPLE
+extern "C" void glFlushRenderAPPLE();
+#endif
+
 #ifndef GL_EXT_texture_filter_anisotropic
 #define GL_TEXTURE_MAX_ANISOTROPY_EXT     0x84FE
 #define GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT 0x84FF
@@ -1971,7 +1975,10 @@ namespace Ogre {
         // It's ready for switching
         if (mCurrentContext!=context)
         {
-            mCurrentContext->barrier(); // ensure that gl resources created in the current context would be visible after context switching
+#if OGRE_PLATFORM == OGRE_PLATFORM_APPLE
+            // NSGLContext::makeCurrentContext does not flush automatically. everybody else does.
+            glFlushRenderAPPLE();
+#endif
             mCurrentContext->endCurrent();
             mCurrentContext = context;
         }

--- a/RenderSystems/GLES2/include/EAGL/OgreEAGLES2Context.h
+++ b/RenderSystems/GLES2/include/EAGL/OgreEAGLES2Context.h
@@ -54,7 +54,6 @@ namespace Ogre {
 #endif
             virtual ~EAGLES2Context();
 
-            virtual void barrier();
             virtual void setCurrent();
             virtual void endCurrent();
             virtual GLContext * clone() const;

--- a/RenderSystems/GLES2/src/EAGL/OgreEAGLES2Context.mm
+++ b/RenderSystems/GLES2/src/EAGL/OgreEAGLES2Context.mm
@@ -226,11 +226,6 @@ namespace Ogre {
         }
     }
 
-    void EAGLES2Context::barrier()
-    {
-        glFlush();
-    }
-
     void EAGLES2Context::setCurrent()
     {
         BOOL ret = [EAGLContext setCurrentContext:mContext];

--- a/RenderSystems/GLES2/src/OgreGLES2RenderSystem.cpp
+++ b/RenderSystems/GLES2/src/OgreGLES2RenderSystem.cpp
@@ -1757,7 +1757,11 @@ namespace Ogre {
         // It's ready for switching
         if (mCurrentContext!=context)
         {
-            mCurrentContext->barrier(); // ensure that gl resources created in the current context would be visible after context switching
+#if OGRE_PLATFORM == OGRE_PLATFORM_APPLE_IOS
+            // EAGLContext::setCurrentContext does not flush automatically. everybody else does.
+            // see https://developer.apple.com/library/content/qa/qa1612/_index.html
+            glFlush();
+#endif
             mCurrentContext->endCurrent();
             mCurrentContext = context;
         }

--- a/RenderSystems/GLSupport/include/OSX/OgreOSXCocoaContext.h
+++ b/RenderSystems/GLSupport/include/OSX/OgreOSXCocoaContext.h
@@ -41,9 +41,6 @@ namespace Ogre {
         CocoaContext(NSOpenGLContext *context, NSOpenGLPixelFormat *pixelFormat);
 
         virtual ~CocoaContext();
-
-        /** See GLContext */
-        virtual void barrier();
         
         /** See GLContext */
         virtual void setCurrent();

--- a/RenderSystems/GLSupport/include/OgreGLContext.h
+++ b/RenderSystems/GLSupport/include/OgreGLContext.h
@@ -47,13 +47,6 @@ namespace Ogre {
         virtual ~GLContext() {}
 
         /**
-         * Sequence gl commands enqueued in current context to be completed before commands that would be enqueued by other contexts after this moment, does not wait for completion.
-         * This ensures for example that resources created in the current context would be available in other shared contexts.
-         * Implementation could flush commands from per-context CPU queue to single GPU queue, use glFenceSync/glWaitSync, eglWaitClient or any other mechanism to accomplish the goal.
-         */
-        virtual void barrier() {}
-
-        /**
          * Enable the context. All subsequent rendering commands will go here.
          */
         virtual void setCurrent() = 0;

--- a/RenderSystems/GLSupport/src/OSX/OgreOSXCocoaContext.mm
+++ b/RenderSystems/GLSupport/src/OSX/OgreOSXCocoaContext.mm
@@ -29,7 +29,6 @@ THE SOFTWARE.
 #import "OgreOSXCocoaContext.h"
 #include "OgreGLRenderSystemCommon.h"
 #include "OgreRoot.h"
-#include <OpenGL/glext.h>
 
 namespace Ogre
 {
@@ -48,11 +47,6 @@ namespace Ogre
 
         if(mNSGLPixelFormat)
             [mNSGLPixelFormat release];
-    }
-    
-    void CocoaContext::barrier()
-    {
-        glFlushRenderAPPLE();
     }
 
     void CocoaContext::setCurrent()


### PR DESCRIPTION
gl calls are supposed to be made by the RS and not by Support