### PR TITLE
[BUGFIX] Calculate ETC compressed image memory size

### DIFF
--- a/OgreMain/src/OgrePixelFormat.cpp
+++ b/OgreMain/src/OgrePixelFormat.cpp
@@ -133,11 +133,15 @@ namespace Ogre {
                 case PF_PVRTC2_4BPP:
                     return (std::max((int)width, 8) * std::max((int)height, 8) * 4 + 7) / 8;
 
+                // Size calculations from the ETC spec
+                // https://www.khronos.org/registry/OpenGL/extensions/OES/OES_compressed_ETC1_RGB8_texture.txt
+                // Basically, 8 bytes is the minimum texture size. Smaller textures are padded up to 8 bytes
                 case PF_ETC1_RGB8:
                 case PF_ETC2_RGB8:
                 case PF_ETC2_RGBA8:
                 case PF_ETC2_RGB8A1:
-                    return ((width * height) >> 1);
+                    return std::max<size_t>((width * height) >> 1, 8);
+
                 case PF_ATC_RGB:
                     return ((width + 3) / 4) * ((height + 3) / 4) * 8;
                 case PF_ATC_RGBA_EXPLICIT_ALPHA:


### PR DESCRIPTION
In case of PF_ETC1_RGB8, PF_ETC2_RGB8, PF_ETC2_RGBA8, PF_ETC2_RGB8A1
PixelUtil::getMemorySize() returns incorrect result.
Basically, we have mipmaps and in order to calculate whole texture size,
we need to calculate every mipmap size. Everything is ok, until we get
2x2 and 1x1. It is said in those ETC docs, that minimum block size is 8
bytes. When we calculate size for 2x2 and 1x1, we have to take that
minimum size, rather than calculated one.