### PR TITLE
GL*: use fixed attribute indices

### DIFF
--- a/RenderSystems/GL/include/OgreGLGpuProgram.h
+++ b/RenderSystems/GL/include/OgreGLGpuProgram.h
@@ -66,9 +66,6 @@ namespace Ogre {
         */
         virtual bool isAttributeValid(VertexElementSemantic semantic, uint index);
 
-        /** Get the fixed attribute bindings normally used by GL for a semantic. */
-        static GLuint getFixedAttributeIndex(VertexElementSemantic semantic, uint index);
-
     protected:
         /** Overridden from GpuProgram, do nothing */
         void loadFromSource(void) {}

--- a/RenderSystems/GL/include/OgreGLGpuProgram.h
+++ b/RenderSystems/GL/include/OgreGLGpuProgram.h
@@ -56,12 +56,6 @@ namespace Ogre {
         /// @copydoc Resource::calculateSize
         virtual size_t calculateSize(void) const;
 
-        /** Get the attribute index for a given semantic. 
-        @remarks
-            This can be used to identify the attribute index to bind non-builtin
-            attributes like tangent and binormal.
-        */
-        virtual GLuint getAttributeIndex(VertexElementSemantic semantic, uint index);
         /** Test whether attribute index for a given semantic is valid. 
         */
         virtual bool isAttributeValid(VertexElementSemantic semantic, uint index);

--- a/RenderSystems/GL/include/OgreGLRenderSystem.h
+++ b/RenderSystems/GL/include/OgreGLRenderSystem.h
@@ -165,7 +165,7 @@ namespace Ogre {
         void setClipPlanesImpl(const PlaneList& clipPlanes);
         void bindVertexElementToGpu(const VertexElement& elem,
                                     const HardwareVertexBufferSharedPtr& vertexBuffer,
-                                    const size_t vertexStart, GLSLProgramCommon* program);
+                                    const size_t vertexStart);
     public:
         // Default constructor / destructor
         GLRenderSystem();

--- a/RenderSystems/GL/src/GLSL/include/OgreGLSLGpuProgram.h
+++ b/RenderSystems/GL/src/GLSL/include/OgreGLSLGpuProgram.h
@@ -63,9 +63,6 @@ namespace Ogre {
         void bindProgramParameters(GpuProgramParametersSharedPtr params, uint16 mask);
         /// Execute the pass iteration param binding functions for this program
         void bindProgramPassIterationParameters(GpuProgramParametersSharedPtr params);
-
-        /// @copydoc GLGpuProgram::getAttributeIndex
-        GLuint getAttributeIndex(VertexElementSemantic semantic, uint index);
         
         /// @copydoc GLGpuProgram::isAttributeValid
         bool isAttributeValid(VertexElementSemantic semantic, uint index);

--- a/RenderSystems/GL/src/GLSL/include/OgreGLSLLinkProgram.h
+++ b/RenderSystems/GL/src/GLSL/include/OgreGLSLLinkProgram.h
@@ -41,14 +41,9 @@ namespace Ogre {
 
     */
 
-    class _OgreGLExport GLSLLinkProgram
+    class _OgreGLExport GLSLLinkProgram : public GLSLProgramCommon
     {
     private:
-        /// Container of uniform references that are active in the program object
-        GLUniformReferenceList mGLUniformReferences;
-
-        /// Linked vertex program
-        GLSLProgram* mVertexProgram;
         /// Linked geometry program
         GLSLProgram* mGeometryProgram;
         /// Linked fragment program
@@ -57,14 +52,6 @@ namespace Ogre {
 
         /// Flag to indicate that uniform references have already been built
         bool        mUniformRefsBuilt;
-        /// GL handle for the program object
-        GLhandleARB mGLHandle;
-        /// Flag indicating that the program object has been successfully linked
-        GLint       mLinked;
-        /// Flag indicating that the program object has tried to link and failed
-        bool        mTriedToLinkAndFailed;
-        /// Flag indicating skeletal animation is being performed
-        bool mSkeletalAnimation;
 
         /// Build uniform references from active named uniforms
         void buildGLUniformReferences(void);
@@ -74,17 +61,6 @@ namespace Ogre {
         typedef set<GLuint>::type AttributeSet;
         /// Custom attribute bindings
         AttributeSet mValidAttributes;
-
-        /// Name / attribute list
-        struct CustomAttribute
-        {
-            String name;
-            GLuint attrib;
-            CustomAttribute(const String& _name, GLuint _attrib)
-                :name(_name), attrib(_attrib) {}
-        };
-
-        static CustomAttribute msCustomAttributes[];
 
         String getCombinedName();       
         /// Compiles and links the the vertex and fragment programs
@@ -105,34 +81,18 @@ namespace Ogre {
         normally called by GLSLGpuProgram::bindParameters() just before rendering occurs.
         */
         void updateUniforms(GpuProgramParametersSharedPtr params, uint16 mask, GpuProgramType fromProgType);
+
+        void updateUniformBlocks(GpuProgramParametersSharedPtr params, uint16 mask, GpuProgramType fromProgType) {}
+
         /** Updates program object uniforms using data from pass iteration GpuProgramParameters.
         normally called by GLSLGpuProgram::bindMultiPassParameters() just before multi pass rendering occurs.
         */
         void updatePassIterationUniforms(GpuProgramParametersSharedPtr params);
         /// Get the GL Handle for the program object
-        GLhandleARB getGLHandle(void) const { return mGLHandle; }
-        /** Sets whether the linked program includes the required instructions
-        to perform skeletal animation. 
-        @remarks
-        If this is set to true, OGRE will not blend the geometry according to 
-        skeletal animation, it will expect the vertex program to do it.
-        */
-        void setSkeletalAnimationIncluded(bool included) 
-        { mSkeletalAnimation = included; }
-
-        /** Returns whether the linked program includes the required instructions
-            to perform skeletal animation. 
-        @remarks
-            If this returns true, OGRE will not blend the geometry according to 
-            skeletal animation, it will expect the vertex program to do it.
-        */
-        bool isSkeletalAnimationIncluded(void) const { return mSkeletalAnimation; }
+        GLhandleARB getGLHandle(void) const { return mGLProgramHandle; }
 
         /// Get the index of a non-standard attribute bound in the linked code
-        GLuint getAttributeIndex(VertexElementSemantic semantic, uint index);
-        /// Is a non-standard attribute bound in the linked code?
-        bool isAttributeValid(VertexElementSemantic semantic, uint index);
-
+        int getAttributeIndex(VertexElementSemantic semantic, uint index);
     };
 
     }

--- a/RenderSystems/GL/src/GLSL/include/OgreGLSLLinkProgram.h
+++ b/RenderSystems/GL/src/GLSL/include/OgreGLSLLinkProgram.h
@@ -90,9 +90,6 @@ namespace Ogre {
         void updatePassIterationUniforms(GpuProgramParametersSharedPtr params);
         /// Get the GL Handle for the program object
         GLhandleARB getGLHandle(void) const { return mGLProgramHandle; }
-
-        /// Get the index of a non-standard attribute bound in the linked code
-        int getAttributeIndex(VertexElementSemantic semantic, uint index);
     };
 
     }

--- a/RenderSystems/GL/src/GLSL/src/OgreGLSLGpuProgram.cpp
+++ b/RenderSystems/GL/src/GLSL/src/OgreGLSLGpuProgram.cpp
@@ -136,23 +136,6 @@ namespace Ogre {
         
     }
     //-----------------------------------------------------------------------------
-    GLuint GLSLGpuProgram::getAttributeIndex(VertexElementSemantic semantic, uint index)
-    {
-        // get link program - only call this in the context of bound program
-        GLSLLinkProgram* linkProgram = GLSLLinkProgramManager::getSingleton().getActiveLinkProgram();
-
-        if (linkProgram->isAttributeValid(semantic, index))
-        {
-            return linkProgram->getAttributeIndex(semantic, index);
-        }
-        else
-        {
-            // fall back to default implementation, allow default bindings
-            return GLGpuProgram::getAttributeIndex(semantic, index);
-        }
-        
-    }
-    //-----------------------------------------------------------------------------
     bool GLSLGpuProgram::isAttributeValid(VertexElementSemantic semantic, uint index)
     {
         // get link program - only call this in the context of bound program

--- a/RenderSystems/GL/src/GLSL/src/OgreGLSLLinkProgram.cpp
+++ b/RenderSystems/GL/src/GLSL/src/OgreGLSLLinkProgram.cpp
@@ -184,11 +184,6 @@ namespace Ogre {
         }
     }
     //-----------------------------------------------------------------------
-    int GLSLLinkProgram::getAttributeIndex(VertexElementSemantic semantic, uint index)
-    {
-        return GLSLProgramCommon::getFixedAttributeIndex(semantic, index);
-    }
-    //-----------------------------------------------------------------------
     void GLSLLinkProgram::buildGLUniformReferences(void)
     {
         if (!mUniformRefsBuilt)

--- a/RenderSystems/GL/src/OgreGLGpuProgram.cpp
+++ b/RenderSystems/GL/src/OgreGLGpuProgram.cpp
@@ -30,6 +30,7 @@ THE SOFTWARE.
 #include "OgreException.h"
 #include "OgreStringConverter.h"
 #include "OgreLogManager.h"
+#include "OgreGLSLProgramCommon.h"
 
 namespace Ogre {
 
@@ -67,56 +68,7 @@ GLGpuProgram::~GLGpuProgram()
 
 GLuint GLGpuProgram::getAttributeIndex(VertexElementSemantic semantic, uint index)
 {
-    return getFixedAttributeIndex(semantic, index);
-}
-
-GLuint GLGpuProgram::getFixedAttributeIndex(VertexElementSemantic semantic, uint index)
-{
-    // Some drivers (e.g. OS X on nvidia) incorrectly determine the attribute binding automatically
-    // and end up aliasing existing built-ins. So avoid! Fixed builtins are: 
-
-    //  a  builtin              custom attrib name
-    // ----------------------------------------------
-    //  0  gl_Vertex            vertex
-    //  1  n/a                  blendWeights        
-    //  2  gl_Normal            normal
-    //  3  gl_Color             colour
-    //  4  gl_SecondaryColor    secondary_colour
-    //  5  gl_FogCoord          fog_coord
-    //  7  n/a                  blendIndices
-    //  8  gl_MultiTexCoord0    uv0
-    //  9  gl_MultiTexCoord1    uv1
-    //  10 gl_MultiTexCoord2    uv2
-    //  11 gl_MultiTexCoord3    uv3
-    //  12 gl_MultiTexCoord4    uv4
-    //  13 gl_MultiTexCoord5    uv5
-    //  14 gl_MultiTexCoord6    uv6, tangent
-    //  15 gl_MultiTexCoord7    uv7, binormal
-    switch(semantic)
-    {
-    case VES_POSITION:
-        return 0;
-    case VES_BLEND_WEIGHTS:
-        return 1;
-    case VES_NORMAL:
-        return 2;
-    case VES_DIFFUSE:
-        return 3;
-    case VES_SPECULAR:
-        return 4;
-    case VES_BLEND_INDICES:
-        return 7;
-    case VES_TEXTURE_COORDINATES:
-        return 8 + index;
-    case VES_TANGENT:
-        return 14;
-    case VES_BINORMAL:
-        return 15;
-    default:
-        assert(false && "Missing attribute!");
-        return 0;
-    };
-
+    return GLSLProgramCommon::getFixedAttributeIndex(semantic, index);
 }
 
 bool GLGpuProgram::isAttributeValid(VertexElementSemantic semantic, uint index)

--- a/RenderSystems/GL/src/OgreGLGpuProgram.cpp
+++ b/RenderSystems/GL/src/OgreGLGpuProgram.cpp
@@ -66,11 +66,6 @@ GLGpuProgram::~GLGpuProgram()
     unload(); 
 }
 
-GLuint GLGpuProgram::getAttributeIndex(VertexElementSemantic semantic, uint index)
-{
-    return GLSLProgramCommon::getFixedAttributeIndex(semantic, index);
-}
-
 bool GLGpuProgram::isAttributeValid(VertexElementSemantic semantic, uint index)
 {
     // default implementation

--- a/RenderSystems/GL/src/OgreGLRenderSystem.cpp
+++ b/RenderSystems/GL/src/OgreGLRenderSystem.cpp
@@ -58,6 +58,8 @@ THE SOFTWARE.
 
 #include "OgreGLPixelFormat.h"
 
+#include "OgreGLSLProgramCommon.h"
+
 #if OGRE_PLATFORM == OGRE_PLATFORM_APPLE
 extern "C" void glFlushRenderAPPLE();
 #endif
@@ -2764,7 +2766,7 @@ namespace Ogre {
             HardwareVertexBufferSharedPtr vertexBuffer =
                 op.vertexData->vertexBufferBinding->getBuffer(source);
 
-            bindVertexElementToGpu(elem, vertexBuffer, op.vertexData->vertexStart, NULL);
+            bindVertexElementToGpu(elem, vertexBuffer, op.vertexData->vertexStart);
         }
 
         if( globalInstanceVertexBuffer && globalVertexDeclaration != NULL )
@@ -2773,7 +2775,7 @@ namespace Ogre {
             for (elemIter = globalVertexDeclaration->getElements().begin(); elemIter != elemEnd; ++elemIter)
             {
                 const VertexElement & elem = *elemIter;
-                bindVertexElementToGpu(elem, globalInstanceVertexBuffer, 0, NULL);
+                bindVertexElementToGpu(elem, globalInstanceVertexBuffer, 0);
 
             }
         }
@@ -3498,7 +3500,7 @@ namespace Ogre {
     //---------------------------------------------------------------------
     void GLRenderSystem::bindVertexElementToGpu(const VertexElement& elem,
                                                 const HardwareVertexBufferSharedPtr& vertexBuffer,
-                                                const size_t vertexStart, GLSLProgramCommon*)
+                                                const size_t vertexStart)
     {
         void* pBufferData = 0;
         const GLHardwareVertexBuffer* hwGlBuffer = static_cast<const GLHardwareVertexBuffer*>(vertexBuffer.get());
@@ -3530,7 +3532,7 @@ namespace Ogre {
 
             if (hwGlBuffer->getIsInstanceData())
             {
-                GLint attrib = mCurrentVertexProgram->getAttributeIndex(sem, elem.getIndex());
+                GLint attrib = GLSLProgramCommon::getFixedAttributeIndex(sem, elem.getIndex());
                 glVertexAttribDivisorARB(attrib, hwGlBuffer->getInstanceDataStepRate() );
                 mRenderInstanceAttribsBound.push_back(attrib);
             }
@@ -3542,7 +3544,7 @@ namespace Ogre {
         // builtins may be done this way too
         if (isCustomAttrib)
         {
-            GLint attrib = mCurrentVertexProgram->getAttributeIndex(sem, elem.getIndex());
+            GLint attrib = GLSLProgramCommon::getFixedAttributeIndex(sem, elem.getIndex());
             unsigned short typeCount = VertexElement::getTypeCount(elem.getType());
             GLboolean normalised = GL_FALSE;
             switch(elem.getType())

--- a/RenderSystems/GL3Plus/include/GLSL/OgreGLSLProgram.h
+++ b/RenderSystems/GL3Plus/include/GLSL/OgreGLSLProgram.h
@@ -75,9 +75,6 @@ namespace Ogre {
                     GLSLShader* computeProgram);
         virtual ~GLSLProgram(void);
 
-        /// Get the index of a non-standard attribute bound in the linked code
-        virtual GLint getAttributeIndex(VertexElementSemantic semantic, uint index);
-
         void bindFixedAttributes(GLuint program);
 
         GLSLShader* getVertexShader() const { return static_cast<GLSLShader*>(mVertexShader); }

--- a/RenderSystems/GL3Plus/include/GLSL/OgreGLSLProgram.h
+++ b/RenderSystems/GL3Plus/include/GLSL/OgreGLSLProgram.h
@@ -78,6 +78,8 @@ namespace Ogre {
         /// Get the index of a non-standard attribute bound in the linked code
         virtual GLint getAttributeIndex(VertexElementSemantic semantic, uint index);
 
+        void bindFixedAttributes(GLuint program);
+
         GLSLShader* getVertexShader() const { return static_cast<GLSLShader*>(mVertexShader); }
         GLSLShader* getHullShader() const { return mHullShader; }
         GLSLShader* getDomainShader() const { return mDomainShader; }

--- a/RenderSystems/GL3Plus/include/GLSL/OgreGLSLSeparableProgram.h
+++ b/RenderSystems/GL3Plus/include/GLSL/OgreGLSLSeparableProgram.h
@@ -118,11 +118,6 @@ namespace Ogre
         */
         void activate(void);
 
-        /** Get the index of a non-standard attribute bound in the
-            linked code.
-        */
-        GLint getAttributeIndex(VertexElementSemantic semantic, uint index);
-
     protected:
         /// GL handle for pipeline object.
         GLuint mGLProgramPipelineHandle;

--- a/RenderSystems/GL3Plus/include/OgreGL3PlusRenderSystem.h
+++ b/RenderSystems/GL3Plus/include/OgreGL3PlusRenderSystem.h
@@ -137,7 +137,7 @@ namespace Ogre {
 
         void bindVertexElementToGpu(const VertexElement& elem,
                                     const HardwareVertexBufferSharedPtr& vertexBuffer,
-                                    const size_t vertexStart, GLSLProgramCommon* program);
+                                    const size_t vertexStart);
 
     public:
         // Default constructor / destructor

--- a/RenderSystems/GL3Plus/src/GLSL/OgreGLSLMonolithicProgram.cpp
+++ b/RenderSystems/GL3Plus/src/GLSL/OgreGLSLMonolithicProgram.cpp
@@ -162,6 +162,8 @@ namespace Ogre {
             mComputeShader->attachToProgramObject(mGLProgramHandle);
         }
 
+        bindFixedAttributes(mGLProgramHandle);
+
         // the link
         OGRE_CHECK_GL_ERROR(glLinkProgram( mGLProgramHandle ));
         OGRE_CHECK_GL_ERROR(glGetProgramiv( mGLProgramHandle, GL_LINK_STATUS, &mLinked ));

--- a/RenderSystems/GL3Plus/src/GLSL/OgreGLSLProgram.cpp
+++ b/RenderSystems/GL3Plus/src/GLSL/OgreGLSLProgram.cpp
@@ -128,6 +128,23 @@ namespace Ogre {
         return res;
     }
 
+    void GLSLProgram::bindFixedAttributes(GLuint program)
+    {
+        GLint max_vertex_attribs = 16;
+        glGetIntegerv( GL_MAX_VERTEX_ATTRIBS , &max_vertex_attribs);
+
+        size_t numAttribs = sizeof(msCustomAttributes) / sizeof(CustomAttribute);
+        for (size_t i = 0; i < numAttribs; ++i)
+        {
+            const CustomAttribute& a = msCustomAttributes[i];
+            if (a.attrib < max_vertex_attribs)
+            {
+
+                OGRE_CHECK_GL_ERROR(glBindAttribLocation(program, a.attrib, a.name));
+            }
+        }
+    }
+
     void GLSLProgram::getMicrocodeFromCache(void)
     {
         GpuProgramManager::Microcode cacheMicrocode =

--- a/RenderSystems/GL3Plus/src/GLSL/OgreGLSLProgram.cpp
+++ b/RenderSystems/GL3Plus/src/GLSL/OgreGLSLProgram.cpp
@@ -99,35 +99,6 @@ namespace Ogre {
         return name;
     }
 
-    GLint GLSLProgram::getAttributeIndex(VertexElementSemantic semantic, uint index)
-    {
-        GLint res = mCustomAttributesIndexes[semantic-1][index];
-        if (res == NULL_CUSTOM_ATTRIBUTES_INDEX)
-        {
-            const char * attString = getAttributeSemanticString(semantic);
-            GLint attrib;
-            OGRE_CHECK_GL_ERROR(attrib = glGetAttribLocation(mGLProgramHandle, attString));
-
-            // Sadly position is a special case.
-            if (attrib == NOT_FOUND_CUSTOM_ATTRIBUTES_INDEX && semantic == VES_POSITION)
-            {
-                OGRE_CHECK_GL_ERROR(attrib = glGetAttribLocation(mGLProgramHandle, "position"));
-            }
-
-            // For uv and other case the index is a part of the name.
-            if (attrib == NOT_FOUND_CUSTOM_ATTRIBUTES_INDEX)
-            {
-                String attStringWithSemantic = String(attString) + StringConverter::toString(index);
-                OGRE_CHECK_GL_ERROR(attrib = glGetAttribLocation(mGLProgramHandle, attStringWithSemantic.c_str()));
-            }
-
-            // Update mCustomAttributesIndexes with the index we found (or didn't find).
-            mCustomAttributesIndexes[semantic-1][index] = attrib;
-            res = attrib;
-        }
-        return res;
-    }
-
     void GLSLProgram::bindFixedAttributes(GLuint program)
     {
         GLint max_vertex_attribs = 16;

--- a/RenderSystems/GL3Plus/src/GLSL/OgreGLSLSeparableProgram.cpp
+++ b/RenderSystems/GL3Plus/src/GLSL/OgreGLSLSeparableProgram.cpp
@@ -185,6 +185,9 @@ namespace Ogre
                         return;
                     }
 
+                    if( program->getType() == GPT_VERTEX_PROGRAM )
+                        bindFixedAttributes( programHandle );
+
                     program->attachToProgramObject(programHandle);
                     OGRE_CHECK_GL_ERROR(glLinkProgram(programHandle));
                     OGRE_CHECK_GL_ERROR(glGetProgramiv(programHandle, GL_LINK_STATUS, &linkStatus));

--- a/RenderSystems/GL3Plus/src/GLSL/OgreGLSLSeparableProgram.cpp
+++ b/RenderSystems/GL3Plus/src/GLSL/OgreGLSLSeparableProgram.cpp
@@ -251,39 +251,6 @@ namespace Ogre
     //     }
     // }
 
-
-    GLint GLSLSeparableProgram::getAttributeIndex(VertexElementSemantic semantic, uint index)
-    {
-        GLint res = mCustomAttributesIndexes[semantic-1][index];
-        if (res == NULL_CUSTOM_ATTRIBUTES_INDEX)
-        {
-            GLuint handle = getVertexShader()->getGLProgramHandle();
-            const char * attString = getAttributeSemanticString(semantic);
-            GLint attrib;
-            OGRE_CHECK_GL_ERROR(attrib = glGetAttribLocation(handle, attString));
-
-            // Sadly position is a special case.
-            if (attrib == NOT_FOUND_CUSTOM_ATTRIBUTES_INDEX && semantic == VES_POSITION)
-            {
-                OGRE_CHECK_GL_ERROR(attrib = glGetAttribLocation(handle, "position"));
-            }
-
-            // For UV and other cases the index is a part of the name.
-            if (attrib == NOT_FOUND_CUSTOM_ATTRIBUTES_INDEX)
-            {
-                String attStringWithSemantic = String(attString) + StringConverter::toString(index);
-                OGRE_CHECK_GL_ERROR(attrib = glGetAttribLocation(handle, attStringWithSemantic.c_str()));
-            }
-
-            // Update mCustomAttributesIndexes with the index we found (or didn't find)
-            mCustomAttributesIndexes[semantic - 1][index] = attrib;
-            res = attrib;
-        }
-
-        return res;
-    }
-
-
     void GLSLSeparableProgram::activate(void)
     {
         if (!mLinked && !mTriedToLinkAndFailed)

--- a/RenderSystems/GLES2/include/OgreGLES2RenderSystem.h
+++ b/RenderSystems/GLES2/include/OgreGLES2RenderSystem.h
@@ -113,7 +113,7 @@ namespace Ogre {
             GLenum getBlendMode(SceneBlendFactor ogreBlend) const;
             void bindVertexElementToGpu(const VertexElement& elem,
                                         const HardwareVertexBufferSharedPtr& vertexBuffer,
-                                        const size_t vertexStart, GLSLProgramCommon* program);
+                                        const size_t vertexStart);
 
             // Mipmap count of the actual bounded texture
             size_t mCurTexMipCount;

--- a/RenderSystems/GLES2/src/GLSLES/include/OgreGLSLESProgramCommon.h
+++ b/RenderSystems/GLES2/src/GLSLES/include/OgreGLSLESProgramCommon.h
@@ -68,6 +68,8 @@ namespace Ogre {
         /// Get the index of a non-standard attribute bound in the linked code
         virtual GLint getAttributeIndex(VertexElementSemantic semantic, uint index);
 
+        void bindFixedAttributes(GLuint program);
+
         GLSLESProgram* getVertexProgram(void) const { return static_cast<GLSLESProgram*>(mVertexShader); }
         GLSLESProgram* getFragmentProgram(void) const { return mFragmentProgram; }
     };

--- a/RenderSystems/GLES2/src/GLSLES/include/OgreGLSLESProgramCommon.h
+++ b/RenderSystems/GLES2/src/GLSLES/include/OgreGLSLESProgramCommon.h
@@ -65,9 +65,6 @@ namespace Ogre {
         GLSLESProgramCommon(GLSLESProgram* vertexProgram, GLSLESProgram* fragmentProgram);
         virtual ~GLSLESProgramCommon(void);
 
-        /// Get the index of a non-standard attribute bound in the linked code
-        virtual GLint getAttributeIndex(VertexElementSemantic semantic, uint index);
-
         void bindFixedAttributes(GLuint program);
 
         GLSLESProgram* getVertexProgram(void) const { return static_cast<GLSLESProgram*>(mVertexShader); }

--- a/RenderSystems/GLES2/src/GLSLES/include/OgreGLSLESProgramPipeline.h
+++ b/RenderSystems/GLES2/src/GLSLES/include/OgreGLSLESProgramPipeline.h
@@ -80,9 +80,6 @@ namespace Ogre
          */
         void activate(void);
 
-        /// Get the index of a non-standard attribute bound in the linked code
-        virtual GLint getAttributeIndex(VertexElementSemantic semantic, uint index);
-
 #if OGRE_PLATFORM == OGRE_PLATFORM_ANDROID || OGRE_PLATFORM == OGRE_PLATFORM_EMSCRIPTEN
         virtual void notifyOnContextLost();
 #endif

--- a/RenderSystems/GLES2/src/GLSLES/src/OgreGLSLESLinkProgram.cpp
+++ b/RenderSystems/GLES2/src/GLSLES/src/OgreGLSLESLinkProgram.cpp
@@ -155,6 +155,8 @@ namespace Ogre {
 
         mFragmentProgram->attachToProgramObject(mGLProgramHandle);
         
+        bindFixedAttributes( mGLProgramHandle );
+
         // The link
         OGRE_CHECK_GL_ERROR(glLinkProgram( mGLProgramHandle ));
         OGRE_CHECK_GL_ERROR(glGetProgramiv( mGLProgramHandle, GL_LINK_STATUS, &mLinked ));

--- a/RenderSystems/GLES2/src/GLSLES/src/OgreGLSLESProgramCommon.cpp
+++ b/RenderSystems/GLES2/src/GLSLES/src/OgreGLSLESProgramCommon.cpp
@@ -97,6 +97,24 @@ namespace Ogre {
         }
         return res;
     }
+
+    void GLSLESProgramCommon::bindFixedAttributes(GLuint program)
+    {
+        GLint max_vertex_attribs = 16;
+        glGetIntegerv( GL_MAX_VERTEX_ATTRIBS , &max_vertex_attribs);
+
+        size_t numAttribs = sizeof(msCustomAttributes) / sizeof(CustomAttribute);
+        for (size_t i = 0; i < numAttribs; ++i)
+        {
+            const CustomAttribute& a = msCustomAttributes[i];
+            if (a.attrib < max_vertex_attribs)
+            {
+
+                OGRE_CHECK_GL_ERROR(glBindAttribLocation(program, a.attrib, a.name));
+            }
+        }
+    }
+
     //-----------------------------------------------------------------------
     bool GLSLESProgramCommon::getMicrocodeFromCache(const String& name, GLuint programHandle)
     {

--- a/RenderSystems/GLES2/src/GLSLES/src/OgreGLSLESProgramCommon.cpp
+++ b/RenderSystems/GLES2/src/GLSLES/src/OgreGLSLESProgramCommon.cpp
@@ -67,36 +67,6 @@ namespace Ogre {
 
         return name;
     }
-    
-    //-----------------------------------------------------------------------
-    GLint GLSLESProgramCommon::getAttributeIndex(VertexElementSemantic semantic, uint index)
-    {
-        GLint res = mCustomAttributesIndexes[semantic-1][index];
-        if (res == NULL_CUSTOM_ATTRIBUTES_INDEX)
-        {
-            const char * attString = getAttributeSemanticString(semantic);
-            GLint attrib;
-            OGRE_CHECK_GL_ERROR(attrib = glGetAttribLocation(mGLProgramHandle, attString));
-
-            // sadly position is a special case 
-            if (attrib == NOT_FOUND_CUSTOM_ATTRIBUTES_INDEX && semantic == VES_POSITION)
-            {
-                OGRE_CHECK_GL_ERROR(attrib = glGetAttribLocation(mGLProgramHandle, "position"));
-            }
-
-            // for uv and other case the index is a part of the name
-            if (attrib == NOT_FOUND_CUSTOM_ATTRIBUTES_INDEX)
-            {
-                String attStringWithSemantic = String(attString) + StringConverter::toString(index);
-                OGRE_CHECK_GL_ERROR(attrib = glGetAttribLocation(mGLProgramHandle, attStringWithSemantic.c_str()));
-            }
-
-            // update mCustomAttributesIndexes with the index we found (or didn't find) 
-            mCustomAttributesIndexes[semantic-1][index] = attrib;
-            res = attrib;
-        }
-        return res;
-    }
 
     void GLSLESProgramCommon::bindFixedAttributes(GLuint program)
     {

--- a/RenderSystems/GLES2/src/GLSLES/src/OgreGLSLESProgramPipeline.cpp
+++ b/RenderSystems/GLES2/src/GLSLES/src/OgreGLSLESProgramPipeline.cpp
@@ -194,38 +194,6 @@ namespace Ogre
 #endif
 
     //-----------------------------------------------------------------------
-    GLint GLSLESProgramPipeline::getAttributeIndex(VertexElementSemantic semantic, uint index)
-    {
-        GLint res = mCustomAttributesIndexes[semantic-1][index];
-        if (res == NULL_CUSTOM_ATTRIBUTES_INDEX)
-        {
-            GLuint handle = getVertexProgram()->getGLProgramHandle();
-            const char * attString = getAttributeSemanticString(semantic);
-            GLint attrib;
-            OGRE_CHECK_GL_ERROR(attrib = glGetAttribLocation(handle, attString));
-
-            // Sadly position is a special case 
-            if (attrib == NOT_FOUND_CUSTOM_ATTRIBUTES_INDEX && semantic == VES_POSITION)
-            {
-                OGRE_CHECK_GL_ERROR(attrib = glGetAttribLocation(handle, "position"));
-            }
-            
-            // For uv and other case the index is a part of the name
-            if (attrib == NOT_FOUND_CUSTOM_ATTRIBUTES_INDEX)
-            {
-                String attStringWithSemantic = String(attString) + StringConverter::toString(index);
-                OGRE_CHECK_GL_ERROR(attrib = glGetAttribLocation(handle, attStringWithSemantic.c_str()));
-            }
-            
-            // Update mCustomAttributesIndexes with the index we found (or didn't find) 
-            mCustomAttributesIndexes[semantic-1][index] = attrib;
-            res = attrib;
-        }
-        
-        return res;
-    }
-
-    //-----------------------------------------------------------------------
     void GLSLESProgramPipeline::activate(void)
     {
         if (!mLinked && !mTriedToLinkAndFailed)

--- a/RenderSystems/GLES2/src/GLSLES/src/OgreGLSLESProgramPipeline.cpp
+++ b/RenderSystems/GLES2/src/GLSLES/src/OgreGLSLESProgramPipeline.cpp
@@ -84,8 +84,10 @@ namespace Ogre
                     mTriedToLinkAndFailed = true;
                     return;
                 }
-
                 GLuint programHandle = getVertexProgram()->getGLProgramHandle();
+
+                bindFixedAttributes( programHandle );
+
                 OGRE_CHECK_GL_ERROR(glProgramParameteriEXT(programHandle, GL_PROGRAM_SEPARABLE_EXT, GL_TRUE));
                 getVertexProgram()->attachToProgramObject(programHandle);
                 OGRE_CHECK_GL_ERROR(glLinkProgram(programHandle));

--- a/RenderSystems/GLES2/src/OgreGLES2HardwarePixelBuffer.cpp
+++ b/RenderSystems/GLES2/src/OgreGLES2HardwarePixelBuffer.cpp
@@ -687,20 +687,8 @@ namespace Ogre {
                 u1, v2, w
             };
 
-            GLuint posAttrIndex = 0;
-            GLuint texAttrIndex = 0;
-            if(Root::getSingleton().getRenderSystem()->getCapabilities()->hasCapability(RSC_SEPARATE_SHADER_OBJECTS))
-            {
-                GLSLESProgramPipeline* programPipeline = GLSLESProgramPipelineManager::getSingleton().getActiveProgramPipeline();
-                posAttrIndex = (GLuint)programPipeline->getAttributeIndex(VES_POSITION, 0);
-                texAttrIndex = (GLuint)programPipeline->getAttributeIndex(VES_TEXTURE_COORDINATES, 0);
-            }
-            else
-            {
-                GLSLESLinkProgram* linkProgram = GLSLESLinkProgramManager::getSingleton().getActiveLinkProgram();
-                posAttrIndex = (GLuint)linkProgram->getAttributeIndex(VES_POSITION, 0);
-                texAttrIndex = (GLuint)linkProgram->getAttributeIndex(VES_TEXTURE_COORDINATES, 0);
-            }
+            GLuint posAttrIndex = GLSLProgramCommon::getFixedAttributeIndex(VES_POSITION, 0);
+            GLuint texAttrIndex = GLSLProgramCommon::getFixedAttributeIndex(VES_TEXTURE_COORDINATES, 0);
 
             // Draw the textured quad
             OGRE_CHECK_GL_ERROR(glVertexAttribPointer(posAttrIndex,

--- a/RenderSystems/GLSupport/include/GLSL/OgreGLSLProgramCommon.h
+++ b/RenderSystems/GLSupport/include/GLSL/OgreGLSLProgramCommon.h
@@ -106,6 +106,9 @@ public:
         Normally called by GLSLShader::bindMultiPassParameters() just before multi pass rendering occurs.
     */
     virtual void updatePassIterationUniforms(GpuProgramParametersSharedPtr params) = 0;
+
+    /** Get the fixed attribute bindings normally used by GL for a semantic. */
+    static uint32 getFixedAttributeIndex(VertexElementSemantic semantic, uint index);
 protected:
     /// Container of uniform references that are active in the program object
     GLUniformReferenceList mGLUniformReferences;
@@ -136,11 +139,17 @@ protected:
     /// Compiles and links the vertex and fragment programs
     virtual void compileAndLink(void) = 0;
 
-    typedef map<String, VertexElementSemantic>::type SemanticToStringMap;
-    SemanticToStringMap mSemanticTypeMap;
+    static VertexElementSemantic getAttributeSemanticEnum(String type);
+    static const char * getAttributeSemanticString(VertexElementSemantic semantic);
 
-    VertexElementSemantic getAttributeSemanticEnum(String type);
-    const char * getAttributeSemanticString(VertexElementSemantic semantic);
+    /// Name / attribute list
+    struct CustomAttribute
+    {
+        const char* name;
+        uint32 attrib;
+        VertexElementSemantic semantic;
+    };
+    static CustomAttribute msCustomAttributes[16];
 };
 
 } /* namespace Ogre */

--- a/RenderSystems/GLSupport/include/GLSL/OgreGLSLProgramCommon.h
+++ b/RenderSystems/GLSupport/include/GLSL/OgreGLSLProgramCommon.h
@@ -78,15 +78,12 @@ public:
     bool isSkeletalAnimationIncluded(void) const { return mSkeletalAnimation; }
 
     /// has the attribute been found in the linked code?
-    bool isAttributeValid(VertexElementSemantic semantic, uint index) {
-        return getAttributeIndex(semantic, index) != NOT_FOUND_CUSTOM_ATTRIBUTES_INDEX;
+    static bool isAttributeValid(VertexElementSemantic semantic, uint index) {
+        return getFixedAttributeIndex(semantic, index) != NOT_FOUND_CUSTOM_ATTRIBUTES_INDEX;
     }
 
     /// Get the GL Handle for the program object
     uint getGLProgramHandle(void) const { return mGLProgramHandle; }
-
-    /// Get the index of a non-standard attribute bound in the linked code
-    virtual int getAttributeIndex(VertexElementSemantic semantic, uint index) = 0;
 
     /** Makes a program object active by making sure it is linked and then putting it in use.
      */
@@ -108,7 +105,7 @@ public:
     virtual void updatePassIterationUniforms(GpuProgramParametersSharedPtr params) = 0;
 
     /** Get the fixed attribute bindings normally used by GL for a semantic. */
-    static uint32 getFixedAttributeIndex(VertexElementSemantic semantic, uint index);
+    static int32 getFixedAttributeIndex(VertexElementSemantic semantic, uint index);
 protected:
     /// Container of uniform references that are active in the program object
     GLUniformReferenceList mGLUniformReferences;
@@ -146,7 +143,7 @@ protected:
     struct CustomAttribute
     {
         const char* name;
-        uint32 attrib;
+        int32 attrib;
         VertexElementSemantic semantic;
     };
     static CustomAttribute msCustomAttributes[16];

--- a/RenderSystems/GLSupport/include/OgreGLRenderSystemCommon.h
+++ b/RenderSystems/GLSupport/include/OgreGLRenderSystemCommon.h
@@ -68,7 +68,7 @@ namespace Ogre {
 
         virtual void bindVertexElementToGpu(const VertexElement& elem,
                                             const HardwareVertexBufferSharedPtr& vertexBuffer,
-                                            const size_t vertexStart, GLSLProgramCommon* program) = 0;
+                                            const size_t vertexStart) = 0;
 
         Real getHorizontalTexelOffset(void) { return 0.0; }               // No offset in GL
         Real getVerticalTexelOffset(void) { return 0.0; }                 // No offset in GL

--- a/RenderSystems/GLSupport/include/OgreGLVertexArrayObject.h
+++ b/RenderSystems/GLSupport/include/OgreGLVertexArrayObject.h
@@ -66,8 +66,8 @@ namespace Ogre {
         void notifyChanged() { mNeedsUpdate = true; }
         void notifyContextDestroyed(GLContext* context) { if(mCreatorContext == context) { mCreatorContext = 0; mVAO = 0; } }
         void bind(GLRenderSystemCommon* rs);
-        bool needsUpdate(GLSLProgramCommon* program, VertexBufferBinding* vertexBufferBinding, size_t vertexStart);
-        void bindToShader(GLRenderSystemCommon* rs, GLSLProgramCommon* program, VertexBufferBinding* vertexBufferBinding, size_t vertexStart);
+        bool needsUpdate(VertexBufferBinding* vertexBufferBinding, size_t vertexStart);
+        void bindToGpu(GLRenderSystemCommon* rs, VertexBufferBinding* vertexBufferBinding, size_t vertexStart);
     };
 
 }

--- a/RenderSystems/GLSupport/src/GLSL/OgreGLSLProgramCommon.cpp
+++ b/RenderSystems/GLSupport/src/GLSL/OgreGLSLProgramCommon.cpp
@@ -12,16 +12,14 @@ namespace Ogre
 {
 VertexElementSemantic GLSLProgramCommon::getAttributeSemanticEnum(String type)
 {
-    VertexElementSemantic semantic = mSemanticTypeMap[type];
-    if (semantic > 0)
+    size_t numAttribs = sizeof(msCustomAttributes)/sizeof(CustomAttribute);
+    for (size_t i = 0; i < numAttribs; ++i)
     {
-        return semantic;
+        if (msCustomAttributes[i].name == type)
+            return msCustomAttributes[i].semantic;
     }
-    else
-    {
-        OgreAssertDbg(false, "Missing attribute!");
-        return (VertexElementSemantic)0;
-    }
+
+    OgreAssertDbg(false, "Missing attribute!");
 }
 
 GLSLProgramCommon::GLSLProgramCommon(GLSLShaderCommon* vertexShader)
@@ -40,26 +38,18 @@ GLSLProgramCommon::GLSLProgramCommon(GLSLShaderCommon* vertexShader)
             mCustomAttributesIndexes[i][j] = NULL_CUSTOM_ATTRIBUTES_INDEX;
         }
     }
-
-    // Initialize the attribute to semantic map
-    mSemanticTypeMap.insert(SemanticToStringMap::value_type("vertex", VES_POSITION));
-    mSemanticTypeMap.insert(SemanticToStringMap::value_type("blendWeights", VES_BLEND_WEIGHTS));
-    mSemanticTypeMap.insert(SemanticToStringMap::value_type("normal", VES_NORMAL));
-    mSemanticTypeMap.insert(SemanticToStringMap::value_type("colour", VES_DIFFUSE));
-    mSemanticTypeMap.insert(SemanticToStringMap::value_type("secondary_colour", VES_SPECULAR));
-    mSemanticTypeMap.insert(SemanticToStringMap::value_type("blendIndices", VES_BLEND_INDICES));
-    mSemanticTypeMap.insert(SemanticToStringMap::value_type("tangent", VES_TANGENT));
-    mSemanticTypeMap.insert(SemanticToStringMap::value_type("binormal", VES_BINORMAL));
-    mSemanticTypeMap.insert(SemanticToStringMap::value_type("uv", VES_TEXTURE_COORDINATES));
 }
 
 const char* GLSLProgramCommon::getAttributeSemanticString(VertexElementSemantic semantic)
 {
-    for (SemanticToStringMap::iterator i = mSemanticTypeMap.begin(); i != mSemanticTypeMap.end();
-         ++i)
+    if(semantic == VES_TEXTURE_COORDINATES)
+        return "uv";
+
+    size_t numAttribs = sizeof(msCustomAttributes)/sizeof(CustomAttribute);
+    for (size_t i = 0; i < numAttribs; ++i)
     {
-        if ((*i).second == semantic)
-            return (*i).first.c_str();
+        if (msCustomAttributes[i].semantic == semantic)
+            return msCustomAttributes[i].name;
     }
 
     OgreAssertDbg(false, "Missing attribute!");
@@ -130,7 +120,7 @@ void GLSLProgramCommon::extractLayoutQualifiers(void)
         if (attrName == "position")
             semantic = getAttributeSemanticEnum("vertex");
         else if(uvPos == 0)
-            semantic = getAttributeSemanticEnum("uv"); // treat "uvXY" as "uv"
+            semantic = getAttributeSemanticEnum("uv0"); // treat "uvXY" as "uv0"
         else
             semantic = getAttributeSemanticEnum(attrName);
 
@@ -145,5 +135,72 @@ void GLSLProgramCommon::extractLayoutQualifiers(void)
 
         currPos = shaderSource.find("layout", currPos);
     }
+}
+
+// Some drivers (e.g. OS X on nvidia) incorrectly determine the attribute binding automatically
+// and end up aliasing existing built-ins. So avoid! Fixed builtins are:
+
+//  a  builtin              custom attrib name
+// ----------------------------------------------
+//  0  gl_Vertex            vertex
+//  1  n/a                  blendWeights
+//  2  gl_Normal            normal
+//  3  gl_Color             colour
+//  4  gl_SecondaryColor    secondary_colour
+//  5  gl_FogCoord          fog_coord
+//  7  n/a                  blendIndices
+//  8  gl_MultiTexCoord0    uv0
+//  9  gl_MultiTexCoord1    uv1
+//  10 gl_MultiTexCoord2    uv2
+//  11 gl_MultiTexCoord3    uv3
+//  12 gl_MultiTexCoord4    uv4
+//  13 gl_MultiTexCoord5    uv5
+//  14 gl_MultiTexCoord6    uv6, tangent
+//  15 gl_MultiTexCoord7    uv7, binormal
+GLSLProgramCommon::CustomAttribute GLSLProgramCommon::msCustomAttributes[16] = {
+    {"vertex", getFixedAttributeIndex(VES_POSITION, 0), VES_POSITION},
+    {"blendWeights", getFixedAttributeIndex(VES_BLEND_WEIGHTS, 0), VES_BLEND_WEIGHTS},
+    {"normal", getFixedAttributeIndex(VES_NORMAL, 0), VES_NORMAL},
+    {"colour", getFixedAttributeIndex(VES_DIFFUSE, 0), VES_DIFFUSE},
+    {"secondary_colour", getFixedAttributeIndex(VES_SPECULAR, 0), VES_SPECULAR},
+    {"blendIndices", getFixedAttributeIndex(VES_BLEND_INDICES, 0), VES_BLEND_INDICES},
+    {"uv0", getFixedAttributeIndex(VES_TEXTURE_COORDINATES, 0), VES_TEXTURE_COORDINATES},
+    {"uv1", getFixedAttributeIndex(VES_TEXTURE_COORDINATES, 1), VES_TEXTURE_COORDINATES},
+    {"uv2", getFixedAttributeIndex(VES_TEXTURE_COORDINATES, 2), VES_TEXTURE_COORDINATES},
+    {"uv3", getFixedAttributeIndex(VES_TEXTURE_COORDINATES, 3), VES_TEXTURE_COORDINATES},
+    {"uv4", getFixedAttributeIndex(VES_TEXTURE_COORDINATES, 4), VES_TEXTURE_COORDINATES},
+    {"uv5", getFixedAttributeIndex(VES_TEXTURE_COORDINATES, 5), VES_TEXTURE_COORDINATES},
+    {"uv6", getFixedAttributeIndex(VES_TEXTURE_COORDINATES, 6), VES_TEXTURE_COORDINATES},
+    {"uv7", getFixedAttributeIndex(VES_TEXTURE_COORDINATES, 7), VES_TEXTURE_COORDINATES},
+    {"tangent", getFixedAttributeIndex(VES_TANGENT, 0), VES_TANGENT},
+    {"binormal", getFixedAttributeIndex(VES_BINORMAL, 0), VES_BINORMAL},
+};
+
+uint32 GLSLProgramCommon::getFixedAttributeIndex(VertexElementSemantic semantic, uint index)
+{
+    switch(semantic)
+    {
+    case VES_POSITION:
+        return 0;
+    case VES_BLEND_WEIGHTS:
+        return 1;
+    case VES_NORMAL:
+        return 2;
+    case VES_DIFFUSE:
+        return 3;
+    case VES_SPECULAR:
+        return 4;
+    case VES_BLEND_INDICES:
+        return 7;
+    case VES_TEXTURE_COORDINATES:
+        return 8 + index;
+    case VES_TANGENT:
+        return 14;
+    case VES_BINORMAL:
+        return 15;
+    default:
+        OgreAssertDbg(false, "Missing attribute!");
+        return 0;
+    };
 }
 } /* namespace Ogre */

--- a/RenderSystems/GLSupport/src/GLSL/OgreGLSLProgramCommon.cpp
+++ b/RenderSystems/GLSupport/src/GLSL/OgreGLSLProgramCommon.cpp
@@ -20,6 +20,7 @@ VertexElementSemantic GLSLProgramCommon::getAttributeSemanticEnum(String type)
     }
 
     OgreAssertDbg(false, "Missing attribute!");
+    return VertexElementSemantic(0);
 }
 
 GLSLProgramCommon::GLSLProgramCommon(GLSLShaderCommon* vertexShader)
@@ -176,7 +177,7 @@ GLSLProgramCommon::CustomAttribute GLSLProgramCommon::msCustomAttributes[16] = {
     {"binormal", getFixedAttributeIndex(VES_BINORMAL, 0), VES_BINORMAL},
 };
 
-uint32 GLSLProgramCommon::getFixedAttributeIndex(VertexElementSemantic semantic, uint index)
+int32 GLSLProgramCommon::getFixedAttributeIndex(VertexElementSemantic semantic, uint index)
 {
     switch(semantic)
     {
@@ -200,7 +201,7 @@ uint32 GLSLProgramCommon::getFixedAttributeIndex(VertexElementSemantic semantic,
         return 15;
     default:
         OgreAssertDbg(false, "Missing attribute!");
-        return 0;
+        return NOT_FOUND_CUSTOM_ATTRIBUTES_INDEX;
     };
 }
 } /* namespace Ogre */

--- a/RenderSystems/GLSupport/src/OgreGLVertexArrayObject.cpp
+++ b/RenderSystems/GLSupport/src/OgreGLVertexArrayObject.cpp
@@ -54,8 +54,7 @@ namespace Ogre {
         rs->_bindVao(mCreatorContext, mVAO);
     }
 
-    bool GLVertexArrayObject::needsUpdate(GLSLProgramCommon* program,
-                                          VertexBufferBinding* vertexBufferBinding,
+    bool GLVertexArrayObject::needsUpdate(VertexBufferBinding* vertexBufferBinding,
                                           size_t vertexStart)
     {
         if(mNeedsUpdate)
@@ -76,10 +75,10 @@ namespace Ogre {
             VertexElementSemantic sem = elem.getSemantic();
             unsigned short elemIndex = elem.getIndex();
 
-            if (!program->isAttributeValid(sem, elemIndex))
+            if (!GLSLProgramCommon::isAttributeValid(sem, elemIndex))
                 continue; // Skip unused elements
 
-            uint32 attrib = (uint32)program->getAttributeIndex(sem, elemIndex);
+            uint32 attrib = (uint32)GLSLProgramCommon::getFixedAttributeIndex(sem, elemIndex);
 
             const HardwareVertexBufferSharedPtr& vertexBuffer = vertexBufferBinding->getBuffer(source);
             AttribBinding binding = {attrib, sem, vertexBuffer.get()};
@@ -100,10 +99,9 @@ namespace Ogre {
         return false;
     }
 
-    void GLVertexArrayObject::bindToShader(GLRenderSystemCommon* rs,
-                                           GLSLProgramCommon* program,
-                                           VertexBufferBinding* vertexBufferBinding,
-                                           size_t vertexStart)
+    void GLVertexArrayObject::bindToGpu(GLRenderSystemCommon* rs,
+                                        VertexBufferBinding* vertexBufferBinding,
+                                        size_t vertexStart)
     {
         mAttribsBound.clear();
         mInstanceAttribsBound.clear();
@@ -123,17 +121,17 @@ namespace Ogre {
             VertexElementSemantic sem = elem.getSemantic();
             unsigned short elemIndex = elem.getIndex();
 
-            if (!program->isAttributeValid(sem, elemIndex))
+            if (!GLSLProgramCommon::isAttributeValid(sem, elemIndex))
                 continue; // Skip unused elements
 
-            uint32 attrib = (uint32)program->getAttributeIndex(sem, elemIndex);
+            uint32 attrib = (uint32)GLSLProgramCommon::getFixedAttributeIndex(sem, elemIndex);
 
             const HardwareVertexBufferSharedPtr& vertexBuffer = vertexBufferBinding->getBuffer(source);
 
             AttribBinding binding = {attrib, sem, vertexBuffer.get()};
             mAttribsBound.push_back(binding);
 
-            rs->bindVertexElementToGpu(elem, vertexBuffer, vertexStart, program);
+            rs->bindVertexElementToGpu(elem, vertexBuffer, vertexStart);
 
             if (vertexBuffer->getIsInstanceData())
                 mInstanceAttribsBound.push_back(attrib);


### PR DESCRIPTION
now that we have fixed and predefined attribute locations, we do not
need to query them by name. Note that even before we only queried a set
of predefined names.

Update API accordingly.