### PR TITLE
add includes for locale_t when using make on macOS

### DIFF
--- a/OgreMain/include/OgreString.h
+++ b/OgreMain/include/OgreString.h
@@ -76,6 +76,14 @@ namespace __gnu_cxx
 #   define strtol_l(ptr, end, base, l) strtol(ptr, end, base)
 #endif
 
+// If compiling with make on macOS, these headers need to be included to get
+// definitions of locale_t, strtod_l, etc...
+// See: http://www.unix.com/man-page/osx/3/strtod_l/
+#if OGRE_PLATFORM == OGRE_PLATFORM_APPLE
+#   include <stdlib.h>
+#   include <xlocale.h>
+#endif
+
 namespace Ogre {
     /** \addtogroup Core
      *  @{


### PR DESCRIPTION
Without these includes, I get this error using the default cmake generator (make) rather than with `-G Xcode`:

```
In file included from /Users/william/ogre-1.10.7/Components/Overlay/src/OgreBorderPanelOverlayElement.cpp:35:
In file included from /Users/william/ogre-1.10.7/OgreMain/include/OgreRoot.h:34:
In file included from /Users/william/ogre-1.10.7/OgreMain/include/OgreSceneManagerEnumerator.h:33:
In file included from /Users/william/ogre-1.10.7/OgreMain/include/OgreSceneManager.h:48:
In file included from /Users/william/ogre-1.10.7/OgreMain/include/OgreRenderSystem.h:37:
In file included from /Users/william/ogre-1.10.7/OgreMain/include/OgreRenderSystemCapabilities.h:34:
/Users/william/ogre-1.10.7/OgreMain/include/OgreStringConverter.h:297:10: error: unknown type name 'locale_t'
                static locale_t _numLocale;
                       ^
1 error generated.
```

This was mentioned on the forums as well here:

http://www.ogre3d.org/forums/viewtopic.php?f=2&t=92948

I believe the reason this is necessary is that when using xcode's build tool it implicitly includes several sets of headers that are not included by default when just using `clang` directly. I can't find any documentation to support this, but that has been my experience at least. Likely I just don't know what to search for.

Either way, including this headers seems to be the "right thing to do" according to this man page reference:

http://www.unix.com/man-page/osx/3/strtod_l/