### PR TITLE
GL*: do not select packed depth-stencil if stencil is unavailable

### DIFF
--- a/RenderSystems/GL/src/OgreGLRenderSystem.cpp
+++ b/RenderSystems/GL/src/OgreGLRenderSystem.cpp
@@ -1157,7 +1157,7 @@ namespace Ogre {
             GLRenderBuffer *depthBuffer = new GLRenderBuffer( depthFormat, fbo->getWidth(),
                                                               fbo->getHeight(), fbo->getFSAA() );
 
-            GLRenderBuffer *stencilBuffer = depthBuffer;
+            GLRenderBuffer *stencilBuffer = stencilFormat ? depthBuffer : NULL;
             if( depthFormat != GL_DEPTH24_STENCIL8_EXT && stencilFormat )
             {
                 stencilBuffer = new GLRenderBuffer( stencilFormat, fbo->getWidth(),

--- a/RenderSystems/GL3Plus/src/OgreGL3PlusRenderSystem.cpp
+++ b/RenderSystems/GL3Plus/src/OgreGL3PlusRenderSystem.cpp
@@ -750,8 +750,8 @@ namespace Ogre {
             GL3PlusRenderBuffer *depthBuffer = new GL3PlusRenderBuffer( depthFormat, fbo->getWidth(),
                                                                         fbo->getHeight(), fbo->getFSAA() );
 
-            GL3PlusRenderBuffer *stencilBuffer = fbo->getFormat() != PF_DEPTH ? depthBuffer : 0;
-            if ( depthFormat != GL_DEPTH24_STENCIL8 && depthFormat != GL_DEPTH32F_STENCIL8 && stencilFormat != GL_NONE )
+            GL3PlusRenderBuffer *stencilBuffer = stencilFormat ? depthBuffer : NULL;
+            if ( depthFormat != GL_DEPTH24_STENCIL8 && depthFormat != GL_DEPTH32F_STENCIL8 && stencilFormat )
             {
                 stencilBuffer = new GL3PlusRenderBuffer( stencilFormat, fbo->getWidth(),
                                                          fbo->getHeight(), fbo->getFSAA() );

--- a/RenderSystems/GLES2/src/OgreGLES2RenderSystem.cpp
+++ b/RenderSystems/GLES2/src/OgreGLES2RenderSystem.cpp
@@ -710,7 +710,7 @@ namespace Ogre {
             GLES2RenderBuffer *depthBuffer = OGRE_NEW GLES2RenderBuffer( depthFormat, fbo->getWidth(),
                                                                 fbo->getHeight(), fbo->getFSAA() );
 
-            GLES2RenderBuffer *stencilBuffer = depthBuffer;
+            GLES2RenderBuffer *stencilBuffer = stencilFormat ? depthBuffer : NULL;
             if( 
 #if OGRE_NO_GLES3_SUPPORT == 0
                depthFormat != GL_DEPTH32F_STENCIL8 &&


### PR DESCRIPTION
discovered on GLES2/ Emscripten