### PR TITLE
RenderQueue: store RenderQueueGroups as plain array instead of std::map

### DIFF
--- a/OgreMain/include/OgreRenderQueue.h
+++ b/OgreMain/include/OgreRenderQueue.h
@@ -93,10 +93,7 @@ namespace Ogre {
     {
     public:
 
-        typedef map< uint8, RenderQueueGroup* >::type RenderQueueGroupMap;
-        /// Iterator over queue groups
-        typedef MapIterator<RenderQueueGroupMap> QueueGroupIterator;
-        typedef ConstMapIterator<RenderQueueGroupMap> ConstQueueGroupIterator;
+        typedef std::unique_ptr<RenderQueueGroup> RenderQueueGroupMap[RENDER_QUEUE_MAX];
 
         /** Class to listen in on items being added to the render queue. 
         @remarks
@@ -239,9 +236,10 @@ namespace Ogre {
         */
         void setDefaultQueueGroup(uint8 grp);
         
-        /** Internal method, returns an iterator for the queue groups. */
-        QueueGroupIterator _getQueueGroupIterator(void);
-        ConstQueueGroupIterator _getQueueGroupIterator(void) const;
+        /** Internal method, returns the queue groups. */
+        const RenderQueueGroupMap& _getQueueGroups() const {
+            return mGroups;
+        }
 
         /** Sets whether or not the queue will split passes by their lighting type,
             ie ambient, per-light and decal. 

--- a/OgreMain/src/OgreSceneManager.cpp
+++ b/OgreMain/src/OgreSceneManager.cpp
@@ -1335,11 +1335,12 @@ void SceneManager::prepareRenderQueue(void)
 
             // Default all the queue groups that are there, new ones will be created
             // with defaults too
-            RenderQueue::QueueGroupIterator groupIter = q->_getQueueGroupIterator();
-            while (groupIter.hasMoreElements())
+            for (size_t i = 0; i < RENDER_QUEUE_MAX; ++i)
             {
-                RenderQueueGroup* g = groupIter.getNext();
-                g->defaultOrganisationMode();
+                if(!q->_getQueueGroups()[i])
+                    continue;
+
+                q->_getQueueGroups()[i]->defaultOrganisationMode();
             }
         }
 
@@ -2360,16 +2361,15 @@ void SceneManager::renderVisibleObjectsDefaultSequence(void)
     firePreRenderQueues();
 
     // Render each separate queue
-    RenderQueue::QueueGroupIterator queueIt = getRenderQueue()->_getQueueGroupIterator();
+    const RenderQueue::RenderQueueGroupMap& groups = getRenderQueue()->_getQueueGroups();
 
-    // NB only queues which have been created are rendered, no time is wasted
-    //   parsing through non-existent queues (even though there are 10 available)
-
-    while (queueIt.hasMoreElements())
+    for (uint8 qId = 0; qId < RENDER_QUEUE_MAX; ++qId)
     {
+        if(!groups[qId])
+            continue;
+
         // Get queue group id
-        uint8 qId = queueIt.peekNextKey();
-        RenderQueueGroup* pGroup = queueIt.getNext();
+        RenderQueueGroup* pGroup = groups[qId].get();
         // Skip this one if not to be processed
         if (!isRenderQueueToBeProcessed(qId))
             continue;


### PR DESCRIPTION
fixes #497 