### PR TITLE
check that glx extension functions are found

### DIFF
--- a/RenderSystems/GLSupport/src/GLX/OgreGLXGLSupport.cpp
+++ b/RenderSystems/GLSupport/src/GLX/OgreGLXGLSupport.cpp
@@ -856,6 +856,12 @@ namespace Ogre
         PFNGLXCREATECONTEXTATTRIBSARBPROC _glXCreateContextAttribsARB;
         _glXCreateContextAttribsARB = (PFNGLXCREATECONTEXTATTRIBSARBPROC)const_cast<GLXGLSupport*>(this)->getProcAddress("glXCreateContextAttribsARB");
 
+        if (!_glXCreateContextAttribsARB) {
+            std::string msg = "glXCreateContextAttribsARB() function not found";
+            LogManager::getSingleton().logMessage(LML_CRITICAL, msg);
+            throw std::runtime_error(msg);
+        }
+
         while(!glxContext && (context_attribs[1] >= minVersion))
         {
             ctxErrorOccurred = false;

--- a/RenderSystems/GLSupport/src/GLX/OgreGLXGLSupport.cpp
+++ b/RenderSystems/GLSupport/src/GLX/OgreGLXGLSupport.cpp
@@ -856,11 +856,7 @@ namespace Ogre
         PFNGLXCREATECONTEXTATTRIBSARBPROC _glXCreateContextAttribsARB;
         _glXCreateContextAttribsARB = (PFNGLXCREATECONTEXTATTRIBSARBPROC)const_cast<GLXGLSupport*>(this)->getProcAddress("glXCreateContextAttribsARB");
 
-        if (!_glXCreateContextAttribsARB) {
-            std::string msg = "glXCreateContextAttribsARB() function not found";
-            LogManager::getSingleton().logMessage(LML_CRITICAL, msg);
-            throw std::runtime_error(msg);
-        }
+	OgreAssert(_glXCreateContextAttribsARB, "glXCreateContextAttribsARB() function not found");
 
         while(!glxContext && (context_attribs[1] >= minVersion))
         {

--- a/RenderSystems/GLSupport/src/GLX/OgreGLXWindow.cpp
+++ b/RenderSystems/GLSupport/src/GLX/OgreGLXWindow.cpp
@@ -601,8 +601,10 @@ namespace Ogre
             }
             else if( _glXSwapIntervalMESA )
                 _glXSwapIntervalMESA( vsync ? mVSyncInterval : 0 );
-            else
+            else if( _glXSwapIntervalSGI )
                 _glXSwapIntervalSGI( vsync ? mVSyncInterval : 0 );
+            else
+                throw std::runtime_error("no glx swap interval function found");
         }
 
         mContext->endCurrent();

--- a/RenderSystems/GLSupport/src/GLX/OgreGLXWindow.cpp
+++ b/RenderSystems/GLSupport/src/GLX/OgreGLXWindow.cpp
@@ -601,9 +601,10 @@ namespace Ogre
             }
             else if( _glXSwapIntervalMESA )
                 _glXSwapIntervalMESA( vsync ? mVSyncInterval : 0 );
-            else
+            else {
 		OgreAssert(_glXSwapIntervalSGI, "no glx swap interval function found");
                 _glXSwapIntervalSGI( vsync ? mVSyncInterval : 0 );
+	    }
         }
 
         mContext->endCurrent();

--- a/RenderSystems/GLSupport/src/GLX/OgreGLXWindow.cpp
+++ b/RenderSystems/GLSupport/src/GLX/OgreGLXWindow.cpp
@@ -601,10 +601,9 @@ namespace Ogre
             }
             else if( _glXSwapIntervalMESA )
                 _glXSwapIntervalMESA( vsync ? mVSyncInterval : 0 );
-            else if( _glXSwapIntervalSGI )
-                _glXSwapIntervalSGI( vsync ? mVSyncInterval : 0 );
             else
-                throw std::runtime_error("no glx swap interval function found");
+		OgreAssert(_glXSwapIntervalSGI, "no glx swap interval function found");
+                _glXSwapIntervalSGI( vsync ? mVSyncInterval : 0 );
         }
 
         mContext->endCurrent();


### PR DESCRIPTION
I'm trying to use Ogre 1.10.7 in a Linux (Ubuntu 16.04) VM on my macbook pro. My opengl version is 2.1 and GSLS version 1.2. I've been running into segfaults because some of the glx extension functions are not being found (i.e. `glXGetProcAddressARB` is returning `nullptr`. In this pull request I'm improving detection for these functions (so you get a runtime error instead of a segfault), but I'm still not sure why these functions are not loading. I'm wondering if the 1.10 releases have been tested on opengl 2.1 very well and maybe some unavailable opengl 3+ functions are being used in the common gl support part of Ogre.

My setup is admittedly a bit exotic (doing static linking and integrating into a Qt5 QWindow), but I can follow up on why these functions are not loaded in my case in a separate issue if this pr is acceptable as-is. I'm hoping someone has an idea of why these are not available.

Also I was able to use this patch to get past the missing `glXCreateContextAttribsARB` function but I cannot get past the missing `_glXSwapIntervalSGI` function:

```diff
diff --git a/RenderSystems/GLSupport/src/GLX/OgreGLXGLSupport.cpp b/RenderSystems/GLSupport/src/GLX/OgreGLXGLSupport.cpp
index 278221b79..aca4d2ecb 100644
--- a/RenderSystems/GLSupport/src/GLX/OgreGLXGLSupport.cpp
+++ b/RenderSystems/GLSupport/src/GLX/OgreGLXGLSupport.cpp
@@ -865,7 +865,11 @@ namespace Ogre
         while(!glxContext && (context_attribs[1] >= minVersion))
         {
             ctxErrorOccurred = false;
-            glxContext = _glXCreateContextAttribsARB(mGLDisplay, fbConfig, shareList, direct, context_attribs);
+            if (!_glXCreateContextAttribsARB) {
+                glxContext = glXCreateNewContext(mGLDisplay, fbConfig, GLX_RGBA_TYPE, shareList, TRUE);
+            } else {
+                glxContext = _glXCreateContextAttribsARB(mGLDisplay, fbConfig, shareList, direct, context_attribs);
+            }
             // Sync to ensure any errors generated are processed.
             XSync( mGLDisplay, False );
             if ( !ctxErrorOccurred && glxContext )
```