### PR TITLE
GL*: use depth buffer as stencil buffer pointer for packed formats

### DIFF
--- a/RenderSystems/GL/src/OgreGLRenderSystem.cpp
+++ b/RenderSystems/GL/src/OgreGLRenderSystem.cpp
@@ -1163,8 +1163,13 @@ namespace Ogre {
             GLRenderBuffer *depthBuffer = new GLRenderBuffer( depthFormat, fbo->getWidth(),
                                                               fbo->getHeight(), fbo->getFSAA() );
 
-            GLRenderBuffer *stencilBuffer = stencilFormat ? depthBuffer : NULL;
-            if( depthFormat != GL_DEPTH24_STENCIL8_EXT && stencilFormat )
+            GLRenderBuffer *stencilBuffer = NULL;
+            if ( depthFormat == GL_DEPTH24_STENCIL8_EXT)
+            {
+                // If we have a packed format, the stencilBuffer is the same as the depthBuffer
+                stencilBuffer = depthBuffer;
+            }
+            else if(stencilFormat)
             {
                 stencilBuffer = new GLRenderBuffer( stencilFormat, fbo->getWidth(),
                                                     fbo->getHeight(), fbo->getFSAA() );

--- a/RenderSystems/GL3Plus/src/OgreGL3PlusRenderSystem.cpp
+++ b/RenderSystems/GL3Plus/src/OgreGL3PlusRenderSystem.cpp
@@ -755,8 +755,13 @@ namespace Ogre {
             GL3PlusRenderBuffer *depthBuffer = new GL3PlusRenderBuffer( depthFormat, fbo->getWidth(),
                                                                         fbo->getHeight(), fbo->getFSAA() );
 
-            GL3PlusRenderBuffer *stencilBuffer = stencilFormat ? depthBuffer : NULL;
-            if ( depthFormat != GL_DEPTH24_STENCIL8 && depthFormat != GL_DEPTH32F_STENCIL8 && stencilFormat )
+            GL3PlusRenderBuffer *stencilBuffer = NULL;
+            if ( depthFormat == GL_DEPTH24_STENCIL8 || depthFormat == GL_DEPTH32F_STENCIL8)
+            {
+                // If we have a packed format, the stencilBuffer is the same as the depthBuffer
+                stencilBuffer = depthBuffer;
+            }
+            else if(stencilFormat)
             {
                 stencilBuffer = new GL3PlusRenderBuffer( stencilFormat, fbo->getWidth(),
                                                          fbo->getHeight(), fbo->getFSAA() );

--- a/RenderSystems/GLES2/src/OgreGLES2RenderSystem.cpp
+++ b/RenderSystems/GLES2/src/OgreGLES2RenderSystem.cpp
@@ -715,16 +715,20 @@ namespace Ogre {
             GLES2RenderBuffer *depthBuffer = OGRE_NEW GLES2RenderBuffer( depthFormat, fbo->getWidth(),
                                                                 fbo->getHeight(), fbo->getFSAA() );
 
-            GLES2RenderBuffer *stencilBuffer = stencilFormat ? depthBuffer : NULL;
-            if( 
+            GLES2RenderBuffer *stencilBuffer = NULL;
+            if(
 #if OGRE_NO_GLES3_SUPPORT == 0
-               depthFormat != GL_DEPTH32F_STENCIL8 &&
+               depthFormat == GL_DEPTH32F_STENCIL8 ||
 #endif
-               depthFormat != GL_DEPTH24_STENCIL8_OES &&
-               stencilFormat )
+               depthFormat == GL_DEPTH24_STENCIL8_OES )
             {
-                stencilBuffer = OGRE_NEW GLES2RenderBuffer( stencilFormat, fbo->getWidth(),
-                                                           fbo->getHeight(), fbo->getFSAA() );
+                // If we have a packed format, the stencilBuffer is the same as the depthBuffer
+                stencilBuffer = depthBuffer;
+            }
+            else if(stencilFormat)
+            {
+                stencilBuffer = new GLES2RenderBuffer( stencilFormat, fbo->getWidth(),
+                                                       fbo->getHeight(), fbo->getFSAA() );
             }
 
             // No "custom-quality" multisample for now in GL


### PR DESCRIPTION
This caused the stencil buffer to be unbound when using stencil test for these formats. 

The bug was introduced at commit 369fdbbfe95b3f5b4991c6718b4e08d07b4a35d0. I'm not sure it is the best way to fix it but that looked safer than modifying getBestDepthStencil(). 
Also beware I did the modifications for all render systems but I could only test it on GL3Plus.