### PR TITLE
GLES2: fix BlitSubTextures

### DIFF
--- a/OgreMain/include/OgreCommon.h
+++ b/OgreMain/include/OgreCommon.h
@@ -211,7 +211,7 @@ namespace Ogre {
             than the additive stencil shadow approach when there are multiple
             lights, but is not an accurate model. 
         */
-        SHADOWTYPE_STENCIL_MODULATIVE = 0x12,
+        SHADOWTYPE_STENCIL_MODULATIVE = SHADOWDETAILTYPE_STENCIL | SHADOWDETAILTYPE_MODULATIVE,
         /** Stencil shadow technique which renders each light as a separate
             additive pass to the scene. This technique can be very fillrate
             intensive because it requires at least 2 passes of the entire
@@ -219,12 +219,12 @@ namespace Ogre {
             accurate model than the modulative stencil approach and this is
             especially apparent when using coloured lights or bump mapping.
         */
-        SHADOWTYPE_STENCIL_ADDITIVE = 0x11,
+        SHADOWTYPE_STENCIL_ADDITIVE = SHADOWDETAILTYPE_STENCIL | SHADOWDETAILTYPE_ADDITIVE,
         /** Texture-based shadow technique which involves a monochrome render-to-texture
             of the shadow caster and a projection of that texture onto the 
             shadow receivers as a modulative pass. 
         */
-        SHADOWTYPE_TEXTURE_MODULATIVE = 0x22,
+        SHADOWTYPE_TEXTURE_MODULATIVE = SHADOWDETAILTYPE_TEXTURE | SHADOWDETAILTYPE_MODULATIVE,
         
         /** Texture-based shadow technique which involves a render-to-texture
             of the shadow caster and a projection of that texture onto the 
@@ -234,7 +234,7 @@ namespace Ogre {
             modulative approach and this is especially apparent when using coloured lights 
             or bump mapping.
         */
-        SHADOWTYPE_TEXTURE_ADDITIVE = 0x21,
+        SHADOWTYPE_TEXTURE_ADDITIVE = SHADOWDETAILTYPE_TEXTURE | SHADOWDETAILTYPE_ADDITIVE,
 
         /** Texture-based shadow technique which involves a render-to-texture
         of the shadow caster and a projection of that texture on to the shadow
@@ -251,7 +251,7 @@ namespace Ogre {
         not mean it does the adding on your receivers automatically though, how you
         use that result is up to you.
         */
-        SHADOWTYPE_TEXTURE_ADDITIVE_INTEGRATED = 0x25,
+        SHADOWTYPE_TEXTURE_ADDITIVE_INTEGRATED = SHADOWTYPE_TEXTURE_ADDITIVE | SHADOWDETAILTYPE_INTEGRATED,
         /** Texture-based shadow technique which involves a render-to-texture
             of the shadow caster and a projection of that texture on to the shadow
             receivers, with the usage of those shadow textures completely controlled
@@ -267,7 +267,7 @@ namespace Ogre {
             not mean it modulates on your receivers automatically though, how you
             use that result is up to you.
         */
-        SHADOWTYPE_TEXTURE_MODULATIVE_INTEGRATED = 0x26
+        SHADOWTYPE_TEXTURE_MODULATIVE_INTEGRATED = SHADOWTYPE_TEXTURE_MODULATIVE | SHADOWDETAILTYPE_INTEGRATED
     };
 
     /** An enumeration describing which material properties should track the vertex colours */

--- a/OgreMain/include/OgreHardwareBuffer.h
+++ b/OgreMain/include/OgreHardwareBuffer.h
@@ -111,13 +111,13 @@ namespace Ogre {
                 /** Combination of HBU_STATIC and HBU_WRITE_ONLY
                 This is the optimal buffer usage setting.
                 */
-                HBU_STATIC_WRITE_ONLY = 5,
+                HBU_STATIC_WRITE_ONLY = HBU_STATIC | HBU_WRITE_ONLY,
                 /** Combination of HBU_DYNAMIC and HBU_WRITE_ONLY. If you use
                 this, strongly consider using HBU_DYNAMIC_WRITE_ONLY_DISCARDABLE
                 instead if you update the entire contents of the buffer very
                 regularly.
                 */
-                HBU_DYNAMIC_WRITE_ONLY = 6,
+                HBU_DYNAMIC_WRITE_ONLY = HBU_DYNAMIC | HBU_WRITE_ONLY,
                 /** Combination of HBU_DYNAMIC, HBU_WRITE_ONLY and HBU_DISCARDABLE
                  This means that you expect to replace the entire contents of the buffer on an
                  extremely regular basis, most likely every frame. By selecting this option, you
@@ -128,7 +128,7 @@ namespace Ogre {
                  update regularly. Note that if you create a buffer this way, you should use the
                  HBL_DISCARD flag when locking the contents of it for writing.
                  */
-                HBU_DYNAMIC_WRITE_ONLY_DISCARDABLE = 14
+                HBU_DYNAMIC_WRITE_ONLY_DISCARDABLE = HBU_DYNAMIC_WRITE_ONLY | HBU_DISCARDABLE
 
             };
             /// Locking options

--- a/RenderSystems/GL/src/OgreGLHardwarePixelBuffer.cpp
+++ b/RenderSystems/GL/src/OgreGLHardwarePixelBuffer.cpp
@@ -74,7 +74,6 @@ void GLHardwarePixelBuffer::blitFromMemory(const PixelBox &src, const Box &dstBo
     }
     else
     {
-        allocateBuffer();
         // No scaling or conversion needed
         scaled = src;
     }

--- a/RenderSystems/GL/src/OgreGLHardwarePixelBuffer.cpp
+++ b/RenderSystems/GL/src/OgreGLHardwarePixelBuffer.cpp
@@ -308,19 +308,20 @@ void GLTextureBuffer::upload(const PixelBox &data, const Box &dest)
             glPixelStorei(GL_UNPACK_ROW_LENGTH, data.rowPitch);
         if(data.getWidth() > 0 && data.getHeight()*data.getWidth() != data.slicePitch)
             glPixelStorei(GL_UNPACK_IMAGE_HEIGHT, (data.slicePitch/data.getWidth()));
-        if(data.left > 0 || data.top > 0 || data.front > 0)
-            glPixelStorei(GL_UNPACK_SKIP_PIXELS, data.left + data.rowPitch * data.top + data.slicePitch * data.front);
         if((data.getWidth()*PixelUtil::getNumElemBytes(data.format)) & 3) {
             // Standard alignment of 4 is not right
             glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
         }
+
+        void* pdata = data.getTopLeftFrontPixelPtr();
+
         switch(mTarget) {
             case GL_TEXTURE_1D:
                 glTexSubImage1D(GL_TEXTURE_1D, mLevel, 
                     dest.left,
                     dest.getWidth(),
                     GLPixelUtil::getGLOriginFormat(data.format), GLPixelUtil::getGLOriginDataType(data.format),
-                    data.data);
+                    pdata);
                 break;
             case GL_TEXTURE_2D:
             case GL_TEXTURE_CUBE_MAP:
@@ -328,7 +329,7 @@ void GLTextureBuffer::upload(const PixelBox &data, const Box &dest)
                     dest.left, dest.top, 
                     dest.getWidth(), dest.getHeight(),
                     GLPixelUtil::getGLOriginFormat(data.format), GLPixelUtil::getGLOriginDataType(data.format),
-                    data.data);
+                    pdata);
                 break;
             case GL_TEXTURE_3D:
             case GL_TEXTURE_2D_ARRAY_EXT:
@@ -337,7 +338,7 @@ void GLTextureBuffer::upload(const PixelBox &data, const Box &dest)
                     dest.left, dest.top, dest.front,
                     dest.getWidth(), dest.getHeight(), dest.getDepth(),
                     GLPixelUtil::getGLOriginFormat(data.format), GLPixelUtil::getGLOriginDataType(data.format),
-                    data.data);
+                    pdata);
                 break;
         }   
     }
@@ -353,7 +354,6 @@ void GLTextureBuffer::upload(const PixelBox &data, const Box &dest)
     glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
     if (GLEW_VERSION_1_2)
         glPixelStorei(GL_UNPACK_IMAGE_HEIGHT, 0);
-    glPixelStorei(GL_UNPACK_SKIP_PIXELS, 0);
     glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
 }
 //-----------------------------------------------------------------------------  
@@ -381,8 +381,6 @@ void GLTextureBuffer::download(const PixelBox &data)
             glPixelStorei(GL_PACK_ROW_LENGTH, data.rowPitch);
         if(data.getHeight()*data.getWidth() != data.slicePitch)
             glPixelStorei(GL_PACK_IMAGE_HEIGHT, (data.slicePitch/data.getWidth()));
-        if(data.left > 0 || data.top > 0 || data.front > 0)
-            glPixelStorei(GL_PACK_SKIP_PIXELS, data.left + data.rowPitch * data.top + data.slicePitch * data.front);
         if((data.getWidth()*PixelUtil::getNumElemBytes(data.format)) & 3) {
             // Standard alignment of 4 is not right
             glPixelStorei(GL_PACK_ALIGNMENT, 1);
@@ -390,11 +388,10 @@ void GLTextureBuffer::download(const PixelBox &data)
         // We can only get the entire texture
         glGetTexImage(mFaceTarget, mLevel, 
             GLPixelUtil::getGLOriginFormat(data.format), GLPixelUtil::getGLOriginDataType(data.format),
-            data.data);
+            data.getTopLeftFrontPixelPtr());
         // Restore defaults
         glPixelStorei(GL_PACK_ROW_LENGTH, 0);
         glPixelStorei(GL_PACK_IMAGE_HEIGHT, 0);
-        glPixelStorei(GL_PACK_SKIP_PIXELS, 0);
         glPixelStorei(GL_PACK_ALIGNMENT, 4);
     }
 }

--- a/RenderSystems/GL3Plus/src/OgreGL3PlusHardwarePixelBuffer.cpp
+++ b/RenderSystems/GL3Plus/src/OgreGL3PlusHardwarePixelBuffer.cpp
@@ -81,7 +81,6 @@ namespace Ogre {
         }
         else
         {
-            allocateBuffer();
             // No scaling or conversion needed.
             scaled = src;
         }

--- a/RenderSystems/GL3Plus/src/OgreGL3PlusTextureBuffer.cpp
+++ b/RenderSystems/GL3Plus/src/OgreGL3PlusTextureBuffer.cpp
@@ -174,7 +174,7 @@ namespace Ogre {
 
         void* pdata = NULL;
 #else
-        void* pdata = data.data;
+        void* pdata = data.getTopLeftFrontPixelPtr();
 #endif
 
         if (PixelUtil::isCompressed(data.format))
@@ -227,8 +227,6 @@ namespace Ogre {
                 OGRE_CHECK_GL_ERROR(glPixelStorei(GL_UNPACK_ROW_LENGTH, data.rowPitch));
             if (data.getHeight() * data.getWidth() != data.slicePitch)
                 OGRE_CHECK_GL_ERROR(glPixelStorei(GL_UNPACK_IMAGE_HEIGHT, (data.slicePitch/data.getWidth())));
-            if (data.left > 0 || data.top > 0 || data.front > 0)
-                OGRE_CHECK_GL_ERROR(glPixelStorei(GL_UNPACK_SKIP_PIXELS, data.left + data.rowPitch * data.top + data.slicePitch * data.front));
             if ((data.getWidth()*PixelUtil::getNumElemBytes(data.format)) & 3) {
                 // Standard alignment of 4 is not right.
                 OGRE_CHECK_GL_ERROR(glPixelStorei(GL_UNPACK_ALIGNMENT, 1));
@@ -297,7 +295,6 @@ namespace Ogre {
         // Restore defaults.
         OGRE_CHECK_GL_ERROR(glPixelStorei(GL_UNPACK_ROW_LENGTH, 0));
         OGRE_CHECK_GL_ERROR(glPixelStorei(GL_UNPACK_IMAGE_HEIGHT, 0));
-        OGRE_CHECK_GL_ERROR(glPixelStorei(GL_UNPACK_SKIP_PIXELS, 0));
         OGRE_CHECK_GL_ERROR(glPixelStorei(GL_UNPACK_ALIGNMENT, 4));
     }
 
@@ -340,8 +337,6 @@ namespace Ogre {
                 OGRE_CHECK_GL_ERROR(glPixelStorei(GL_PACK_ROW_LENGTH, data.rowPitch));
             if (data.getHeight()*data.getWidth() != data.slicePitch)
                 OGRE_CHECK_GL_ERROR(glPixelStorei(GL_PACK_IMAGE_HEIGHT, (data.slicePitch/data.getWidth())));
-            if (data.left > 0 || data.top > 0 || data.front > 0)
-                OGRE_CHECK_GL_ERROR(glPixelStorei(GL_PACK_SKIP_PIXELS, data.left + data.rowPitch * data.top + data.slicePitch * data.front));
             if ((data.getWidth()*PixelUtil::getNumElemBytes(data.format)) & 3) {
                 // Standard alignment of 4 is not right
                 OGRE_CHECK_GL_ERROR(glPixelStorei(GL_PACK_ALIGNMENT, 1));
@@ -355,7 +350,6 @@ namespace Ogre {
             // Restore defaults
             OGRE_CHECK_GL_ERROR(glPixelStorei(GL_PACK_ROW_LENGTH, 0));
             OGRE_CHECK_GL_ERROR(glPixelStorei(GL_PACK_IMAGE_HEIGHT, 0));
-            OGRE_CHECK_GL_ERROR(glPixelStorei(GL_PACK_SKIP_PIXELS, 0));
             OGRE_CHECK_GL_ERROR(glPixelStorei(GL_PACK_ALIGNMENT, 4));
         }
 
@@ -376,7 +370,7 @@ namespace Ogre {
         }
 
         // Copy to destination buffer
-        buffer.readData(offsetInBytes, mSizeInBytes, data.data);
+        buffer.readData(offsetInBytes, mSizeInBytes, data.getTopLeftFrontPixelPtr());
     }
 
 

--- a/RenderSystems/GLES2/src/OgreGLES2HardwarePixelBuffer.cpp
+++ b/RenderSystems/GLES2/src/OgreGLES2HardwarePixelBuffer.cpp
@@ -59,7 +59,6 @@ namespace Ogre {
                         "GLES2HardwarePixelBuffer::blitFromMemory");
         }
 
-        bool freeScaledBuffer = false;
         PixelBox scaled;
 
         if (src.getWidth() != dstBox.getWidth() ||
@@ -84,32 +83,10 @@ namespace Ogre {
         {
             // No scaling or conversion needed
             scaled = src;
-
-            if (src.format == PF_R8G8B8)
-            {
-                freeScaledBuffer = true;
-                size_t srcSize = PixelUtil::getMemorySize(src.getWidth(), src.getHeight(), src.getDepth(), src.format);
-                scaled.format = PF_B8G8R8;
-                scaled.data = new uint8[srcSize];
-                memcpy(scaled.data, src.data, srcSize);
-                PixelUtil::bulkPixelConversion(src, scaled);
-            }
-#if OGRE_PLATFORM != OGRE_PLATFORM_APPLE_IOS
-            if (src.format == PF_A8R8G8B8)
-            {
-                scaled.format = PF_A8B8G8R8;
-                PixelUtil::bulkPixelConversion(src, scaled);
-            }
-#endif
         }
 
         upload(scaled, dstBox);
         freeBuffer();
-        
-        if (freeScaledBuffer)
-        {
-            delete[] (uint8*)scaled.data;
-        }
     }
 
     void GLES2HardwarePixelBuffer::blitToMemory(const Box &srcBox, const PixelBox &dst)

--- a/RenderSystems/GLES2/src/OgreGLES2HardwarePixelBuffer.cpp
+++ b/RenderSystems/GLES2/src/OgreGLES2HardwarePixelBuffer.cpp
@@ -82,8 +82,6 @@ namespace Ogre {
         }
         else
         {
-            allocateBuffer();
-
             // No scaling or conversion needed
             scaled = src;
 

--- a/RenderSystems/GLES2/src/OgreGLES2HardwarePixelBuffer.cpp
+++ b/RenderSystems/GLES2/src/OgreGLES2HardwarePixelBuffer.cpp
@@ -85,7 +85,7 @@ namespace Ogre {
             allocateBuffer();
 
             // No scaling or conversion needed
-            scaled = PixelBox(src.getWidth(), src.getHeight(), src.getDepth(), src.format, src.data);
+            scaled = src;
 
             if (src.format == PF_R8G8B8)
             {
@@ -255,7 +255,8 @@ namespace Ogre {
         rs->_getStateCacheManager()->bindGLTexture(mTarget, mTextureID);
 
         bool hasGLES30 = rs->hasMinGLVersion(3, 0);
-#if OGRE_NO_GLES3_SUPPORT == 0
+        // PBO handling is broken
+#if 0// OGRE_NO_GLES3_SUPPORT == 0
         // Calculate size for all mip levels of the texture
         size_t dataSize = 0;
         if(mTarget == GL_TEXTURE_2D_ARRAY)

--- a/RenderSystems/GLES2/src/OgreGLES2HardwarePixelBuffer.cpp
+++ b/RenderSystems/GLES2/src/OgreGLES2HardwarePixelBuffer.cpp
@@ -288,7 +288,7 @@ namespace Ogre {
         LogManager::getSingleton().logMessage(LML_NORMAL, str.str());
 #endif
 #else
-        void* pdata = data.data;
+        void* pdata = data.getTopLeftFrontPixelPtr();
 #if OGRE_DEBUG_MODE
         LogManager::getSingleton().logMessage("GLES2TextureBuffer::upload - ID: " + StringConverter::toString(mTextureID) +
                                               " Target: " + StringConverter::toString(mTarget) +
@@ -351,9 +351,6 @@ namespace Ogre {
                 OGRE_CHECK_GL_ERROR(glPixelStorei(GL_UNPACK_IMAGE_HEIGHT, (data.slicePitch/data.getWidth())));
             }
 
-            if(hasGLES30 && (data.left > 0 || data.top > 0 || data.front > 0))
-                OGRE_CHECK_GL_ERROR(glPixelStorei(GL_UNPACK_SKIP_PIXELS, data.left + data.rowPitch * data.top + data.slicePitch * data.front));
-
             if((data.getWidth()*PixelUtil::getNumElemBytes(data.format)) & 3) {
                 // Standard alignment of 4 is not right
                 OGRE_CHECK_GL_ERROR(glPixelStorei(GL_UNPACK_ALIGNMENT, 1));
@@ -395,7 +392,6 @@ namespace Ogre {
         if(hasGLES30) {
             OGRE_CHECK_GL_ERROR(glPixelStorei(GL_UNPACK_ROW_LENGTH, 0));
             OGRE_CHECK_GL_ERROR(glPixelStorei(GL_UNPACK_IMAGE_HEIGHT, 0));
-            OGRE_CHECK_GL_ERROR(glPixelStorei(GL_UNPACK_SKIP_PIXELS, 0));
         }
 
         OGRE_CHECK_GL_ERROR(glPixelStorei(GL_UNPACK_ALIGNMENT, 4));

--- a/RenderSystems/GLSupport/src/OgreGLHardwarePixelBufferCommon.cpp
+++ b/RenderSystems/GLSupport/src/OgreGLHardwarePixelBufferCommon.cpp
@@ -67,7 +67,7 @@ void GLHardwarePixelBufferCommon::freeBuffer()
 PixelBox GLHardwarePixelBufferCommon::lockImpl(const Box& lockBox, LockOptions options)
 {
     allocateBuffer();
-    if (options != HardwareBuffer::HBL_DISCARD)
+    if (!((mUsage & HBU_WRITE_ONLY) || (options == HBL_DISCARD) || (options == HBL_WRITE_ONLY)))
     {
         // Download the old contents of the texture
         download(mBuffer);
@@ -79,7 +79,7 @@ PixelBox GLHardwarePixelBufferCommon::lockImpl(const Box& lockBox, LockOptions o
 
 void GLHardwarePixelBufferCommon::unlockImpl(void)
 {
-    if (mCurrentLockOptions != HardwareBuffer::HBL_READ_ONLY)
+    if (mCurrentLockOptions != HBL_READ_ONLY)
     {
         // From buffer to card, only upload if was locked for writing.
         upload(mCurrentLock, mLockedBox);


### PR DESCRIPTION
- use copy assignment to keep the correct stride
- disable incorrect PBO upload on GLES3