### PR TITLE
Make sure parent node is marked as dirty.

### DIFF
--- a/OgreMain/src/OgreInstanceBatch.cpp
+++ b/OgreMain/src/OgreInstanceBatch.cpp
@@ -162,6 +162,9 @@ namespace Ogre
 
 
         mBoundingRadius = Math::boundingRadiusFromAABBCentered( mFullBoundingBox );
+        if (mParentNode) {
+            mParentNode->needUpdate();
+        }
         mBoundsDirty    = false;
     }
 


### PR DESCRIPTION
This fixes an issue where bounding boxes wouldn't be updated.