### PR TITLE
Fix V595 warnings from PVS-Studio Static Analyzer

### DIFF
--- a/Components/Bites/src/OgreApplicationContext.cpp
+++ b/Components/Bites/src/OgreApplicationContext.cpp
@@ -97,10 +97,10 @@ void ApplicationContext::initApp()
 void ApplicationContext::closeApp()
 {
 #if OGRE_PLATFORM != OGRE_PLATFORM_ANDROID
-	if (mRoot)
-	{
-		mRoot->saveConfig();
-	}
+    if (mRoot)
+    {
+        mRoot->saveConfig();
+    }
 #endif
 
     shutdown();

--- a/Components/Bites/src/OgreApplicationContext.cpp
+++ b/Components/Bites/src/OgreApplicationContext.cpp
@@ -97,7 +97,10 @@ void ApplicationContext::initApp()
 void ApplicationContext::closeApp()
 {
 #if OGRE_PLATFORM != OGRE_PLATFORM_ANDROID
-    mRoot->saveConfig();
+	if (mRoot)
+	{
+		mRoot->saveConfig();
+	}
 #endif
 
     shutdown();

--- a/OgreMain/src/OgreEntity.cpp
+++ b/OgreMain/src/OgreEntity.cpp
@@ -2001,7 +2001,7 @@ namespace Ogre {
                     AnimationStateSet* targetState = mLodEntityList[mMeshLodIndex-1]->mAnimationState;
                     if (mAnimationState != targetState) // only copy if lods have different skeleton instances
                     {
-                        if (mAnimationState->getDirtyFrameNumber() != targetState->getDirtyFrameNumber()) // only copy if animation was updated
+                        if (mAnimationState && mAnimationState->getDirtyFrameNumber() != targetState->getDirtyFrameNumber()) // only copy if animation was updated
                             mAnimationState->copyMatchingState(targetState);
                     }
                 }

--- a/OgreMain/src/OgreMaterial.cpp
+++ b/OgreMain/src/OgreMaterial.cpp
@@ -788,7 +788,8 @@ namespace Ogre {
         mLodValues.clear();
         mUserLodValues.clear();
         mUserLodValues.push_back(0);
-        mLodValues.push_back(mLodStrategy->getBaseValue());
+		if (mLodStrategy)
+			mLodValues.push_back(mLodStrategy->getBaseValue());
         for (i = lodValues.begin(); i != iend; ++i)
         {
             mUserLodValues.push_back(*i);

--- a/OgreMain/src/OgreMaterial.cpp
+++ b/OgreMain/src/OgreMaterial.cpp
@@ -788,8 +788,8 @@ namespace Ogre {
         mLodValues.clear();
         mUserLodValues.clear();
         mUserLodValues.push_back(0);
-		if (mLodStrategy)
-			mLodValues.push_back(mLodStrategy->getBaseValue());
+        if (mLodStrategy)
+            mLodValues.push_back(mLodStrategy->getBaseValue());
         for (i = lodValues.begin(); i != iend; ++i)
         {
             mUserLodValues.push_back(*i);

--- a/RenderSystems/GL/src/nvparse/ps1.0_program.cpp
+++ b/RenderSystems/GL/src/nvparse/ps1.0_program.cpp
@@ -905,26 +905,29 @@ void ps10::SetFinalCombinerStage()
 }
 
 void ps10::invoke(vector<constdef> * c,
-                  list<vector<string> > * a,
-                  list<vector<string> > * b)
+	list<vector<string> > * a,
+	list<vector<string> > * b)
 {
-    const_to_combiner_reg_mapping_count = 0; // Hansong
+	const_to_combiner_reg_mapping_count = 0; // Hansong
 
-    GLint activeTex = 0;
-    glGetIntegerv(GL_ACTIVE_TEXTURE, &activeTex);
+	GLint activeTex = 0;
+	glGetIntegerv(GL_ACTIVE_TEXTURE, &activeTex);
 
-    glEnable(GL_PER_STAGE_CONSTANTS_NV); // should we require apps to do this?
-    if(c)
-        for_each(c->begin(), c->end(), set_constants());
-    if(a)
-        for_each(a->begin(), a->end(), set_texture_shaders(c));
-    glActiveTextureARB( GL_TEXTURE0_ARB );
-    int numCombiners = 0;
-    list<vector<string> >::iterator it = b->begin();
-    for(; it!=b->end(); ++it) {
-      if ( (*it)[0] != "+" )
-        numCombiners++;
-    }
+	glEnable(GL_PER_STAGE_CONSTANTS_NV); // should we require apps to do this?
+	if (c)
+		for_each(c->begin(), c->end(), set_constants());
+	if (a)
+		for_each(a->begin(), a->end(), set_texture_shaders(c));
+	glActiveTextureARB(GL_TEXTURE0_ARB);
+	int numCombiners = 0;
+	if(b)
+	{
+		list<vector<string> >::iterator it = b->begin();
+		for (; it != b->end(); ++it) {
+			if ((*it)[0] != "+")
+				numCombiners++;
+		}
+	}
     glCombinerParameteriNV(GL_NUM_GENERAL_COMBINERS_NV, numCombiners);
     if(b)
         for_each(b->begin(), b->end(), set_register_combiners());

--- a/RenderSystems/GL/src/nvparse/ps1.0_program.cpp
+++ b/RenderSystems/GL/src/nvparse/ps1.0_program.cpp
@@ -920,14 +920,14 @@ void ps10::invoke(vector<constdef> * c,
 		for_each(a->begin(), a->end(), set_texture_shaders(c));
 	glActiveTextureARB(GL_TEXTURE0_ARB);
 	int numCombiners = 0;
-	if(b)
-	{
-		list<vector<string> >::iterator it = b->begin();
-		for (; it != b->end(); ++it) {
-			if ((*it)[0] != "+")
-				numCombiners++;
-		}
-	}
+    if(b)
+    {
+        list<vector<string> >::iterator it = b->begin();
+        for (; it != b->end(); ++it) {
+            if ((*it)[0] != "+")
+                numCombiners++;
+        }
+    }
     glCombinerParameteriNV(GL_NUM_GENERAL_COMBINERS_NV, numCombiners);
     if(b)
         for_each(b->begin(), b->end(), set_register_combiners());


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.
Warnings:
- [V595](https://www.viva64.com/en/w/v595/) The 'mRoot' pointer was utilized before it was verified against nullptr. Check lines: 100, 104. [ogreapplicationcontext.cpp 100](https://github.com/OGRECave/ogre/blob/master/Components/Bites/src/OgreApplicationContext.cpp#L100)
- [V595](https://www.viva64.com/en/w/v595/) The 'mAnimationState' pointer was utilized before it was verified against nullptr. Check lines: 2005, 2020. [ogreentity.cpp 2005](https://github.com/OGRECave/ogre/blob/master/OgreMain/src/OgreEntity.cpp#L2005)
- [V595](https://www.viva64.com/en/w/v595/) The 'mLodStrategy' pointer was utilized before it was verified against nullptr. Check lines: 791, 795. [ogrematerial.cpp 791](https://github.com/OGRECave/ogre/blob/master/OgreMain/src/OgreMaterial.cpp#L791)
- [V595](https://www.viva64.com/en/w/v595/) The 'b' pointer was utilized before it was verified against nullptr. Check lines: 923, 929. [ps1.0_program.cpp 923](https://github.com/OGRECave/ogre/blob/master/RenderSystems/GL/src/nvparse/ps1.0_program.cpp#L923)