### PR TITLE
Fix V535 warnings from PVS-Studio Static Analyzer

### DIFF
--- a/Components/Bites/src/OgreApplicationContext.cpp
+++ b/Components/Bites/src/OgreApplicationContext.cpp
@@ -97,10 +97,10 @@ void ApplicationContext::initApp()
 void ApplicationContext::closeApp()
 {
 #if OGRE_PLATFORM != OGRE_PLATFORM_ANDROID
-	if (mRoot)
-	{
-		mRoot->saveConfig();
-	}
+    if (mRoot)
+    {
+        mRoot->saveConfig();
+    }
 #endif
 
     shutdown();

--- a/Components/Bites/src/OgreApplicationContext.cpp
+++ b/Components/Bites/src/OgreApplicationContext.cpp
@@ -97,7 +97,10 @@ void ApplicationContext::initApp()
 void ApplicationContext::closeApp()
 {
 #if OGRE_PLATFORM != OGRE_PLATFORM_ANDROID
-    mRoot->saveConfig();
+	if (mRoot)
+	{
+		mRoot->saveConfig();
+	}
 #endif
 
     shutdown();

--- a/OgreMain/src/OgreEdgeListBuilder.cpp
+++ b/OgreMain/src/OgreEdgeListBuilder.cpp
@@ -483,7 +483,7 @@ namespace Ogre {
         l->logMessage("Number of vertex sets: " + StringConverter::toString(mVertexDataList.size()));
         l->logMessage("Number of index sets: " + StringConverter::toString(mGeometryList.size()));
         
-        size_t i, j;
+        size_t i, j, k;
         // Log original vertex data
         for(i = 0; i < mVertexDataList.size(); ++i)
         {
@@ -591,10 +591,10 @@ namespace Ogre {
             l->logMessage(".");
             l->logMessage("Common vertex list - vertex count " + 
                 StringConverter::toString(mVertices.size()));
-            for (i = 0; i < mVertices.size(); ++i)
+            for (k = 0; k < mVertices.size(); ++k)
             {
-                CommonVertex& c = mVertices[i];
-                l->logMessage("Common vertex " + StringConverter::toString(i) + 
+                CommonVertex& c = mVertices[k];
+                l->logMessage("Common vertex " + StringConverter::toString(k) + 
                     ": (vertexSet=" + StringConverter::toString(c.vertexSet) + 
                     ", originalIndex=" + StringConverter::toString(c.originalIndex) + 
                     ", position=" + StringConverter::toString(c.position));

--- a/OgreMain/src/OgreEntity.cpp
+++ b/OgreMain/src/OgreEntity.cpp
@@ -2001,7 +2001,7 @@ namespace Ogre {
                     AnimationStateSet* targetState = mLodEntityList[mMeshLodIndex-1]->mAnimationState;
                     if (mAnimationState != targetState) // only copy if lods have different skeleton instances
                     {
-                        if (mAnimationState->getDirtyFrameNumber() != targetState->getDirtyFrameNumber()) // only copy if animation was updated
+                        if (mAnimationState && mAnimationState->getDirtyFrameNumber() != targetState->getDirtyFrameNumber()) // only copy if animation was updated
                             mAnimationState->copyMatchingState(targetState);
                     }
                 }

--- a/OgreMain/src/OgreMaterial.cpp
+++ b/OgreMain/src/OgreMaterial.cpp
@@ -788,7 +788,8 @@ namespace Ogre {
         mLodValues.clear();
         mUserLodValues.clear();
         mUserLodValues.push_back(0);
-        mLodValues.push_back(mLodStrategy->getBaseValue());
+		if (mLodStrategy)
+			mLodValues.push_back(mLodStrategy->getBaseValue());
         for (i = lodValues.begin(); i != iend; ++i)
         {
             mUserLodValues.push_back(*i);

--- a/OgreMain/src/OgreMaterial.cpp
+++ b/OgreMain/src/OgreMaterial.cpp
@@ -788,8 +788,8 @@ namespace Ogre {
         mLodValues.clear();
         mUserLodValues.clear();
         mUserLodValues.push_back(0);
-		if (mLodStrategy)
-			mLodValues.push_back(mLodStrategy->getBaseValue());
+        if (mLodStrategy)
+            mLodValues.push_back(mLodStrategy->getBaseValue());
         for (i = lodValues.begin(); i != iend; ++i)
         {
             mUserLodValues.push_back(*i);

--- a/RenderSystems/GL/src/nvparse/ps1.0_program.cpp
+++ b/RenderSystems/GL/src/nvparse/ps1.0_program.cpp
@@ -905,26 +905,29 @@ void ps10::SetFinalCombinerStage()
 }
 
 void ps10::invoke(vector<constdef> * c,
-                  list<vector<string> > * a,
-                  list<vector<string> > * b)
+	list<vector<string> > * a,
+	list<vector<string> > * b)
 {
-    const_to_combiner_reg_mapping_count = 0; // Hansong
+	const_to_combiner_reg_mapping_count = 0; // Hansong
 
-    GLint activeTex = 0;
-    glGetIntegerv(GL_ACTIVE_TEXTURE, &activeTex);
+	GLint activeTex = 0;
+	glGetIntegerv(GL_ACTIVE_TEXTURE, &activeTex);
 
-    glEnable(GL_PER_STAGE_CONSTANTS_NV); // should we require apps to do this?
-    if(c)
-        for_each(c->begin(), c->end(), set_constants());
-    if(a)
-        for_each(a->begin(), a->end(), set_texture_shaders(c));
-    glActiveTextureARB( GL_TEXTURE0_ARB );
-    int numCombiners = 0;
-    list<vector<string> >::iterator it = b->begin();
-    for(; it!=b->end(); ++it) {
-      if ( (*it)[0] != "+" )
-        numCombiners++;
-    }
+	glEnable(GL_PER_STAGE_CONSTANTS_NV); // should we require apps to do this?
+	if (c)
+		for_each(c->begin(), c->end(), set_constants());
+	if (a)
+		for_each(a->begin(), a->end(), set_texture_shaders(c));
+	glActiveTextureARB(GL_TEXTURE0_ARB);
+	int numCombiners = 0;
+	if(b)
+	{
+		list<vector<string> >::iterator it = b->begin();
+		for (; it != b->end(); ++it) {
+			if ((*it)[0] != "+")
+				numCombiners++;
+		}
+	}
     glCombinerParameteriNV(GL_NUM_GENERAL_COMBINERS_NV, numCombiners);
     if(b)
         for_each(b->begin(), b->end(), set_register_combiners());

--- a/RenderSystems/GL/src/nvparse/ps1.0_program.cpp
+++ b/RenderSystems/GL/src/nvparse/ps1.0_program.cpp
@@ -920,14 +920,14 @@ void ps10::invoke(vector<constdef> * c,
 		for_each(a->begin(), a->end(), set_texture_shaders(c));
 	glActiveTextureARB(GL_TEXTURE0_ARB);
 	int numCombiners = 0;
-	if(b)
-	{
-		list<vector<string> >::iterator it = b->begin();
-		for (; it != b->end(); ++it) {
-			if ((*it)[0] != "+")
-				numCombiners++;
-		}
-	}
+    if(b)
+    {
+        list<vector<string> >::iterator it = b->begin();
+        for (; it != b->end(); ++it) {
+            if ((*it)[0] != "+")
+                numCombiners++;
+        }
+    }
     glCombinerParameteriNV(GL_NUM_GENERAL_COMBINERS_NV, numCombiners);
     if(b)
         for_each(b->begin(), b->end(), set_register_combiners());


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.
Warning:
- [V535](https://www.viva64.com/en/w/v535/) The variable 'i' is being used for this loop and for the outer loop. Check lines: 515, 594. [ogreedgelistbuilder.cpp 594](https://github.com/OGRECave/ogre/blob/master/OgreMain/src/OgreEdgeListBuilder.cpp#L594)