### PR TITLE
Resolved InstanceManager using invalid render operation when all batc…

### DIFF
--- a/OgreMain/src/OgreInstanceManager.cpp
+++ b/OgreMain/src/OgreInstanceManager.cpp
@@ -174,7 +174,8 @@ namespace Ogre
     {
         InstanceBatch *instanceBatch;
 
-        if( mInstanceBatches.empty() )
+        if( mInstanceBatches.empty() ||
+            (mInstanceBatches[materialName].size () == 0))
             instanceBatch = buildNewBatch( materialName, true );
         else
             instanceBatch = getFreeBatch( materialName );


### PR DESCRIPTION
…hes removed

Added check for empty batch list so render operation is recreated with
the 'first' batch is created again.