### PR TITLE
Fixed issue with indices.

### DIFF
--- a/OgreMain/src/OgreInstanceManager.cpp
+++ b/OgreMain/src/OgreInstanceManager.cpp
@@ -528,7 +528,9 @@ namespace Ogre
             TIndexType index = data[i];
             if (indicesMap.find(index) == indicesMap.end()) 
             {
-                indicesMap[index] = (uint32)(indicesMap.size());
+                //We need to guarantee that the size is read before an entry is added, hence these are on separate lines.
+                uint32 size = (uint32)(indicesMap.size());
+                indicesMap[index] = size;
             }
         }
 


### PR DESCRIPTION
Depending on the compiler, inserting into a map while reading the size
of in the same line produces different results. So on some machines the
indices would be messed up if a mesh with shared vertex data was used.

See https://blog.jayway.com/2015/09/08/undefined-behaviour-in-c-when-adding-to-map/ for more info.