### PR TITLE
OgreTerrainGroup thread safety regarding Terrain creation

### DIFF
--- a/Components/Terrain/include/OgreTerrainGroup.h
+++ b/Components/Terrain/include/OgreTerrainGroup.h
@@ -512,8 +512,17 @@ namespace Ogre
         void autoUpdateLod(long x, long y, bool synchronous, const Any &data);
         void autoUpdateLodAll(bool synchronous, const Any &data);
 
+        /** Get the number of terrains that are still waiting for the Terrain::prepare() to be called.
+         *
+         * @note Terrain::prepare() happens in background thread so the actual call will be completed
+         *       a bit before this returns the reduced number.
+         *
+         * @return Amount of terrain prepare requests pending.
+         */
+        size_t getNumTerrainPrepareRequests() const;
+
     protected:
-        typedef std::map<Terrain*, bool> TerrainLoadRequestMap;
+        typedef std::map<TerrainSlot*, WorkQueue::RequestID> TerrainPrepareRequestMap;
         SceneManager *mSceneManager;
         Terrain::Alignment mAlignment;
         uint16 mTerrainSize;
@@ -521,7 +530,7 @@ namespace Ogre
         Terrain::ImportData mDefaultImportData;
         Vector3 mOrigin;
         TerrainSlotMap mTerrainSlots;
-        TerrainLoadRequestMap mTerrainLoadRequests;
+        TerrainPrepareRequestMap mTerrainPrepareRequests;
         uint16 mWorkQueueChannel;
         String mFilenamePrefix;
         String mFilenameExtension;
@@ -544,7 +553,6 @@ namespace Ogre
         {
             TerrainSlot* slot;
             TerrainGroup* origin;
-            static uint loadingTaskNum;
             _OgreTerrainExport friend std::ostream& operator<<(std::ostream& o, const LoadRequest& r)
             { return o; }       
         };

--- a/Components/Terrain/include/OgreTerrainGroup.h
+++ b/Components/Terrain/include/OgreTerrainGroup.h
@@ -513,6 +513,7 @@ namespace Ogre
         void autoUpdateLodAll(bool synchronous, const Any &data);
 
     protected:
+        typedef std::map<Terrain*, bool> TerrainLoadRequestMap;
         SceneManager *mSceneManager;
         Terrain::Alignment mAlignment;
         uint16 mTerrainSize;
@@ -520,6 +521,7 @@ namespace Ogre
         Terrain::ImportData mDefaultImportData;
         Vector3 mOrigin;
         TerrainSlotMap mTerrainSlots;
+        TerrainLoadRequestMap mTerrainLoadRequests;
         uint16 mWorkQueueChannel;
         String mFilenamePrefix;
         String mFilenameExtension;
@@ -532,6 +534,7 @@ namespace Ogre
         /// Retrieve a slot, potentially allocate one
         TerrainSlot* getTerrainSlot(long x, long y, bool createIfMissing);
         TerrainSlot* getTerrainSlot(long x, long y) const;
+        void freeTerrainSlotInstance(TerrainSlot* slot);
         void connectNeighbour(TerrainSlot* slot, long offsetx, long offsety);
 
         void loadTerrainImpl(TerrainSlot* slot, bool synchronous);

--- a/Components/Terrain/src/OgreTerrainGroup.cpp
+++ b/Components/Terrain/src/OgreTerrainGroup.cpp
@@ -709,6 +709,7 @@ namespace Ogre
         if (it == mTerrainPrepareRequests.end())
         {
             freeTerrainSlotInstance(lreq.slot);
+            return;
         }
         else
         {

--- a/OgreMain/include/OgreWorkQueue.h
+++ b/OgreMain/include/OgreWorkQueue.h
@@ -280,6 +280,15 @@ namespace Ogre
         */
         virtual void abortRequest(RequestID id) = 0;
 
+        /** Abort request if it is not being processed currently.
+         *
+         * @param id The ID of the previously issued request.
+         *
+         * @retval true If request was aborted successfully.
+         * @retval false If request is already being processed so it can not be aborted.
+         */
+        virtual bool abortPendingRequest(RequestID id) = 0;
+
         /** Abort all previously issued requests in a given channel.
         Any requests still waiting to be processed of the given channel, will be 
         removed from the queue.
@@ -436,6 +445,8 @@ namespace Ogre
             bool forceSynchronous = false, bool idleThread = false);
         /// @copydoc WorkQueue::abortRequest
         virtual void abortRequest(RequestID id);
+        /// @copydoc WorkQueue::abortPendingRequest
+        virtual bool abortPendingRequest(RequestID id);
         /// @copydoc WorkQueue::abortRequestsByChannel
         virtual void abortRequestsByChannel(uint16 channel);
         /// @copydoc WorkQueue::abortPendingRequestsByChannel

--- a/OgreMain/src/OgreWorkQueue.cpp
+++ b/OgreMain/src/OgreWorkQueue.cpp
@@ -323,6 +323,35 @@ namespace Ogre {
         }
     }
     //---------------------------------------------------------------------
+    bool DefaultWorkQueueBase::abortPendingRequest(RequestID id)
+    {
+        // Request should not exist in idle queue and request queue simultaneously.
+        {
+            OGRE_WQ_LOCK_MUTEX(mRequestMutex);
+            for (RequestQueue::iterator i = mRequestQueue.begin(); i != mRequestQueue.end(); ++i)
+            {
+                if ((*i)->getID() == id)
+                {
+                    (*i)->abortRequest();
+                    return true;
+                }
+            }
+        }
+        {
+            OGRE_WQ_LOCK_MUTEX(mIdleMutex);
+            for (RequestQueue::iterator i = mIdleRequestQueue.begin(); i != mIdleRequestQueue.end(); ++i)
+            {
+                if ((*i)->getID() == id)
+                {
+                    (*i)->abortRequest();
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+    //---------------------------------------------------------------------
     void DefaultWorkQueueBase::abortRequestsByChannel(uint16 channel)
     {
             OGRE_WQ_LOCK_MUTEX(mProcessMutex);


### PR DESCRIPTION
TerrainGroup will use Terrain instance inside thread but allows destroying it while it's being processed in the thread.