### PR TITLE
Specify that constants are ULL.

### DIFF
--- a/OgreMain/src/OgrePixelFormatDescriptions.h
+++ b/OgreMain/src/OgrePixelFormatDescriptions.h
@@ -760,7 +760,7 @@ namespace Ogre {
             /* rbits, gbits, bbits, abits */
             16, 16, 16, 0,
             /* Masks and shifts */
-            0xFFFF00000000, 0x0000FFFF0000, 0x00000000FFFF, 0,
+            0xFFFF00000000ULL, 0x0000FFFF0000ULL, 0x00000000FFFFULL, 0,
             32, 16, 0, 0
         },
         //-----------------------------------------------------------------------
@@ -774,7 +774,7 @@ namespace Ogre {
             /* rbits, gbits, bbits, abits */
             16, 16, 16, 16,
             /* Masks and shifts */
-            0xFFFF000000000000, 0x0000FFFF00000000, 0x00000000FFFF0000, 0x000000000000FFFF,
+            0xFFFF000000000000ULL, 0x0000FFFF00000000ULL, 0x00000000FFFF0000ULL, 0x000000000000FFFFULL,
             48, 32, 16, 0
         },
         //-----------------------------------------------------------------------
@@ -802,7 +802,7 @@ namespace Ogre {
             /* rbits, gbits, bbits, abits */
             32, 32, 0, 0,
             /* Masks and shifts */
-            0xFFFFFFFF00000000, 0xFFFFFFFF, 0, 0,
+            0xFFFFFFFF00000000ULL, 0xFFFFFFFFULL, 0, 0,
             32, 0, 0, 0
         },
         //-----------------------------------------------------------------------
@@ -928,7 +928,7 @@ namespace Ogre {
             /* rbits, gbits, bbits, abits */
             16, 16, 16, 0,
             /* Masks and shifts */
-            0xFFFF00000000, 0x0000FFFF0000, 0x00000000FFFF, 0,
+            0xFFFF00000000ULL, 0x0000FFFF0000ULL, 0x00000000FFFFULL, 0,
             32, 16, 0, 0
         },
         //-----------------------------------------------------------------------
@@ -942,7 +942,7 @@ namespace Ogre {
             /* rbits, gbits, bbits, abits */
             16, 16, 16, 16,
             /* Masks and shifts */
-            0xFFFF000000000000, 0x0000FFFF00000000, 0x00000000FFFF0000, 0x000000000000FFFF,
+            0xFFFF000000000000ULL, 0x0000FFFF00000000ULL, 0x00000000FFFF0000ULL, 0x000000000000FFFFULL,
             48, 32, 16, 0
         },
         //-----------------------------------------------------------------------
@@ -970,7 +970,7 @@ namespace Ogre {
             /* rbits, gbits, bbits, abits */
             32, 32, 0, 0,
             /* Masks and shifts */
-            0xFFFFFFFF00000000, 0xFFFFFFFF, 0, 0,
+            0xFFFFFFFF00000000ULL, 0xFFFFFFFFULL, 0, 0,
             32, 0, 0, 0
         },
         //-----------------------------------------------------------------------
@@ -1242,7 +1242,7 @@ namespace Ogre {
             /* rbits, gbits, bbits, abits */
             16, 16, 16, 0,
             /* Masks and shifts */
-            0xFFFF00000000, 0x0000FFFF0000, 0x00000000FFFF, 0,
+            0xFFFF00000000ULL, 0x0000FFFF0000ULL, 0x00000000FFFFULL, 0,
             32, 16, 0, 0
         },
         //-----------------------------------------------------------------------
@@ -1256,7 +1256,7 @@ namespace Ogre {
             /* rbits, gbits, bbits, abits */
             16, 16, 16, 16,
             /* Masks and shifts */
-            0xFFFF000000000000, 0x0000FFFF00000000, 0x00000000FFFF0000, 0x000000000000FFFF,
+            0xFFFF000000000000ULL, 0x0000FFFF00000000ULL, 0x00000000FFFF0000ULL, 0x000000000000FFFFULL,
             48, 32, 16, 0
         },
         


### PR DESCRIPTION
Needed for older compilers.