### PR TITLE
Android Build SampleBrowser library using CMake instead of android makefiles

### DIFF
--- a/CMake/Utils/AndroidMacros.cmake
+++ b/CMake/Utils/AndroidMacros.cmake
@@ -8,23 +8,25 @@
 #-------------------------------------------------------------------
 
 
-if(NOT TARGET cpufeatures)
-    add_library(cpufeatures STATIC ${ANDROID_NDK}/sources/android/cpufeatures/cpu-features.c)
-    target_link_libraries(cpufeatures dl)
-endif(NOT TARGET cpufeatures)
+if(OGRE_BUILD_ANDROID_JNI_LIBS_CMAKE)
+    if(NOT TARGET cpufeatures)
+        add_library(cpufeatures STATIC ${ANDROID_NDK}/sources/android/cpufeatures/cpu-features.c)
+        target_link_libraries(cpufeatures dl)
+    endif(NOT TARGET cpufeatures)
 
-if(NOT TARGET native_app_glue)
-    add_library(native_app_glue STATIC ${ANDROID_NDK}/sources/android/native_app_glue/android_native_app_glue.c)
-    target_link_libraries(native_app_glue log)
-endif(NOT TARGET native_app_glue)
+    if(NOT TARGET native_app_glue)
+        add_library(native_app_glue STATIC ${ANDROID_NDK}/sources/android/native_app_glue/android_native_app_glue.c)
+        target_link_libraries(native_app_glue log)
+    endif(NOT TARGET native_app_glue)
 
-macro(add_ndk_cpufeatures_includes)
-    include_directories(${ANDROID_NDK}/sources/android/cpufeatures)
-endmacro(add_ndk_cpufeatures_includes)
+    macro(add_ndk_cpufeatures_includes)
+        include_directories(${ANDROID_NDK}/sources/android/cpufeatures)
+    endmacro(add_ndk_cpufeatures_includes)
 
-macro(add_ndk_native_app_glue_includes)
-    include_directories(${ANDROID_NDK}/sources/android/native_app_glue)
-endmacro(add_ndk_native_app_glue_includes)
+    macro(add_ndk_native_app_glue_includes)
+        include_directories(${ANDROID_NDK}/sources/android/native_app_glue)
+    endmacro(add_ndk_native_app_glue_includes)
+endif(OGRE_BUILD_ANDROID_JNI_LIBS_CMAKE)
 
 macro(add_static_libs LIB_DIR)
     foreach(LIB_NAME ${ARGN})

--- a/CMake/Utils/AndroidMacros.cmake
+++ b/CMake/Utils/AndroidMacros.cmake
@@ -8,25 +8,23 @@
 #-------------------------------------------------------------------
 
 
-if(OGRE_BUILD_ANDROID_JNI_LIBS_CMAKE)
-    if(NOT TARGET cpufeatures)
-        add_library(cpufeatures STATIC ${ANDROID_NDK}/sources/android/cpufeatures/cpu-features.c)
-        target_link_libraries(cpufeatures dl)
-    endif(NOT TARGET cpufeatures)
+if(NOT TARGET cpufeatures)
+    add_library(cpufeatures STATIC ${ANDROID_NDK}/sources/android/cpufeatures/cpu-features.c)
+    target_link_libraries(cpufeatures dl)
+endif(NOT TARGET cpufeatures)
 
-    if(NOT TARGET native_app_glue)
-        add_library(native_app_glue STATIC ${ANDROID_NDK}/sources/android/native_app_glue/android_native_app_glue.c)
-        target_link_libraries(native_app_glue log)
-    endif(NOT TARGET native_app_glue)
+if(NOT TARGET native_app_glue)
+    add_library(native_app_glue STATIC ${ANDROID_NDK}/sources/android/native_app_glue/android_native_app_glue.c)
+    target_link_libraries(native_app_glue log)
+endif(NOT TARGET native_app_glue)
 
-    macro(add_ndk_cpufeatures_includes)
-        include_directories(${ANDROID_NDK}/sources/android/cpufeatures)
-    endmacro(add_ndk_cpufeatures_includes)
+macro(add_ndk_cpufeatures_includes)
+    include_directories(${ANDROID_NDK}/sources/android/cpufeatures)
+endmacro(add_ndk_cpufeatures_includes)
 
-    macro(add_ndk_native_app_glue_includes)
-        include_directories(${ANDROID_NDK}/sources/android/native_app_glue)
-    endmacro(add_ndk_native_app_glue_includes)
-endif(OGRE_BUILD_ANDROID_JNI_LIBS_CMAKE)
+macro(add_ndk_native_app_glue_includes)
+    include_directories(${ANDROID_NDK}/sources/android/native_app_glue)
+endmacro(add_ndk_native_app_glue_includes)
 
 macro(add_static_libs LIB_DIR)
     foreach(LIB_NAME ${ARGN})

--- a/CMake/Utils/AndroidMacros.cmake
+++ b/CMake/Utils/AndroidMacros.cmake
@@ -8,6 +8,18 @@
 #-------------------------------------------------------------------
 
 
+if(NOT TARGET cpufeatures)
+    include_directories(${ANDROID_NDK}/sources/android/cpufeatures)
+    add_library(cpufeatures STATIC ${ANDROID_NDK}/sources/android/cpufeatures/cpu-features.c)
+    target_link_libraries(cpufeatures dl)
+endif(NOT TARGET cpufeatures)
+
+if(NOT TARGET native_app_glue)
+    include_directories(${ANDROID_NDK}/sources/android/native_app_glue)
+    add_library(native_app_glue STATIC ${ANDROID_NDK}/sources/android/native_app_glue/android_native_app_glue.c)
+    target_link_libraries(native_app_glue log)
+endif(NOT TARGET native_app_glue)
+
 macro(add_static_libs LIB_DIR)
     foreach(LIB_NAME ${ARGN})
         SET(HEADERS "${HEADERS}# ${LIB_NAME}\n\tinclude $(CLEAR_VARS)\n\tLOCAL_MODULE    := ${LIB_NAME}\n\tLOCAL_SRC_FILES := ${LIB_DIR}/lib${LIB_NAME}.a\n\tinclude $(PREBUILT_STATIC_LIBRARY)\n\n")

--- a/CMake/Utils/AndroidMacros.cmake
+++ b/CMake/Utils/AndroidMacros.cmake
@@ -9,16 +9,22 @@
 
 
 if(NOT TARGET cpufeatures)
-    include_directories(${ANDROID_NDK}/sources/android/cpufeatures)
     add_library(cpufeatures STATIC ${ANDROID_NDK}/sources/android/cpufeatures/cpu-features.c)
     target_link_libraries(cpufeatures dl)
 endif(NOT TARGET cpufeatures)
 
 if(NOT TARGET native_app_glue)
-    include_directories(${ANDROID_NDK}/sources/android/native_app_glue)
     add_library(native_app_glue STATIC ${ANDROID_NDK}/sources/android/native_app_glue/android_native_app_glue.c)
     target_link_libraries(native_app_glue log)
 endif(NOT TARGET native_app_glue)
+
+macro(add_ndk_cpufeatures_includes)
+    include_directories(${ANDROID_NDK}/sources/android/cpufeatures)
+endmacro(add_ndk_cpufeatures_includes)
+
+macro(add_ndk_native_app_glue_includes)
+    include_directories(${ANDROID_NDK}/sources/android/native_app_glue)
+endmacro(add_ndk_native_app_glue_includes)
 
 macro(add_static_libs LIB_DIR)
     foreach(LIB_NAME ${ARGN})

--- a/CMake/Utils/AndroidMacros.cmake
+++ b/CMake/Utils/AndroidMacros.cmake
@@ -7,23 +7,20 @@
 # free to make use of it in any way you like.
 #-------------------------------------------------------------------
 
-
-if(NOT TARGET cpufeatures)
-    add_library(cpufeatures STATIC ${ANDROID_NDK}/sources/android/cpufeatures/cpu-features.c)
-    target_link_libraries(cpufeatures dl)
-endif(NOT TARGET cpufeatures)
-
-if(NOT TARGET native_app_glue)
-    add_library(native_app_glue STATIC ${ANDROID_NDK}/sources/android/native_app_glue/android_native_app_glue.c)
-    target_link_libraries(native_app_glue log)
-endif(NOT TARGET native_app_glue)
-
 macro(add_ndk_cpufeatures_includes)
     include_directories(${ANDROID_NDK}/sources/android/cpufeatures)
+    if(NOT TARGET cpufeatures)
+        add_library(cpufeatures STATIC ${ANDROID_NDK}/sources/android/cpufeatures/cpu-features.c)
+        target_link_libraries(cpufeatures dl)
+    endif(NOT TARGET cpufeatures)
 endmacro(add_ndk_cpufeatures_includes)
 
 macro(add_ndk_native_app_glue_includes)
     include_directories(${ANDROID_NDK}/sources/android/native_app_glue)
+    if(NOT TARGET native_app_glue)
+        add_library(native_app_glue STATIC ${ANDROID_NDK}/sources/android/native_app_glue/android_native_app_glue.c)
+        target_link_libraries(native_app_glue log)
+    endif(NOT TARGET native_app_glue)
 endmacro(add_ndk_native_app_glue_includes)
 
 macro(add_static_libs LIB_DIR)

--- a/CMake/Utils/AndroidMacros.cmake
+++ b/CMake/Utils/AndroidMacros.cmake
@@ -7,21 +7,21 @@
 # free to make use of it in any way you like.
 #-------------------------------------------------------------------
 
-macro(add_ndk_cpufeatures_includes)
+macro(add_ndk_cpufeatures_library)
     include_directories(${ANDROID_NDK}/sources/android/cpufeatures)
     if(NOT TARGET cpufeatures)
         add_library(cpufeatures STATIC ${ANDROID_NDK}/sources/android/cpufeatures/cpu-features.c)
         target_link_libraries(cpufeatures dl)
     endif(NOT TARGET cpufeatures)
-endmacro(add_ndk_cpufeatures_includes)
+endmacro(add_ndk_cpufeatures_library)
 
-macro(add_ndk_native_app_glue_includes)
+macro(add_ndk_native_app_glue_library)
     include_directories(${ANDROID_NDK}/sources/android/native_app_glue)
     if(NOT TARGET native_app_glue)
         add_library(native_app_glue STATIC ${ANDROID_NDK}/sources/android/native_app_glue/android_native_app_glue.c)
         target_link_libraries(native_app_glue log)
     endif(NOT TARGET native_app_glue)
-endmacro(add_ndk_native_app_glue_includes)
+endmacro(add_ndk_native_app_glue_library)
 
 macro(add_static_libs LIB_DIR)
     foreach(LIB_NAME ${ARGN})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,7 +269,6 @@ elseif (ANDROID)
   set(OGRE_PLATFORM OGRE_PLATFORM_ANDROID)
   set(OGRE_CONFIG_ENABLE_VIEWPORT_ORIENTATIONMODE FALSE CACHE BOOL "Disable viewport orientation Android" FORCE)
   option(OGRE_BUILD_ANDROID_JNI_SAMPLE "Enable JNI Sample" FALSE)
-  option(OGRE_BUILD_ANDROID_JNI_LIBS_CMAKE "Build native android JNI libs using CMake instead of android makefiles [BETA]" FALSE)
 
   set(OGRE_BUILD_RENDERSYSTEM_GLES2 TRUE CACHE BOOL "Forcing OpenGL ES 2 RenderSystem for Android" FORCE)
   set(OGRE_BUILD_RENDERSYSTEM_GLES FALSE CACHE BOOL "Disable OpenGL ES 1 RenderSystem for Android" FORCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,6 +269,7 @@ elseif (ANDROID)
   set(OGRE_PLATFORM OGRE_PLATFORM_ANDROID)
   set(OGRE_CONFIG_ENABLE_VIEWPORT_ORIENTATIONMODE FALSE CACHE BOOL "Disable viewport orientation Android" FORCE)
   option(OGRE_BUILD_ANDROID_JNI_SAMPLE "Enable JNI Sample" FALSE)
+  option(OGRE_BUILD_ANDROID_JNI_LIBS_CMAKE "Build native android JNI libs using CMake instead of android makefiles [BETA]" FALSE)
 
   set(OGRE_BUILD_RENDERSYSTEM_GLES2 TRUE CACHE BOOL "Forcing OpenGL ES 2 RenderSystem for Android" FORCE)
   set(OGRE_BUILD_RENDERSYSTEM_GLES FALSE CACHE BOOL "Disable OpenGL ES 1 RenderSystem for Android" FORCE)

--- a/Samples/Browser/CMakeLists.txt
+++ b/Samples/Browser/CMakeLists.txt
@@ -10,14 +10,14 @@
 # Configure Browser demo build
 
 set (HEADER_FILES
-	include/SampleBrowser.h
+	${OGRE_SOURCE_DIR}/Samples/Browser/include/SampleBrowser.h
 	${OGRE_SOURCE_DIR}/Samples/Common/include/Sample.h
 	${OGRE_SOURCE_DIR}/Samples/Common/include/SampleContext.h
 	${OGRE_SOURCE_DIR}/Samples/Common/include/SamplePlugin.h
 	${OGRE_SOURCE_DIR}/Samples/Common/include/SdkSample.h
 )
 
-set(SOURCE_FILES src/SampleBrowser.cpp)
+set(SOURCE_FILES ${OGRE_SOURCE_DIR}/Samples/Browser/src/SampleBrowser.cpp)
 
 # Get the list of configured samples
 get_property(OGRE_SAMPLES_LIST GLOBAL PROPERTY "OGRE_SAMPLES_LIST")
@@ -43,20 +43,20 @@ endif ()
 
 if (APPLE AND APPLE_IOS)
   set(HEADER_FILES ${HEADER_FILES}
-    include/SampleBrowser_iOS.h
+    ${OGRE_SOURCE_DIR}/Samples/Browser/include/SampleBrowser_iOS.h
   )
 elseif (OGRE_BUILD_PLATFORM_NACL)
   set(HEADER_FILES ${HEADER_FILES}
-    include/SampleBrowser_NaCl.h
+    ${OGRE_SOURCE_DIR}/Samples/Browser/include/SampleBrowser_NaCl.h
   )
 elseif (APPLE)
   set(HEADER_FILES ${HEADER_FILES}
-    include/SampleBrowser_OSX.h
+    ${OGRE_SOURCE_DIR}/Samples/Browser/include/SampleBrowser_OSX.h
 	${OGRE_SOURCE_DIR}/Samples/Common/misc/SampleBrowser_OSX.icns
   )
 elseif (ANDROID)
   set(HEADER_FILES ${HEADER_FILES}
-    include/SampleBrowser_Android.h)
+    ${OGRE_SOURCE_DIR}/Samples/Browser/include/SampleBrowser_Android.h)
 endif (APPLE AND APPLE_IOS)
 
 
@@ -186,7 +186,7 @@ if (ANDROID)
     add_ndk_cpufeatures_library()
     add_ndk_native_app_glue_library()
 
-    set(SOURCE_FILES ${SOURCE_FILES} src/gestureDetector.cpp)
+    set(SOURCE_FILES ${SOURCE_FILES} ${OGRE_SOURCE_DIR}/Samples/Browser/src/gestureDetector.cpp)
 
     ogre_add_library(SampleBrowser SHARED ${HEADER_FILES} ${SOURCE_FILES} ${RESOURCE_FILES})
 else()

--- a/Samples/Browser/CMakeLists.txt
+++ b/Samples/Browser/CMakeLists.txt
@@ -422,6 +422,7 @@ if (ANDROID)
     file(MAKE_DIRECTORY "${NDKOUT}/libs")
     file(MAKE_DIRECTORY "${NDKOUT}/libs/${ANDROID_NDK_ABI_NAME}")
     set_target_properties(SampleBrowser PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${NDKOUT}/libs/${ANDROID_NDK_ABI_NAME}")
+    set_target_properties(SampleBrowser PROPERTIES OUTPUT_NAME "OgreSampleBrowser")
 
     file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/dummy.cpp "int x = 0;")
     ogre_add_library_to_folder(Samples SampleBrowserDummy SHARED ${CMAKE_CURRENT_BINARY_DIR}/dummy.cpp)

--- a/Samples/Browser/CMakeLists.txt
+++ b/Samples/Browser/CMakeLists.txt
@@ -170,7 +170,7 @@ if (WINDOWS_STORE OR WINDOWS_PHONE)
 endif()
 
 
-if(ANDROID)
+if(ANDROID AND NOT OGRE_BUILD_ANDROID_JNI_LIBS_CMAKE)
     include(AndroidMacros)
     
     SET(ANDROID_MOD_NAME "OgreSampleBrowser")
@@ -225,7 +225,15 @@ if (OGRE_BUILD_RENDERSYSTEM_D3D9 AND OGRE_STATIC)
     link_directories(${DirectX9_LIBRARY_DIR})
 endif()
 
-ogre_add_executable(SampleBrowser WIN32 ${HEADER_FILES} ${SOURCE_FILES} ${RESOURCE_FILES})
+if (ANDROID)
+    include(AndroidMacros) # makes libraries native_app_glue and cpufeatures available
+
+    set(SOURCE_FILES src/gestureDetector.cpp)
+
+    ogre_add_library(SampleBrowser SHARED ${HEADER_FILES} ${SOURCE_FILES} ${RESOURCE_FILES})
+else()
+    ogre_add_executable(SampleBrowser WIN32 ${HEADER_FILES} ${SOURCE_FILES} ${RESOURCE_FILES})
+endif()
 
 # Fix for static build with MinGW
 if (OGRE_BUILD_RENDERSYSTEM_D3D9 AND OGRE_STATIC)
@@ -233,6 +241,10 @@ if (OGRE_BUILD_RENDERSYSTEM_D3D9 AND OGRE_STATIC)
 endif()
 
 target_link_libraries(SampleBrowser ${OGRE_LIBRARIES} ${OGRE_PLUGIN_LIBRARIES} ${SDL2_LIBRARY} ${SAMPLE_LIBRARIES} OgreBites)
+
+if(ANDROID)
+    target_link_libraries(SampleBrowser native_app_glue cpufeatures android c m dl z log EGL GLESv2)
+endif()
 
 # Add samples as dependencies
 add_dependencies(SampleBrowser ${OGRE_SAMPLES_LIST})
@@ -408,4 +420,4 @@ if (OGRE_INSTALL_SAMPLES)
 			)
 	endif ()
 endif ()
-endif(ANDROID)
+endif(ANDROID AND NOT OGRE_BUILD_ANDROID_JNI_LIBS_CMAKE)

--- a/Samples/Browser/CMakeLists.txt
+++ b/Samples/Browser/CMakeLists.txt
@@ -408,6 +408,28 @@ if (APPLE)
 
 endif (APPLE)
 
+if (ANDROID)
+    SET(ANDROID_MOD_NAME "OgreSampleBrowser")
+    SET(NDKOUT "${CMAKE_BINARY_DIR}/SampleBrowserNDK")
+    SET(PKG_NAME "org.ogre.browser")
+    SET(HAS_CODE "false")
+    SET(MAIN_ACTIVITY "android.app.NativeActivity")
+    SET(HEADERS "")
+    SET(SAMPLE_LDLIBS "")
+
+    copy_assets_to_android_proj()
+
+    file(MAKE_DIRECTORY "${NDKOUT}/libs")
+    file(MAKE_DIRECTORY "${NDKOUT}/libs/${ANDROID_NDK_ABI_NAME}")
+    set_target_properties(SampleBrowser PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${NDKOUT}/libs/${ANDROID_NDK_ABI_NAME}")
+
+    file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/dummy.cpp "int x = 0;")
+    ogre_add_library_to_folder(Samples SampleBrowserDummy SHARED ${CMAKE_CURRENT_BINARY_DIR}/dummy.cpp)
+
+    create_android_proj(SampleBrowserDummy)
+    # this whole part should be simplified more
+endif(ANDROID)
+
 if (OGRE_INSTALL_SAMPLES)
 	ogre_install_target(SampleBrowser "" FALSE)
 	if (OGRE_INSTALL_PDB)

--- a/Samples/Browser/CMakeLists.txt
+++ b/Samples/Browser/CMakeLists.txt
@@ -231,7 +231,7 @@ if (ANDROID)
     add_ndk_cpufeatures_includes()
     add_ndk_native_app_glue_includes()
 
-    set(SOURCE_FILES src/gestureDetector.cpp)
+    set(SOURCE_FILES ${SOURCE_FILES} src/gestureDetector.cpp)
 
     ogre_add_library(SampleBrowser SHARED ${HEADER_FILES} ${SOURCE_FILES} ${RESOURCE_FILES})
 else()

--- a/Samples/Browser/CMakeLists.txt
+++ b/Samples/Browser/CMakeLists.txt
@@ -226,10 +226,10 @@ if (OGRE_BUILD_RENDERSYSTEM_D3D9 AND OGRE_STATIC)
 endif()
 
 if (ANDROID)
-    include(AndroidMacros) # makes libraries native_app_glue and cpufeatures available
+    include(AndroidMacros)
 
-    add_ndk_cpufeatures_includes()
-    add_ndk_native_app_glue_includes()
+    add_ndk_cpufeatures_library()
+    add_ndk_native_app_glue_library()
 
     set(SOURCE_FILES ${SOURCE_FILES} src/gestureDetector.cpp)
 

--- a/Samples/Browser/CMakeLists.txt
+++ b/Samples/Browser/CMakeLists.txt
@@ -228,6 +228,9 @@ endif()
 if (ANDROID)
     include(AndroidMacros) # makes libraries native_app_glue and cpufeatures available
 
+    add_ndk_cpufeatures_includes()
+    add_ndk_native_app_glue_includes()
+
     set(SOURCE_FILES src/gestureDetector.cpp)
 
     ogre_add_library(SampleBrowser SHARED ${HEADER_FILES} ${SOURCE_FILES} ${RESOURCE_FILES})

--- a/Samples/Browser/CMakeLists.txt
+++ b/Samples/Browser/CMakeLists.txt
@@ -246,7 +246,7 @@ endif()
 target_link_libraries(SampleBrowser ${OGRE_LIBRARIES} ${OGRE_PLUGIN_LIBRARIES} ${SDL2_LIBRARY} ${SAMPLE_LIBRARIES} OgreBites)
 
 if(ANDROID)
-    target_link_libraries(SampleBrowser native_app_glue cpufeatures android c m dl z log EGL GLESv2)
+    target_link_libraries(SampleBrowser native_app_glue cpufeatures android c m dl z log EGL GLESv2 "-u ANativeActivity_onCreate")
 endif()
 
 # Add samples as dependencies

--- a/Samples/Browser/CMakeLists.txt
+++ b/Samples/Browser/CMakeLists.txt
@@ -427,10 +427,7 @@ if (ANDROID)
     set_target_properties(SampleBrowser PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${NDKOUT}/libs/${ANDROID_NDK_ABI_NAME}")
     set_target_properties(SampleBrowser PROPERTIES OUTPUT_NAME "OgreSampleBrowser")
 
-    file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/dummy.cpp "int x = 0;")
-    ogre_add_library_to_folder(Samples SampleBrowserDummy SHARED ${CMAKE_CURRENT_BINARY_DIR}/dummy.cpp)
-
-    create_android_proj(SampleBrowserDummy)
+    create_android_proj(SampleBrowser)
     # this whole part should be simplified more
 endif(ANDROID)
 

--- a/Samples/Browser/CMakeLists.txt
+++ b/Samples/Browser/CMakeLists.txt
@@ -169,51 +169,6 @@ if (WINDOWS_STORE OR WINDOWS_PHONE)
 
 endif()
 
-
-if(ANDROID AND NOT OGRE_BUILD_ANDROID_JNI_LIBS_CMAKE)
-    include(AndroidMacros)
-    
-    SET(ANDROID_MOD_NAME "OgreSampleBrowser")
-    SET(JNI_PATH "${CMAKE_SOURCE_DIR}/Samples/Browser/src")
-    SET(JNI_SRC_FILES "SampleBrowser.cpp gestureDetector.cpp")
-    
-    SET(NDKOUT "${CMAKE_BINARY_DIR}/SampleBrowserNDK")
-    
-    # Force export ANativeActivity_onCreate()  
-    # Refer to: https://github.com/android-ndk/ndk/issues/381.
-    # Only needed when building with NDK-R14 and older
-    SET(OGRE_ANDROID_LDFLAGS "-u ANativeActivity_onCreate")
-
-    SET(PKG_NAME "org.ogre.browser")
-    # Set this variable to false if no java code will be present (google android:hasCode for more info)
-    SET(HAS_CODE "false")
-    
-    SET(MAIN_ACTIVITY "android.app.NativeActivity")
-    SET(HEADERS "")
-    SET(SAMPLE_LDLIBS "android_native_app_glue")
-    
-    add_static_libs("${OGRE_BINARY_DIR}/lib" "Sample_Water" "Sample_Ocean" "Sample_NewInstancing" "Sample_ShaderSystem" "Sample_DeferredShading" "Sample_EndlessWorld" "Sample_VolumeCSG" "Sample_VolumeTerrain" "Sample_Terrain" "Sample_ShaderSystemMultiLight" "Sample_ShaderSystemTexturedFog")
-	add_static_libs("${OGRE_BINARY_DIR}/lib" "Sample_FacialAnimation" "Sample_Fresnel" "Sample_Grass" "Sample_ParticleFX" "Sample_MeshLod" "Sample_SkyBox" "Sample_SkyPlane" "Sample_SkyDome" "Sample_Smoke")
-	add_static_libs("${OGRE_BINARY_DIR}/lib" "Sample_CameraTrack" "Sample_CelShading" "Sample_Character" "Sample_Compositor" "Sample_Lighting" "Sample_BezierPatch" "Sample_CubeMapping" "Sample_DynTex")
-	add_static_libs("${OGRE_BINARY_DIR}/lib" "Sample_HLMS" "Sample_VolumeTex")
-
-    if(OGRE_BUILD_TESTS)
-        set(OGRE_ANDROID_CFLAGS -DSAMPLES_INCLUDE_PLAYPEN)
-        set(OGRE_ANDROID_INCLUDES ${OGRE_SOURCE_DIR}/Tests/VisualTests/PlayPen/include)
-        add_static_libs("${OGRE_BINARY_DIR}/lib" PlayPenTests)
-    endif()
-
-	copy_assets_to_android_proj()
-    
-    file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/dummy.cpp "int x = 0;")
-    ogre_add_library_to_folder(Samples SampleBrowserDummy SHARED ${CMAKE_CURRENT_BINARY_DIR}/dummy.cpp)
-    target_link_libraries(SampleBrowserDummy ${SAMPLE_LIBRARIES})
-    add_dependencies(SampleBrowserDummy ${OGRE_SAMPLES_LIST})
-    
-    create_android_proj(SampleBrowserDummy)
-
-else()
-
 if (OGRE_BUILD_TESTS)
 	add_definitions(-DSAMPLES_INCLUDE_PLAYPEN)
 	include_directories(${OGRE_SOURCE_DIR}/Tests/PlayPen/include
@@ -443,4 +398,3 @@ if (OGRE_INSTALL_SAMPLES)
 			)
 	endif ()
 endif ()
-endif(ANDROID AND NOT OGRE_BUILD_ANDROID_JNI_LIBS_CMAKE)


### PR DESCRIPTION
This pull request is related to https://ogre3d.atlassian.net/browse/OGRE-568.
It adds the option `OGRE_BUILD_ANDROID_JNI_LIBS_CMAKE` which enables the building of the SampleBrowser library on android using CMake instead of android makefiles.

However this does not completely solve the referenced issue.

I tested this on a physical android device, where it worked.
Besides, it was the only way to build OGRE using the newest NDK with the Clang compiler.