### PR TITLE
Fixes assert in PBS setTexture to allow setting null texture

### DIFF
--- a/Components/Hlms/Pbs/src/OgreHlmsPbsDatablock.cpp
+++ b/Components/Hlms/Pbs/src/OgreHlmsPbsDatablock.cpp
@@ -717,7 +717,7 @@ namespace Ogre
                                        const TexturePtr &newTexture, const HlmsSamplerblock *refParams )
     {
         //PBS can only use texture arrays.
-        assert( newTexture->getTextureType() == TextureType::TEX_TYPE_2D_ARRAY || texType == PBSM_REFLECTION );
+        assert( newTexture.isNull() || newTexture->getTextureType() == TextureType::TEX_TYPE_2D_ARRAY || texType == PBSM_REFLECTION );
 
         PbsBakedTexture textures[NUM_PBSM_TEXTURE_TYPES];
 


### PR DESCRIPTION
Fixes the assert to allow setting PbsDatablock texture to the null texture.