### PR TITLE
Fixes metal pvrtc support

### DIFF
--- a/OgreMain/src/OgreETCCodec.cpp
+++ b/OgreMain/src/OgreETCCodec.cpp
@@ -328,6 +328,18 @@ namespace Ogre {
         case 33779: // DXT 5
             imgData->format = PF_DXT5;
             break;
+         case 0x8c00: // COMPRESSED_RGB_PVRTC_4BPPV1_IMG
+            imgData->format = PF_PVRTC_RGB4;
+            break;
+        case 0x8c01: // COMPRESSED_RGB_PVRTC_2BPPV1_IMG
+            imgData->format = PF_PVRTC_RGB2;
+            break;
+        case 0x8c02: // COMPRESSED_RGBA_PVRTC_4BPPV1_IMG
+            imgData->format = PF_PVRTC_RGBA4;
+            break;
+        case 0x8c03: // COMPRESSED_RGBA_PVRTC_2BPPV1_IMG
+            imgData->format = PF_PVRTC_RGBA2;
+            break;
         default:        
             imgData->format = PF_ETC1_RGB8;
             break;

--- a/OgreMain/src/OgreETCCodec.cpp
+++ b/OgreMain/src/OgreETCCodec.cpp
@@ -349,8 +349,10 @@ namespace Ogre {
         if (header.glType == 0 || header.glFormat == 0)
             imgData->flags |= IF_COMPRESSED;
 
-        size_t numFaces = 1; // Assume one face until we know otherwise
-                             // Calculate total size from number of mipmaps, faces and size
+		size_t numFaces = header.numberOfFaces;
+		if (numFaces > 1)
+			imgData->flags |= IF_CUBEMAP;
+        // Calculate total size from number of mipmaps, faces and size
         imgData->size = Image::calculateSize(imgData->num_mipmaps, numFaces,
                                              imgData->width, imgData->height, imgData->depth, imgData->format);
 
@@ -362,12 +364,18 @@ namespace Ogre {
 
         // Now deal with the data
         uchar* destPtr = output->getPtr();
+        uint32 mipOffset = 0;
         for (uint32 level = 0; level < header.numberOfMipmapLevels; ++level)
         {
             uint32 imageSize = 0;
             stream->read(&imageSize, sizeof(uint32));
-            stream->read(destPtr, imageSize);
-            destPtr += imageSize;
+
+            for(uint32 face = 0; face < numFaces; ++face)
+            {
+                uchar* placePtr = destPtr + ((imgData->size)/numFaces)*face + mipOffset; // shuffle mip and face
+                stream->read(placePtr, imageSize);
+            }
+            mipOffset += imageSize;
         }
 
         result.first = output;

--- a/OgreMain/src/OgrePixelFormat.cpp
+++ b/OgreMain/src/OgrePixelFormat.cpp
@@ -125,8 +125,8 @@ namespace Ogre {
     {
         if(PixelUtil::isCompressed(format))
         {
-            if(def.left == left && def.top == top && def.front == front &&
-               def.right == right && def.bottom == bottom && def.back == back)
+            if(def.left == left && def.top == top && def.right == right &&
+			   def.bottom == bottom)
             {
                 // Entire buffer is being queried
                 return *this;
@@ -1066,8 +1066,7 @@ namespace Ogre {
     void PixelUtil::bulkPixelConversion(const PixelBox &src, const PixelBox &dst)
     {
         assert(src.getWidth() == dst.getWidth() &&
-               src.getHeight() == dst.getHeight() &&
-               src.getDepth() == dst.getDepth());
+               src.getHeight() == dst.getHeight());
 
         // Check for compressed formats, we don't support decompression, compression or recoding
         if(PixelUtil::isCompressed(src.format) || PixelUtil::isCompressed(dst.format))


### PR DESCRIPTION
This PR do essentially three things (aiming to get pvrtc to work on Metal/iOS):
 - Adds support for PVRTC pixel format in the KTX-loader (named ETCCodec). KTX is a general container (similar to DDS) and it can be useful to be able to use that not only on Android.
 - Adds support for loading KTX-texture with mip maps.
 - Loosens the PixelFormat functions to be able to work on at least a full slice when pixel format is compressed. Otherwise Metal renderer fails to load pvrtc compressed textures.
 
