### PR TITLE
CMake: fix static build problem

### DIFF
--- a/CMake/CMakeLists.txt
+++ b/CMake/CMakeLists.txt
@@ -42,7 +42,6 @@ set(STATIC_INST_FILES
   Packages/FindDirectX.cmake
   Packages/FindDirectX11.cmake
   Packages/FindFreeImage.cmake
-  Packages/FindFreetype.cmake
   Packages/FindOpenGLES2.cmake
   Packages/FindZZip.cmake
   Packages/FindSoftimage.cmake


### PR DESCRIPTION
Fixed a problem where `FindFreetype.cmake` could not be found during installation.