### PR TITLE
GLSupport: fix layout qualifier parsing

### DIFF
--- a/RenderSystems/GLSupport/src/GLSL/OgreGLSLProgramCommon.cpp
+++ b/RenderSystems/GLSupport/src/GLSL/OgreGLSLProgramCommon.cpp
@@ -108,28 +108,36 @@ void GLSLProgramCommon::extractLayoutQualifiers(void)
             // It should contain 3 parts, i.e. "attribute vec4 vertex".
             break;
         }
-        if (parts[0] == "out")
+        size_t attrStart = 0;
+        if (parts.size() == 4)
         {
-            // This is an output attribute, skip it
-            continue;
+            if( parts[0] == "flat" || parts[0] == "smooth"|| parts[0] == "perspective")
+            {
+                // Skip the interpolation qualifier
+                attrStart = 1;
+            }
         }
 
-        String attrName = parts[2];
-        String::size_type uvPos = attrName.find("uv");
-
-        if(uvPos == 0)
-            semantic = getAttributeSemanticEnum("uv0"); // treat "uvXY" as "uv0"
-        else
-            semantic = getAttributeSemanticEnum(attrName);
-
-        // Find the texture unit index.
-        if (uvPos == 0)
+        // Skip output attribute
+        if (parts[attrStart] != "out")
         {
-            String uvIndex = attrName.substr(uvPos + 2, attrName.length() - 2);
-            index = StringConverter::parseInt(uvIndex);
-        }
+            String attrName = parts[attrStart + 2];
+            String::size_type uvPos = attrName.find("uv");
 
-        mCustomAttributesIndexes[semantic - 1][index] = attrib;
+            if(uvPos == 0)
+                semantic = getAttributeSemanticEnum("uv0"); // treat "uvXY" as "uv0"
+            else
+                semantic = getAttributeSemanticEnum(attrName);
+
+            // Find the texture unit index.
+            if (uvPos == 0)
+            {
+                String uvIndex = attrName.substr(uvPos + 2, attrName.length() - 2);
+                index = StringConverter::parseInt(uvIndex);
+            }
+
+            mCustomAttributesIndexes[semantic - 1][index] = attrib;
+        }
 
         currPos = shaderSource.find("layout", currPos);
     }


### PR DESCRIPTION
This brings two fixes for `extractLayoutQualifiers()`.

## 1. Handle case with interpolation qualifier

When using both layout location and interpolation qualifiers, I use to write it this way:
```
flat layout(location = 1) out vec4 outColor;
```
However I discovered that this syntax is not supported by the MacOs GLSL compiler. It is hard to find an official documentation to know what is the correct syntax (nothing [here](https://www.khronos.org/opengl/wiki/Layout_Qualifier_(GLSL)) for instance), but I found that this way works on all the platforms I tested so far (Linux, Windows, MacOs):
```
layout(location = 1) flat out vec4 outColor;
```
However, `GLSLProgramCommon::extractLayoutQualifiers(void)` fails to parse this correctly. I propose so to detect the case when a interpolation qualifiers is used and skip it appropriately since it does not provide any information we need.

## 2. Fix the increment of curPos when skipping 'out' qualifiers

Working on the previous fix, I discovered that the loop was broken with 'out' qualifiers. The keyword `continue` was used, but without calling the loop increment `currPos = shaderSource.find("layout", currPos);`. So a line with an `out` qualifier was parsed many times before being really skipped, and sometimes this led to raise an assertion.
I propose to avoid the use of continue which led to this issue and invert the `if` condition.