### PR TITLE
Fix "PlugIns/EXRCodec/src/OgreEXRCodec.cpp" VS2017 error C2872

### DIFF
--- a/PlugIns/EXRCodec/src/OgreEXRCodec.cpp
+++ b/PlugIns/EXRCodec/src/OgreEXRCodec.cpp
@@ -93,23 +93,23 @@ Codec::DecodeResult EXRCodec::decode(const DataStreamPtr& input) const
         uchar *pixels = output->getPtr();
         FrameBuffer frameBuffer;
         frameBuffer.insert("R",             // name
-                    Slice (FLOAT,       // type
+                    Slice (PixelType::FLOAT,       // type
                        ((char *) pixels)+0, // base
                        4 * components,      // xStride
                     4 * components * width));    // yStride
         frameBuffer.insert("G",             // name
-                    Slice (FLOAT,       // type
+                    Slice (PixelType::FLOAT,       // type
                        ((char *) pixels)+4, // base
                        4 * components,      // xStride
                     4 * components * width));    // yStride
         frameBuffer.insert("B",             // name
-                    Slice (FLOAT,       // type
+                    Slice (PixelType::FLOAT,       // type
                        ((char *) pixels)+8, // base
                        4 * components,      // xStride
                     4 * components * width));    // yStride
         if(components==4) {
             frameBuffer.insert("A",                 // name
-                        Slice (FLOAT,           // type
+                        Slice (PixelType::FLOAT,           // type
                            ((char *) pixels)+12,        // base
                            4 * components,      // xStride
                         4 * components * width));    // yStride


### PR DESCRIPTION
VS2017 yields error C2872:
```
1>d:\prj\buildogre.git\ogre\plugins\exrcodec\src\ogreexrcodec.cpp(97): error C2872: 'FLOAT': ambiguous symbol
1>c:\program files (x86)\windows kits\10\include\10.0.16299.0\shared\minwindef.h(160): note: could be 'float FLOAT'
1>d:\prj\buildogre.git\dependencies\include\openexr\imfpixeltype.h(55): note: or       'Imf::PixelType FLOAT'
1>d:\prj\buildogre.git\ogre\plugins\exrcodec\src\ogreexrcodec.cpp(97): error C2275: 'FLOAT': illegal use of this type as an expression
1>c:\program files (x86)\windows kits\10\include\10.0.16299.0\shared\minwindef.h(160): note: see declaration of 'FLOAT'
1>d:\prj\buildogre.git\ogre\plugins\exrcodec\src\ogreexrcodec.cpp(96): error C2661: 'Imf::FrameBuffer::insert': no overloaded function takes 1 arguments
```
'FLOAT' symbol conflicts with Windows SDK 10.