### PR TITLE
CMake: drop OGRE_FULL_RPATH in favor of CMAKE_SKIP_RPATH

### DIFF
--- a/CMake/Utils/OgreConfigTargets.cmake
+++ b/CMake/Utils/OgreConfigTargets.cmake
@@ -313,13 +313,6 @@ function(ogre_config_sample_common SAMPLENAME)
   if (OGRE_PROJECT_FOLDERS)
     set_property(TARGET ${LIBNAME} PROPERTY FOLDER Samples)
   endif ()
-
-  # set install RPATH for Unix systems
-  if (UNIX AND OGRE_FULL_RPATH)
-    set_property(TARGET ${SAMPLENAME} APPEND PROPERTY
-      INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/${OGRE_LIB_DIRECTORY})
-    set_property(TARGET ${SAMPLENAME} PROPERTY INSTALL_RPATH_USE_LINK_PATH TRUE)
-  endif ()
   
   if (APPLE)
     # On OS X, create .app bundle
@@ -424,13 +417,6 @@ function(ogre_config_tool TOOLNAME)
   #set _d debug postfix
   if (WIN32)
 	set_property(TARGET ${TOOLNAME} APPEND PROPERTY DEBUG_POSTFIX "_d")
-  endif ()
-
-  # set install RPATH for Unix systems
-  if (UNIX AND OGRE_FULL_RPATH)
-    set_property(TARGET ${TOOLNAME} APPEND PROPERTY
-      INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/${OGRE_LIB_DIRECTORY})
-    set_property(TARGET ${TOOLNAME} PROPERTY INSTALL_RPATH_USE_LINK_PATH TRUE)
   endif ()
 
   if (OGRE_INSTALL_TOOLS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -387,7 +387,6 @@ option(OGRE_INSTALL_TOOLS "Install Ogre tools." TRUE)
 option(OGRE_INSTALL_DOCS "Install documentation." TRUE)
 option(OGRE_INSTALL_SAMPLES_SOURCE "Install samples source files." FALSE)
 cmake_dependent_option(OGRE_INSTALL_PDB "Install debug pdb files" TRUE "MSVC" FALSE)
-cmake_dependent_option(OGRE_FULL_RPATH "Build executables with the full required RPATH to run from their install location." FALSE "NOT WIN32" FALSE)
 option(OGRE_PROFILING "Enable internal profiling support." FALSE)
 cmake_dependent_option(OGRE_CONFIG_STATIC_LINK_CRT "Statically link the MS CRT dlls (msvcrt)" FALSE "MSVC" FALSE)
 set(OGRE_LIB_DIRECTORY "lib${LIB_SUFFIX}" CACHE STRING "Install path for libraries, e.g. 'lib64' on some 64-bit Linux distros.")
@@ -427,7 +426,6 @@ mark_as_advanced(
   OGRE_CONFIG_ENABLE_GLES3_SUPPORT
   OGRE_CONFIG_ENABLE_TBB_SCHEDULER
   OGRE_INSTALL_SAMPLES_SOURCE
-  OGRE_FULL_RPATH
   OGRE_PROFILING
   OGRE_CONFIG_STATIC_LINK_CRT
   OGRE_LIB_DIRECTORY
@@ -437,6 +435,9 @@ mark_as_advanced(
 # configure global build settings based on selected build options
 ###################################################################
 include(ConfigureBuild)
+
+set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${OGRE_LIB_DIRECTORY}")
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 ###################################################################
 # disable way too common compiler warnings on project level

--- a/Components/Python/CMakeLists.txt
+++ b/Components/Python/CMakeLists.txt
@@ -21,8 +21,7 @@ endif()
 
 macro(ogre_python_module target)
     set_target_properties(${SWIG_MODULE_${target}_REAL_NAME} PROPERTIES 
-                        DEBUG_POSTFIX ""
-                        INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+                        DEBUG_POSTFIX "")
     install(TARGETS ${SWIG_MODULE_${target}_REAL_NAME} LIBRARY DESTINATION ${PYTHON_SITE_PACKAGES})
     install(FILES ${CMAKE_BINARY_DIR}/Components/Python/${target}.py DESTINATION ${PYTHON_SITE_PACKAGES})
 endmacro()

--- a/Samples/Browser/CMakeLists.txt
+++ b/Samples/Browser/CMakeLists.txt
@@ -182,13 +182,6 @@ if (WIN32 AND NOT (WINDOWS_STORE OR WINDOWS_PHONE))
 	set_property(TARGET SampleBrowser APPEND PROPERTY DEBUG_POSTFIX "_d")
 endif ()
 
-# set install RPATH for Unix systems
-if (UNIX AND OGRE_FULL_RPATH)
-	set_property(TARGET SampleBrowser APPEND PROPERTY
-		INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/${OGRE_LIB_DIRECTORY})
-	set_property(TARGET SampleBrowser PROPERTY INSTALL_RPATH_USE_LINK_PATH TRUE)
-endif ()
-
 if (WINDOWS_STORE OR WINDOWS_PHONE)
 	set_target_properties(SampleBrowser PROPERTIES VS_WINRT_COMPONENT "true")
 endif()


### PR DESCRIPTION
and properly set RPATH via CMAKE_INSTALL_RPATH