### PR TITLE
OgreSceneManager: add missing include for compilation with ninja

### DIFF
--- a/OgreMain/include/OgreSceneManager.h
+++ b/OgreMain/include/OgreSceneManager.h
@@ -48,6 +48,7 @@ Torus Knot Software Ltd.
 #include "OgreRenderSystem.h"
 #include "OgreLodListener.h"
 #include "OgreHeaderPrefix.h"
+#include "OgreManualObject.h"
 #include "OgreNameGenerator.h"
 
 namespace Ogre {


### PR DESCRIPTION
## What does this MR do?

Hi,
I work on Windows 10 64 bits and I'm using `ninja` as a generator for CMake. 
My compiler is from Visual Studio: `cl` version 19.00.24215.1.
It appears that in the file `OgreSceneManager` l:442, there is a `ManualObject` but the include is missing.
This MR allows fixing that.

## How to test it?

Generate with `ninja` and compile with `cl`.