### PR TITLE
fix crash in Ogre::Root::getSingleton().createRenderWindow

### DIFF
--- a/RenderSystems/GLSupport/src/win32/OgreWin32Window.cpp
+++ b/RenderSystems/GLSupport/src/win32/OgreWin32Window.cpp
@@ -380,7 +380,7 @@ namespace Ogre {
                 classStyle |= CS_DBLCLKS;
 
             // register class and create window
-            WNDCLASS wc = { classStyle, NULL, 0, 0, hInst,
+            WNDCLASS wc = { classStyle, DefWindowProc, 0, 0, hInst,
                 LoadIcon(NULL, IDI_APPLICATION), LoadCursor(NULL, IDC_ARROW),
                 (HBRUSH)GetStockObject(BLACK_BRUSH), NULL, "OgreGLWindow" };
             RegisterClass(&wc);


### PR DESCRIPTION
... which called Win32Window::create in the file
RenderSystems/GLSupport/src/win32/OgreWin32Window.cpp
The crash was at the line:

        // Pass pointer to self as WM_CREATE parameter
        mHWnd = CreateWindowEx(dwStyleEx, "OgreGLWindow", title.c_str(),
            getWindowStyle(fullScreen), mLeft, mTop, mWidth, mHeight, parent, 0, hInst, this);

Introduced in commit aa90530a586d1c484abdf8be316838afe27c7bd1.

Fixes #814.