### PR TITLE
Samples/PNTriangles: fixed exception in light setup

### DIFF
--- a/Samples/PNTrianglesTessellation/include/PNTrianglesTessellation.h
+++ b/Samples/PNTrianglesTessellation/include/PNTrianglesTessellation.h
@@ -202,6 +202,12 @@ protected:
         mLightPivot1 = mSceneMgr->getRootSceneNode()->createChildSceneNode();
         mLightPivot2 = mSceneMgr->getRootSceneNode()->createChildSceneNode();
 
+        mLightPivot1->setPosition(Vector3(200, 0, 0));
+        mLightPivot2->setPosition(Vector3(-200, 0, 0));
+
+        mLightPivot1->setDirection(-Vector3::UNIT_X);        
+        mLightPivot2->setDirection(Vector3::UNIT_X);
+
         Light* l;
         BillboardSet* bbs;
 
@@ -209,32 +215,24 @@ protected:
         l = mSceneMgr->createLight();
         l->setDiffuseColour(1.0f, 1.0f, 1.0f);
         l->setSpecularColour(1.0f, 1.0f, 1.0f);
-        SceneNode* ln = mSceneMgr->getRootSceneNode()->createChildSceneNode();
-        ln->setPosition(Vector3(200, 0, 0));
-        ln->setDirection(-Vector3::UNIT_X);
-        ln->attachObject(l);
+        mLightPivot1->attachObject(l);
+
         // create white flare
         bbs = mSceneMgr->createBillboardSet();
         bbs->setMaterialName("Examples/Flare");
         bbs->createBillboard(200, 0, 0)->setColour(ColourValue::White);
-
-        mLightPivot1->attachObject(l);
         mLightPivot1->attachObject(bbs);
 
         // create red light
         l = mSceneMgr->createLight();
         l->setDiffuseColour(1.0f, 0.0f, 0.0f);
         l->setSpecularColour(1.0f, 0.0f, 0.0f);
-        ln = mSceneMgr->getRootSceneNode()->createChildSceneNode();
-        ln->setPosition(Vector3(-200, 0, 0));
-        ln->setDirection(Vector3::UNIT_X);
-        ln->attachObject(l);
+        mLightPivot2->attachObject(l);
+
         // create white flare
         bbs = mSceneMgr->createBillboardSet();
         bbs->setMaterialName("Examples/Flare");
         bbs->createBillboard(-200, 0, 0)->setColour(ColourValue::Red);
-
-        mLightPivot2->attachObject(l);
         mLightPivot2->attachObject(bbs);
     }
 


### PR DESCRIPTION
Light was being parented to 2 scene nodes, causing OGRE to throw Exception::ERR_INVALIDPARAMS every time the sample was starting.