### PR TITLE
Main: move the adjacency flag to render operation where it belongs

### DIFF
--- a/Docs/src/high-level-programs.md
+++ b/Docs/src/high-level-programs.md
@@ -598,15 +598,6 @@ If your vertex program makes use of [Vertex Texture Fetch](#Vertex-Texture-Fetch
    uses_vertex_texture_fetch true
 ```
 
-# Adjacency information in Geometry Programs {#Adjacency-information-in-Geometry-Programs}
-
-Some geometry programs require adjacency information from the geometry. It means that a geometry shader doesn’t only get the information of the primitive it operates on, it also has access to its neighbours (in the case of lines or triangles). This directive will tell Ogre to send the information to the geometry shader.
-
-```cpp
-   uses_adjacency_information true
-```
-
-
 # Vertex Texture Fetch {#Vertex-Texture-Fetch}
 
 More recent generations of video card allow you to perform a read from a texture in the vertex program rather than just the fragment program, as is traditional. This allows you to, for example, read the contents of a texture and displace vertices based on the intensity of the colour contained within.

--- a/OgreMain/include/OgreGpuProgram.h
+++ b/OgreMain/include/OgreGpuProgram.h
@@ -326,13 +326,9 @@ namespace Ogre {
     */
     virtual bool isVertexTextureFetchRequired(void) const { return mVertexTextureFetch; }
 
-    /** Sets whether this geometry program requires adjacency information
-        from the input primitives.
-    */
+    /// @deprecated
     virtual void setAdjacencyInfoRequired(bool r) { mNeedsAdjacencyInfo = r; }
-    /** Returns whether this geometry program requires adjacency information
-        from the input primitives.
-    */
+    /// @deprecated
     virtual bool isAdjacencyInfoRequired(void) const { return mNeedsAdjacencyInfo; }
     /** Sets the number of process groups dispatched by this compute
         program.

--- a/OgreMain/include/OgreRenderOperation.h
+++ b/OgreMain/include/OgreRenderOperation.h
@@ -90,7 +90,18 @@ namespace Ogre {
             OT_PATCH_29_CONTROL_POINT   = 35,
             OT_PATCH_30_CONTROL_POINT   = 36,
             OT_PATCH_31_CONTROL_POINT   = 37,
-            OT_PATCH_32_CONTROL_POINT   = 38
+            OT_PATCH_32_CONTROL_POINT   = 38,
+            // max valid base OT_ = (1 << 6) - 1
+            /// Mark that the index buffer contains adjacency information
+            OT_DETAIL_ADJACENCY_BIT     = 1 << 6,
+            /// like OT_POINT_LIST but with adjacency information for the geometry shader
+            OT_LINE_LIST_ADJ            = OT_LINE_LIST | OT_DETAIL_ADJACENCY_BIT,
+            /// like OT_LINE_STRIP but with adjacency information for the geometry shader
+            OT_LINE_STRIP_ADJ           = OT_LINE_STRIP | OT_DETAIL_ADJACENCY_BIT,
+            /// like OT_TRIANGLE_LIST but with adjacency information for the geometry shader
+            OT_TRIANGLE_LIST_ADJ        = OT_TRIANGLE_LIST | OT_DETAIL_ADJACENCY_BIT,
+            /// like OT_TRIANGLE_STRIP but with adjacency information for the geometry shader
+            OT_TRIANGLE_STRIP_ADJ       = OT_TRIANGLE_STRIP | OT_DETAIL_ADJACENCY_BIT,
         };
 
         /// Vertex source data

--- a/OgreMain/src/OgreGpuProgram.cpp
+++ b/OgreMain/src/OgreGpuProgram.cpp
@@ -509,8 +509,10 @@ namespace Ogre
     }
     void GpuProgram::CmdAdjacency::doSet(void* target, const String& val)
     {
+        LogManager::getSingleton().logWarning("'uses_adjacency_information' is deprecated. "
+        "Set the respective RenderOperation::OpertionType instead.");
         GpuProgram* t = static_cast<GpuProgram*>(target);
-        t->setAdjacencyInfoRequired(StringConverter::parseBool(val));
+        t->mNeedsAdjacencyInfo = StringConverter::parseBool(val);
     }
     //-----------------------------------------------------------------------
     String GpuProgram::CmdComputeGroupDims::doGet(const void* target) const

--- a/OgreMain/src/OgreRenderSystem.cpp
+++ b/OgreMain/src/OgreRenderSystem.cpp
@@ -626,45 +626,17 @@ namespace Ogre {
         case RenderOperation::OT_TRIANGLE_LIST:
             mFaceCount += (val / 3);
             break;
+        case RenderOperation::OT_TRIANGLE_LIST_ADJ:
+            mFaceCount += (val / 6);
+            break;
+        case RenderOperation::OT_TRIANGLE_STRIP_ADJ:
+            mFaceCount += (val / 2 - 2);
+            break;
         case RenderOperation::OT_TRIANGLE_STRIP:
         case RenderOperation::OT_TRIANGLE_FAN:
             mFaceCount += (val - 2);
             break;
-        case RenderOperation::OT_POINT_LIST:
-        case RenderOperation::OT_LINE_LIST:
-        case RenderOperation::OT_LINE_STRIP:
-        case RenderOperation::OT_PATCH_1_CONTROL_POINT:
-        case RenderOperation::OT_PATCH_2_CONTROL_POINT:
-        case RenderOperation::OT_PATCH_3_CONTROL_POINT:
-        case RenderOperation::OT_PATCH_4_CONTROL_POINT:
-        case RenderOperation::OT_PATCH_5_CONTROL_POINT:
-        case RenderOperation::OT_PATCH_6_CONTROL_POINT:
-        case RenderOperation::OT_PATCH_7_CONTROL_POINT:
-        case RenderOperation::OT_PATCH_8_CONTROL_POINT:
-        case RenderOperation::OT_PATCH_9_CONTROL_POINT:
-        case RenderOperation::OT_PATCH_10_CONTROL_POINT:
-        case RenderOperation::OT_PATCH_11_CONTROL_POINT:
-        case RenderOperation::OT_PATCH_12_CONTROL_POINT:
-        case RenderOperation::OT_PATCH_13_CONTROL_POINT:
-        case RenderOperation::OT_PATCH_14_CONTROL_POINT:
-        case RenderOperation::OT_PATCH_15_CONTROL_POINT:
-        case RenderOperation::OT_PATCH_16_CONTROL_POINT:
-        case RenderOperation::OT_PATCH_17_CONTROL_POINT:
-        case RenderOperation::OT_PATCH_18_CONTROL_POINT:
-        case RenderOperation::OT_PATCH_19_CONTROL_POINT:
-        case RenderOperation::OT_PATCH_20_CONTROL_POINT:
-        case RenderOperation::OT_PATCH_21_CONTROL_POINT:
-        case RenderOperation::OT_PATCH_22_CONTROL_POINT:
-        case RenderOperation::OT_PATCH_23_CONTROL_POINT:
-        case RenderOperation::OT_PATCH_24_CONTROL_POINT:
-        case RenderOperation::OT_PATCH_25_CONTROL_POINT:
-        case RenderOperation::OT_PATCH_26_CONTROL_POINT:
-        case RenderOperation::OT_PATCH_27_CONTROL_POINT:
-        case RenderOperation::OT_PATCH_28_CONTROL_POINT:
-        case RenderOperation::OT_PATCH_29_CONTROL_POINT:
-        case RenderOperation::OT_PATCH_30_CONTROL_POINT:
-        case RenderOperation::OT_PATCH_31_CONTROL_POINT:
-        case RenderOperation::OT_PATCH_32_CONTROL_POINT:
+        default:
             break;
         }
 

--- a/PlugIns/CgProgramManager/src/OgreCgProgram.cpp
+++ b/PlugIns/CgProgramManager/src/OgreCgProgram.cpp
@@ -198,8 +198,7 @@ namespace Ogre {
 				}
 				else if (mInputOp == CG_LINE_ADJ)
 				{
-					mDelegate->setParameter("input_operation_type", "line_strip");
-					mDelegate->setAdjacencyInfoRequired(true);
+					mDelegate->setParameter("input_operation_type", "line_strip_adj");
 				}
 				else if (mInputOp == CG_TRIANGLE)
 				{
@@ -207,8 +206,7 @@ namespace Ogre {
 				}
 				else if (mInputOp == CG_TRIANGLE_ADJ)
 				{
-					mDelegate->setParameter("input_operation_type", "triangle_strip");
-					mDelegate->setAdjacencyInfoRequired(true);
+					mDelegate->setParameter("input_operation_type", "triangle_strip_adj");
 				}
 
 				if (mOutputOp == CG_POINT_OUT)

--- a/RenderSystems/Direct3D11/src/OgreD3D11RenderSystem.cpp
+++ b/RenderSystems/Direct3D11/src/OgreD3D11RenderSystem.cpp
@@ -2668,9 +2668,12 @@ namespace Ogre
         }
         else
         {
-            //rendering without tessellation.
-            bool useAdjacency = (mGeometryProgramBound && mBoundGeometryProgram && mBoundGeometryProgram->isAdjacencyInfoRequired());
-            switch( op.operationType )
+            //rendering without tessellation.   
+            int operationType = op.operationType;
+            if(mGeometryProgramBound && mBoundGeometryProgram && mBoundGeometryProgram->isAdjacencyInfoRequired())
+                operationType |= RenderOperation::OT_DETAIL_ADJACENCY_BIT;
+
+            switch( operationType )
             {
             case RenderOperation::OT_POINT_LIST:
                 primType = D3D11_PRIMITIVE_TOPOLOGY_POINTLIST;
@@ -2678,23 +2681,43 @@ namespace Ogre
                 break;
 
             case RenderOperation::OT_LINE_LIST:
-                primType = useAdjacency ? D3D11_PRIMITIVE_TOPOLOGY_LINELIST_ADJ : D3D11_PRIMITIVE_TOPOLOGY_LINELIST;
+                primType = D3D11_PRIMITIVE_TOPOLOGY_LINELIST;
                 primCount = (DWORD)(op.useIndexes ? op.indexData->indexCount : op.vertexData->vertexCount) / 2;
                 break;
 
+            case RenderOperation::OT_LINE_LIST_ADJ:
+                primType = D3D11_PRIMITIVE_TOPOLOGY_LINELIST_ADJ;
+                primCount = (DWORD)(op.useIndexes ? op.indexData->indexCount : op.vertexData->vertexCount) / 4;
+                break;
+
             case RenderOperation::OT_LINE_STRIP:
-                primType = useAdjacency ? D3D11_PRIMITIVE_TOPOLOGY_LINESTRIP_ADJ : D3D11_PRIMITIVE_TOPOLOGY_LINESTRIP;
+                primType = D3D11_PRIMITIVE_TOPOLOGY_LINESTRIP;
                 primCount = (DWORD)(op.useIndexes ? op.indexData->indexCount : op.vertexData->vertexCount) - 1;
                 break;
 
+            case RenderOperation::OT_LINE_STRIP_ADJ:
+                primType = D3D11_PRIMITIVE_TOPOLOGY_LINESTRIP_ADJ;
+                primCount = (DWORD)(op.useIndexes ? op.indexData->indexCount : op.vertexData->vertexCount) - 2;
+                break;
+
             case RenderOperation::OT_TRIANGLE_LIST:
-                primType = useAdjacency ? D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST_ADJ : D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST;
+                primType = D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST;
                 primCount = (DWORD)(op.useIndexes ? op.indexData->indexCount : op.vertexData->vertexCount) / 3;
                 break;
 
+            case RenderOperation::OT_TRIANGLE_LIST_ADJ:
+                primType = D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST_ADJ;
+                primCount = (DWORD)(op.useIndexes ? op.indexData->indexCount : op.vertexData->vertexCount) / 6;
+                break;
+
             case RenderOperation::OT_TRIANGLE_STRIP:
-                primType = useAdjacency ? D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP_ADJ : D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP;
+                primType = D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP;
                 primCount = (DWORD)(op.useIndexes ? op.indexData->indexCount : op.vertexData->vertexCount) - 2;
+                break;
+
+            case RenderOperation::OT_TRIANGLE_STRIP_ADJ:
+                primType = D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP_ADJ;
+                primCount = (DWORD)(op.useIndexes ? op.indexData->indexCount : op.vertexData->vertexCount) / 2 - 2;
                 break;
 
             case RenderOperation::OT_TRIANGLE_FAN:

--- a/RenderSystems/GL/src/GLSL/src/OgreGLSLLinkProgram.cpp
+++ b/RenderSystems/GL/src/GLSL/src/OgreGLSLLinkProgram.cpp
@@ -39,7 +39,7 @@ THE SOFTWARE.
 namespace Ogre {
     namespace GLSL {
 
-    static GLint getGLGeometryInputPrimitiveType(RenderOperation::OperationType operationType, bool requiresAdjacency)
+    static GLint getGLGeometryInputPrimitiveType(RenderOperation::OperationType operationType)
     {
         switch (operationType)
         {
@@ -47,13 +47,19 @@ namespace Ogre {
             return GL_POINTS;
         case RenderOperation::OT_LINE_LIST:
         case RenderOperation::OT_LINE_STRIP:
-            return requiresAdjacency ? GL_LINES_ADJACENCY_EXT : GL_LINES;
+			return GL_LINES;
+        case RenderOperation::OT_LINE_LIST_ADJ:
+        case RenderOperation::OT_LINE_STRIP_ADJ:
+			return GL_LINES_ADJACENCY_EXT;
+        case RenderOperation::OT_TRIANGLE_LIST_ADJ:
+        case RenderOperation::OT_TRIANGLE_STRIP_ADJ:
+            return GL_TRIANGLES_ADJACENCY_EXT;
         default:
         case RenderOperation::OT_TRIANGLE_LIST:
         case RenderOperation::OT_TRIANGLE_STRIP:
         case RenderOperation::OT_TRIANGLE_FAN:
-            return requiresAdjacency ? GL_TRIANGLES_ADJACENCY_EXT : GL_TRIANGLES;
-        }
+            return GL_TRIANGLES;
+		}
     }
     //-----------------------------------------------------------------------
     static GLint getGLGeometryOutputPrimitiveType(RenderOperation::OperationType operationType)
@@ -498,7 +504,7 @@ namespace Ogre {
 
             RenderOperation::OperationType inputOperationType = mGeometryProgram->getInputOperationType();
             glProgramParameteriEXT(mGLProgramHandle, GL_GEOMETRY_INPUT_TYPE_EXT,
-                getGLGeometryInputPrimitiveType(inputOperationType, mGeometryProgram->isAdjacencyInfoRequired()));
+                getGLGeometryInputPrimitiveType(inputOperationType));
 
             RenderOperation::OperationType outputOperationType = mGeometryProgram->getOutputOperationType();
 

--- a/RenderSystems/GL/src/OgreGLRenderSystem.cpp
+++ b/RenderSystems/GL/src/OgreGLRenderSystem.cpp
@@ -2601,25 +2601,39 @@ namespace Ogre {
 
         // Find the correct type to render
         GLint primType;
-        //Use adjacency if there is a geometry program and it requested adjacency info
-        bool useAdjacency = (mGeometryProgramBound && mCurrentGeometryProgram && mCurrentGeometryProgram->isAdjacencyInfoRequired());
-        switch (op.operationType)
+        int operationType = op.operationType;
+        // Use adjacency if there is a geometry program and it requested adjacency info
+        if(mGeometryProgramBound && mCurrentGeometryProgram && mCurrentGeometryProgram->isAdjacencyInfoRequired())
+            operationType |= RenderOperation::OT_DETAIL_ADJACENCY_BIT;
+        switch (operationType)
         {
         case RenderOperation::OT_POINT_LIST:
             primType = GL_POINTS;
             break;
         case RenderOperation::OT_LINE_LIST:
-            primType = useAdjacency ? GL_LINES_ADJACENCY_EXT : GL_LINES;
+            primType = GL_LINES;
+            break;
+        case RenderOperation::OT_LINE_LIST_ADJ:
+            primType = GL_LINES_ADJACENCY_EXT;
             break;
         case RenderOperation::OT_LINE_STRIP:
-            primType = useAdjacency ? GL_LINE_STRIP_ADJACENCY_EXT : GL_LINE_STRIP;
+            primType = GL_LINE_STRIP;
+            break;
+        case RenderOperation::OT_LINE_STRIP_ADJ:
+            primType = GL_LINE_STRIP_ADJACENCY_EXT;
             break;
         default:
         case RenderOperation::OT_TRIANGLE_LIST:
-            primType = useAdjacency ? GL_TRIANGLES_ADJACENCY_EXT : GL_TRIANGLES;
+            primType = GL_TRIANGLES;
+            break;
+        case RenderOperation::OT_TRIANGLE_LIST_ADJ:
+            primType = GL_TRIANGLES_ADJACENCY_EXT;
             break;
         case RenderOperation::OT_TRIANGLE_STRIP:
-            primType = useAdjacency ? GL_TRIANGLE_STRIP_ADJACENCY_EXT : GL_TRIANGLE_STRIP;
+            primType = GL_TRIANGLE_STRIP;
+            break;
+        case RenderOperation::OT_TRIANGLE_STRIP_ADJ:
+            primType = GL_TRIANGLE_STRIP_ADJACENCY_EXT;
             break;
         case RenderOperation::OT_TRIANGLE_FAN:
             primType = GL_TRIANGLE_FAN;

--- a/RenderSystems/GL3Plus/src/OgreGL3PlusRenderSystem.cpp
+++ b/RenderSystems/GL3Plus/src/OgreGL3PlusRenderSystem.cpp
@@ -1449,28 +1449,42 @@ namespace Ogre {
             //     mComputeProgramExecutions++;
         }
 
+        int operationType = op.operationType;
+        // Use adjacency if there is a geometry program and it requested adjacency info
+        if(mGeometryProgramBound && mCurrentGeometryShader && mCurrentGeometryShader->isAdjacencyInfoRequired())
+            operationType |= RenderOperation::OT_DETAIL_ADJACENCY_BIT;
 
         // Determine the correct primitive type to render.
         GLint primType;
-        // Use adjacency if there is a geometry program and it requested adjacency info.
-        bool useAdjacency = (mGeometryProgramBound && mCurrentGeometryShader && mCurrentGeometryShader->isAdjacencyInfoRequired());
-        switch (op.operationType)
+        switch (operationType)
         {
         case RenderOperation::OT_POINT_LIST:
             primType = GL_POINTS;
             break;
         case RenderOperation::OT_LINE_LIST:
-            primType = useAdjacency ? GL_LINES_ADJACENCY : GL_LINES;
+            primType = GL_LINES;
+            break;
+        case RenderOperation::OT_LINE_LIST_ADJ:
+            primType = GL_LINES_ADJACENCY;
             break;
         case RenderOperation::OT_LINE_STRIP:
-            primType = useAdjacency ? GL_LINE_STRIP_ADJACENCY : GL_LINE_STRIP;
+            primType = GL_LINE_STRIP;
+            break;
+        case RenderOperation::OT_LINE_STRIP_ADJ:
+            primType = GL_LINE_STRIP_ADJACENCY;
             break;
         default:
         case RenderOperation::OT_TRIANGLE_LIST:
-            primType = useAdjacency ? GL_TRIANGLES_ADJACENCY : GL_TRIANGLES;
+            primType = GL_TRIANGLES;
+            break;
+        case RenderOperation::OT_TRIANGLE_LIST_ADJ:
+            primType = GL_TRIANGLES_ADJACENCY;
             break;
         case RenderOperation::OT_TRIANGLE_STRIP:
-            primType = useAdjacency ? GL_TRIANGLE_STRIP_ADJACENCY : GL_TRIANGLE_STRIP;
+            primType = GL_TRIANGLE_STRIP;
+            break;
+        case RenderOperation::OT_TRIANGLE_STRIP_ADJ:
+            primType = GL_TRIANGLE_STRIP_ADJACENCY;
             break;
         case RenderOperation::OT_TRIANGLE_FAN:
             primType = GL_TRIANGLE_FAN;

--- a/RenderSystems/GLSupport/src/GLSL/OgreGLSLShaderCommon.cpp
+++ b/RenderSystems/GLSupport/src/GLSL/OgreGLSLShaderCommon.cpp
@@ -229,17 +229,33 @@ namespace Ogre {
         {
             return RenderOperation::OT_LINE_LIST;
         }
+        else if (val == "line_list_adj")
+        {
+            return RenderOperation::OT_LINE_LIST_ADJ;
+        }
         else if (val == "line_strip")
         {
             return RenderOperation::OT_LINE_STRIP;
+        }
+        else if (val == "line_strip_adj")
+        {
+            return RenderOperation::OT_LINE_STRIP_ADJ;
         }
         else if (val == "triangle_strip")
         {
             return RenderOperation::OT_TRIANGLE_STRIP;
         }
+        else if (val == "triangle_strip_adj")
+        {
+            return RenderOperation::OT_TRIANGLE_STRIP_ADJ;
+        }
         else if (val == "triangle_fan")
         {
             return RenderOperation::OT_TRIANGLE_FAN;
+        }
+        else if (val == "triangle_list_adj")
+        {
+            return RenderOperation::OT_TRIANGLE_LIST_ADJ;
         }
         else 
         {
@@ -258,14 +274,26 @@ namespace Ogre {
         case RenderOperation::OT_LINE_LIST:
             return "line_list";
             break;
+        case RenderOperation::OT_LINE_LIST_ADJ:
+            return "line_list_adj";
+            break;
         case RenderOperation::OT_LINE_STRIP:
             return "line_strip";
+            break;
+        case RenderOperation::OT_LINE_STRIP_ADJ:
+            return "line_strip_adj";
             break;
         case RenderOperation::OT_TRIANGLE_STRIP:
             return "triangle_strip";
             break;
+        case RenderOperation::OT_TRIANGLE_STRIP_ADJ:
+            return "triangle_strip_adj";
+            break;
         case RenderOperation::OT_TRIANGLE_FAN:
             return "triangle_fan";
+            break;
+        case RenderOperation::OT_TRIANGLE_LIST_ADJ:
+            return "triangle_list_adj";
             break;
         case RenderOperation::OT_TRIANGLE_LIST:
         default:

--- a/Samples/Isosurf/src/ProceduralTools.cpp
+++ b/Samples/Isosurf/src/ProceduralTools.cpp
@@ -53,7 +53,7 @@ MeshPtr ProceduralTools::generateTetrahedra()
         ("TetrahedraMesh", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
 
     SubMesh* tetrahedraSubMesh = tetrahedraMesh->createSubMesh();
-    tetrahedraSubMesh->operationType = RenderOperation::OT_LINE_LIST;
+    tetrahedraSubMesh->operationType = RenderOperation::OT_LINE_LIST_ADJ;
     //tetrahedraSubMesh->operationType = RenderOperation::OT_TRIANGLE_STRIP;
     tetrahedraSubMesh->setMaterialName("Ogre/Isosurf/TessellateTetrahedra");
     //tetrahedraSubMesh->setMaterialName("BaseWhiteNoLighting");

--- a/Samples/Media/materials/scripts/IsoSurf.material
+++ b/Samples/Media/materials/scripts/IsoSurf.material
@@ -20,7 +20,6 @@ geometry_program Ogre/Isosurf/TessellateTetrahedraGS_HLSL hlsl
 	source isosurf.hlsl
 	entry_point mainGS
 	target gs_4_0
-	uses_adjacency_information true
 
 	default_params
 	{
@@ -57,7 +56,6 @@ geometry_program Ogre/Isosurf/TessellateTetrahedraGS_CG cg
 	source isosurf.cg
 	entry_point mainGS
 	profiles gpu_gp gp4_gp
-	uses_adjacency_information true
 
 	default_params
 	{
@@ -92,7 +90,6 @@ geometry_program Ogre/Isosurf/TessellateTetrahedraGS_GLSL glsl
 {
 	source IsosurfGS.glsl
 	syntax glsl150
-	uses_adjacency_information true
 
 	default_params
 	{

--- a/Tools/XMLConverter/docs/ogremeshxml.dtd
+++ b/Tools/XMLConverter/docs/ogremeshxml.dtd
@@ -9,7 +9,7 @@
 	material 			CDATA 			#REQUIRED
 	usesharedvertices	(true|false)	"true"
 	use32bitindexes		(true|false)	"false"
-	operationtype       (triangle_list|triangle_strip|triangle_fan)	"triangle_list">
+	operationtype       (line_list|line_strip|point_list|triangle_list|triangle_strip|triangle_fan|line_list_adj|line_strip_adj|triangle_list_adj|triangle_strip_adj)	"triangle_list">
 <!ELEMENT textures (texture+)>
 <!ELEMENT texture EMPTY>
 <!ATTLIST texture

--- a/Tools/XMLConverter/src/OgreXMLMeshSerializer.cpp
+++ b/Tools/XMLConverter/src/OgreXMLMeshSerializer.cpp
@@ -257,6 +257,18 @@ namespace Ogre {
         case RenderOperation::OT_TRIANGLE_STRIP:
             subMeshNode->SetAttribute("operationtype", "triangle_strip");
             break;
+        case RenderOperation::OT_TRIANGLE_LIST_ADJ:
+            subMeshNode->SetAttribute("operationtype", "triangle_list_adj");
+            break;
+        case RenderOperation::OT_TRIANGLE_STRIP_ADJ:
+            subMeshNode->SetAttribute("operationtype", "triangle_strip_adj");
+            break;
+        case RenderOperation::OT_LINE_LIST_ADJ:
+            subMeshNode->SetAttribute("operationtype", "line_list_adj");
+            break;
+        case RenderOperation::OT_LINE_STRIP_ADJ:
+            subMeshNode->SetAttribute("operationtype", "line_strip_adj");
+            break;
         default:
             OgreAssert(false, "Patch control point operations not supported");
             break;
@@ -746,7 +758,24 @@ namespace Ogre {
                     sm->operationType = RenderOperation::OT_POINT_LIST;
                     readFaces = false;
                 }
-
+                else if (!strcmp(optype, "triangle_list_adj"))
+                {
+                    sm->operationType = RenderOperation::OT_TRIANGLE_LIST_ADJ;
+                }
+                else if (!strcmp(optype, "triangle_strip_adj"))
+                {
+                    sm->operationType = RenderOperation::OT_TRIANGLE_STRIP_ADJ;
+                }
+                else if (!strcmp(optype, "line_strip_adj"))
+                {
+                    sm->operationType = RenderOperation::OT_LINE_STRIP_ADJ;
+                    readFaces = false;
+                }
+                else if (!strcmp(optype, "line_list_adj"))
+                {
+                    sm->operationType = RenderOperation::OT_LINE_LIST_ADJ;
+                    readFaces = false;
+                }
             }
 
             const char* tmp = smElem->Attribute("usesharedvertices");


### PR DESCRIPTION
instead of the geometry shader - for e.g. rendering adjacency buffers
without an geometry shader attached.

patch based on
https://forums.ogre3d.org/viewtopic.php?f=4&t=94417#p542277