### PR TITLE
Main: allow using native endian byte pixel formats in scripts

### DIFF
--- a/OgreMain/src/OgrePixelFormat.cpp
+++ b/OgreMain/src/OgrePixelFormat.cpp
@@ -302,6 +302,17 @@ namespace Ogre {
                     return pf;
             }
         }
+
+        // allow look-up by alias name
+        if(tmp == "PF_BYTE_RGB")
+            return PF_BYTE_RGB;
+        if(tmp == "PF_BYTE_RGBA")
+            return PF_BYTE_RGBA;
+        if(tmp == "PF_BYTE_BGR")
+            return PF_BYTE_BGR;
+        if(tmp == "PF_BYTE_BGRA")
+            return PF_BYTE_BGRA;
+
         return PF_UNKNOWN;
     }
     //-----------------------------------------------------------------------

--- a/Samples/Media/DeferredShadingMedia/ssao.compositor
+++ b/Samples/Media/DeferredShadingMedia/ssao.compositor
@@ -5,10 +5,10 @@ compositor DeferredShading/SSAO
 		compositor_logic SSAOLogic
 		
         texture_ref geom DeferredShading/GBuffer mrt_output
-        texture scene target_width target_height PF_R8G8B8A8
-        texture ssao target_width_scaled 0.5 target_height_scaled 0.5 PF_R8G8B8
-        texture ssaoBlurX target_width target_height PF_R8G8B8
-        texture ssaoBlurY target_width target_height PF_R8G8B8
+        texture scene target_width target_height PF_BYTE_RGBA
+        texture ssao target_width_scaled 0.5 target_height_scaled 0.5 PF_BYTE_RGB
+        texture ssaoBlurX target_width target_height PF_BYTE_RGB
+        texture ssaoBlurY target_width target_height PF_BYTE_RGB
 
         // the scene we want to modulate
         target scene

--- a/Samples/Media/materials/scripts/Examples.compositor
+++ b/Samples/Media/materials/scripts/Examples.compositor
@@ -4,9 +4,9 @@ compositor Bloom
     technique
     {
         // Temporary textures
-        texture rt_output target_width target_height PF_R8G8B8
-        texture rt0 target_width_scaled 0.25 target_height_scaled 0.25 PF_R8G8B8
-        texture rt1 target_width_scaled 0.25 target_height_scaled 0.25 PF_R8G8B8
+        texture rt_output target_width target_height PF_BYTE_RGB
+        texture rt0 target_width_scaled 0.25 target_height_scaled 0.25 PF_BYTE_RGB
+        texture rt1 target_width_scaled 0.25 target_height_scaled 0.25 PF_BYTE_RGB
 
         target rt_output
         {
@@ -73,7 +73,7 @@ compositor Glass
 {
     technique
     {
-        texture rt0 target_width target_height PF_R8G8B8
+        texture rt0 target_width target_height PF_BYTE_RGB
 
         target rt0 { input previous }
 
@@ -95,7 +95,7 @@ compositor "Old TV"
 {
     technique
     {
-        texture rt0 target_width target_height PF_R8G8B8
+        texture rt0 target_width target_height PF_BYTE_RGB
 
         // render scene to a texture
         target rt0 { input previous }
@@ -123,7 +123,7 @@ compositor B&W
     technique
     {
         // Temporary textures
-        texture rt0 target_width target_height PF_A8R8G8B8
+        texture rt0 target_width target_height PF_BYTE_RGBA
 
         target rt0
         {
@@ -152,8 +152,8 @@ compositor B&W
 //    technique
 //    {
 //        // Temporary textures
-//        texture rt0 target_width target_height PF_A8R8G8B8
-//        texture rt1 target_width target_height PF_A8R8G8B8
+//        texture rt0 target_width target_height PF_BYTE_RGBA
+//        texture rt1 target_width target_height PF_BYTE_RGBA
 //
 //        target rt1
 //        {
@@ -209,7 +209,7 @@ compositor Embossed
     technique
     {
         // Temporary textures
-        texture rt0 target_width target_height PF_A8R8G8B8
+        texture rt0 target_width target_height PF_BYTE_RGBA
 
         target rt0
         {
@@ -238,7 +238,7 @@ compositor "Sharpen Edges"
     technique
     {
         // Temporary textures
-        texture rt0 target_width target_height PF_A8R8G8B8
+        texture rt0 target_width target_height PF_BYTE_RGBA
 
         target rt0
         {
@@ -267,7 +267,7 @@ compositor Invert
     technique
     {
         // Temporary textures
-        texture rt0 target_width target_height PF_A8R8G8B8
+        texture rt0 target_width target_height PF_BYTE_RGBA
 
         target rt0
         {
@@ -296,7 +296,7 @@ compositor Posterize
     technique
     {
         // Temporary textures
-        texture rt0 target_width target_height PF_A8R8G8B8
+        texture rt0 target_width target_height PF_BYTE_RGBA
 
         target rt0
         {
@@ -325,7 +325,7 @@ compositor Laplace
     technique
     {
         // Temporary textures
-        texture rt0 target_width target_height PF_A8R8G8B8
+        texture rt0 target_width target_height PF_BYTE_RGBA
 
         target rt0
         {
@@ -354,7 +354,7 @@ compositor Tiling
     technique
     {
         // Temporary textures
-        texture rt0 target_width target_height PF_A8R8G8B8
+        texture rt0 target_width target_height PF_BYTE_RGBA
 
         target rt0
         {
@@ -424,10 +424,10 @@ compositor HDR
 		texture rt_lum3 64 64 PF_FLOAT16_RGB
 		texture rt_lum4 128 128 PF_FLOAT16_RGB
 		// Bright-pass filtered target (tone mapped)
-		texture rt_brightpass 128 128 PF_R8G8B8
+		texture rt_brightpass 128 128 PF_BYTE_RGB
 		// Bloom filter targets
-		texture rt_bloom0 128 128 PF_R8G8B8
-		texture rt_bloom1 128 128 PF_R8G8B8
+		texture rt_bloom0 128 128 PF_BYTE_RGB
+		texture rt_bloom1 128 128 PF_BYTE_RGB
 
 
 		target rt_full
@@ -572,8 +572,8 @@ compositor "Gaussian Blur"
 		compositor_logic GaussianBlur
 		
         // Temporary textures
-        texture rt0 target_width target_height PF_A8R8G8B8
-        texture rt1 target_width target_height PF_A8R8G8B8
+        texture rt0 target_width target_height PF_BYTE_RGBA
+        texture rt1 target_width target_height PF_BYTE_RGBA
 
         target rt0
         {
@@ -616,7 +616,7 @@ compositor TestMRT
 	{
 		// temporary texture (MRT!)
 		// 4 sub-surfaces, all 32-bit
-		texture mrt0 target_width target_height PF_A8R8G8B8 PF_A8R8G8B8 PF_A8R8G8B8 PF_A8R8G8B8
+		texture mrt0 target_width target_height PF_BYTE_RGBA PF_BYTE_RGBA PF_BYTE_RGBA PF_BYTE_RGBA
 
         target mrt0
         {
@@ -657,7 +657,7 @@ compositor "Radial Blur"
     technique
     {
         // Temporary textures
-        texture rt0 target_width target_height PF_A8R8G8B8
+        texture rt0 target_width target_height PF_BYTE_RGBA
 
         target rt0
         {
@@ -686,7 +686,7 @@ compositor ASCII
     technique
     {
         // Temporary textures
-        texture rt0 target_width target_height PF_A8R8G8B8
+        texture rt0 target_width target_height PF_BYTE_RGBA
         target rt0
         {
             // Render output from previous compositor (or original scene)
@@ -714,7 +714,7 @@ compositor Halftone
     technique
     {
         // Temporary textures
-        texture rt0 target_width target_height PF_A8R8G8B8
+        texture rt0 target_width target_height PF_BYTE_RGBA
 
         target rt0
         {
@@ -742,7 +742,7 @@ compositor "Night Vision"
 {
     technique
     {
-        texture rt0 target_width target_height PF_A8R8G8B8
+        texture rt0 target_width target_height PF_BYTE_RGBA
 	
 	target rt0
 	{
@@ -767,7 +767,7 @@ compositor Dither
 {
     technique
     {
-        texture rt0 target_width target_height PF_A8R8G8B8
+        texture rt0 target_width target_height PF_BYTE_RGBA
 	
 	target rt0
 	{

--- a/Samples/Media/materials/scripts/SSAO/SSAO.compositor
+++ b/Samples/Media/materials/scripts/SSAO/SSAO.compositor
@@ -12,7 +12,7 @@ compositor SSAO/GBuffer
         // ---------------------------------------------------------------------
         texture mrt target_width target_height PF_FLOAT32_RGBA PF_FLOAT32_RGBA chain_scope
         texture occlusion target_width target_height PF_FLOAT32_RGBA chain_scope
-		texture scene target_width target_height PF_R8G8B8A8 chain_scope
+		texture scene target_width target_height PF_BYTE_RGBA chain_scope
 		
 		// the scene we want to modulate
         target scene

--- a/Samples/Media/materials/scripts/SSAO/SSAOPost.compositor
+++ b/Samples/Media/materials/scripts/SSAO/SSAOPost.compositor
@@ -2,7 +2,7 @@ compositor SSAO/Post/Modulate
 {
     technique 
     {
-		texture ssao target_width target_height PF_A8R8G8B8 chain_scope
+		texture ssao target_width target_height PF_BYTE_RGBA chain_scope
         
 	    target ssao
         {
@@ -74,7 +74,7 @@ compositor SSAO/Post/CrossBilateralFilter
 {
     technique
     {
-        texture accessibility target_width target_height PF_R8G8B8A8
+        texture accessibility target_width target_height PF_BYTE_RGBA
 
         target accessibility
         {


### PR DESCRIPTION
and port compositors - instead of hardcoding (A)BGR which on most
platforms requires colour conversions.