### PR TITLE
Main: prevent compositor instances from having empty render targets

### DIFF
--- a/OgreMain/src/OgreCompositorInstance.cpp
+++ b/OgreMain/src/OgreCompositorInstance.cpp
@@ -645,11 +645,17 @@ void CompositorInstance::createResources(bool forResizeOnly)
             deriveTextureRenderTargetOptions(def->name, &hwGamma, &fsaa, &fsaaHint);
             
             if(width == 0)
+            {
                 width = static_cast<size_t>(
                                             static_cast<float>(mChain->getViewport()->getActualWidth()) * def->widthFactor);
+                width = width == 0 ? 1 : width;
+            }
             if(height == 0)
+            {
                 height = static_cast<size_t>(
                                              static_cast<float>(mChain->getViewport()->getActualHeight()) * def->heightFactor);
+                height = height == 0 ? 1 : height;
+            }
             
             // determine options as a combination of selected options and possible options
             if (!def->fsaa)


### PR DESCRIPTION
When resizing the render window we sometimes ended up with compositor render targets having a height or a width of 0 resulting in segfault when trying to access the render target's texture buffer.

This is due to the render target's size factor which, when multiplied to the window size, could give a width or height < 1.

I'm not sure if this is the best solution but it may be useful.