### PR TITLE
Main: VectorBase - do not mark as export as it is fully inline

### DIFF
--- a/OgreMain/include/OgreVector.h
+++ b/OgreMain/include/OgreVector.h
@@ -43,7 +43,7 @@ namespace Ogre
     *  @{
     */
     /// helper class to implement legacy API. Notably x, y, z access
-    template <int dims, typename T> struct _OgreExport VectorBase
+    template <int dims, typename T> struct VectorBase
     {
         VectorBase() {}
         VectorBase(T _x, T _y)


### PR DESCRIPTION
fixes MSVC15 linking of Vector3i