### PR TITLE
Terrain: really reduce requirements to GLSL120

### DIFF
--- a/Components/Terrain/src/OgreTerrainMaterialGeneratorA.cpp
+++ b/Components/Terrain/src/OgreTerrainMaterialGeneratorA.cpp
@@ -98,8 +98,7 @@ namespace Ogre
         {
             mShaderLanguage = "hlsl";
         }
-        else if (hmgr.isLanguageSupported("glsl")
-                 && Root::getSingleton().getRenderSystem()->getNativeShadingLanguageVersion() >= 150)
+        else if (hmgr.isLanguageSupported("glsl"))
         {
             mShaderLanguage = "glsl";
         }


### PR DESCRIPTION
fixes "flat" terrain on GL rendersystem with drivers only exposing 3.0
compatibility profile, hence GLSL130