### PR TITLE
Reintroduce _WndProc from 1.10

### DIFF
--- a/Components/Bites/include/OgreWindowEventUtilities.h
+++ b/Components/Bites/include/OgreWindowEventUtilities.h
@@ -34,6 +34,16 @@ THE SOFTWARE.
 #include "OgreCommon.h"
 #include "OgreHeaderPrefix.h"
 
+#if OGRE_PLATFORM == OGRE_PLATFORM_WIN32
+#  if !defined(WIN32_LEAN_AND_MEAN)
+#   define WIN32_LEAN_AND_MEAN
+#  endif
+#  if !defined(NOMINMAX) && defined(_MSC_VER)
+#   define NOMINMAX // required to stop windows.h messing up std::min
+#  endif
+#  include <windows.h>
+#endif
+
 /** \addtogroup Optional
 *  @{
 */
@@ -149,6 +159,12 @@ namespace OgreBites
             The RenderWindow to remove from list
         */
         static void _removeRenderWindow(Ogre::RenderWindow* window);
+
+        // backwards compatibility
+#if OGRE_PLATFORM == OGRE_PLATFORM_WIN32
+        //! Internal winProc (RenderWindow's use this when creating the Win32 Window)
+        static LRESULT CALLBACK _WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
+#endif
     };
 }
 /** @} */

--- a/Components/Bites/src/OgreWindowEventUtilities.cpp
+++ b/Components/Bites/src/OgreWindowEventUtilities.cpp
@@ -51,6 +51,125 @@ static RenderWindowList _msWindows;
 static void GLXProc( RenderWindow *win, const XEvent &event );
 #endif
 
+#if OGRE_PLATFORM == OGRE_PLATFORM_WIN32
+//--------------------------------------------------------------------------------//
+LRESULT CALLBACK WindowEventUtilities::_WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
+{
+    if (uMsg == WM_CREATE)
+    {   // Store pointer to Win32Window in user data area
+        SetWindowLongPtr(hWnd, GWLP_USERDATA, (LONG_PTR)(((LPCREATESTRUCT)lParam)->lpCreateParams));
+        return 0;
+    }
+
+    // look up window instance
+    // note: it is possible to get a WM_SIZE before WM_CREATE
+    RenderWindow* win = (RenderWindow*)GetWindowLongPtr(hWnd, GWLP_USERDATA);
+    if (!win)
+        return DefWindowProc(hWnd, uMsg, wParam, lParam);
+
+    //LogManager* log = LogManager::getSingletonPtr();
+    //Iterator of all listeners registered to this RenderWindow
+    WindowEventListeners::iterator index,
+        start = _msListeners.lower_bound(win),
+        end = _msListeners.upper_bound(win);
+
+    switch( uMsg )
+    {
+    case WM_ACTIVATE:
+    {
+        bool active = (LOWORD(wParam) != WA_INACTIVE);
+        if( active )
+        {
+            win->setActive( true );
+        }
+        else
+        {
+            if( win->isDeactivatedOnFocusChange() )
+            {
+                win->setActive( false );
+            }
+        }
+
+        for( ; start != end; ++start )
+            (start->second)->windowFocusChange(win);
+        break;
+    }
+    case WM_SYSKEYDOWN:
+        switch( wParam )
+        {
+        case VK_CONTROL:
+        case VK_SHIFT:
+        case VK_MENU: //ALT
+            //return zero to bypass defProc and signal we processed the message
+            return 0;
+        }
+        break;
+    case WM_SYSKEYUP:
+        switch( wParam )
+        {
+        case VK_CONTROL:
+        case VK_SHIFT:
+        case VK_MENU: //ALT
+        case VK_F10:
+            //return zero to bypass defProc and signal we processed the message
+            return 0;
+        }
+        break;
+    case WM_SYSCHAR:
+        // return zero to bypass defProc and signal we processed the message, unless it's an ALT-space
+        if (wParam != VK_SPACE)
+            return 0;
+        break;
+    case WM_ENTERSIZEMOVE:
+        //log->logMessage("WM_ENTERSIZEMOVE");
+        break;
+    case WM_EXITSIZEMOVE:
+        //log->logMessage("WM_EXITSIZEMOVE");
+        break;
+    case WM_MOVE:
+        //log->logMessage("WM_MOVE");
+        win->windowMovedOrResized();
+        for(index = start; index != end; ++index)
+            (index->second)->windowMoved(win);
+        break;
+    case WM_DISPLAYCHANGE:
+        win->windowMovedOrResized();
+        for(index = start; index != end; ++index)
+            (index->second)->windowResized(win);
+        break;
+    case WM_SIZE:
+        //log->logMessage("WM_SIZE");
+        win->windowMovedOrResized();
+        for(index = start; index != end; ++index)
+            (index->second)->windowResized(win);
+        break;
+    case WM_GETMINMAXINFO:
+        // Prevent the window from going smaller than some minimu size
+        ((MINMAXINFO*)lParam)->ptMinTrackSize.x = 100;
+        ((MINMAXINFO*)lParam)->ptMinTrackSize.y = 100;
+        break;
+    case WM_CLOSE:
+    {
+        //log->logMessage("WM_CLOSE");
+        bool close = true;
+        for(index = start; index != end; ++index)
+        {
+            if (!(index->second)->windowClosing(win))
+                close = false;
+        }
+        if (!close) return 0;
+
+        for(index = _msListeners.lower_bound(win); index != end; ++index)
+            (index->second)->windowClosed(win);
+        win->destroy();
+        return 0;
+    }
+    }
+
+    return DefWindowProc( hWnd, uMsg, wParam, lParam );
+}
+#endif // OGRE_PLATFORM == OGRE_PLATFORM_WIN32
+
 //--------------------------------------------------------------------------------//
 void WindowEventUtilities::messagePump()
 {

--- a/RenderSystems/Direct3D11/src/OgreD3D11RenderWindow.cpp
+++ b/RenderSystems/Direct3D11/src/OgreD3D11RenderWindow.cpp
@@ -664,6 +664,7 @@ namespace Ogre
         D3D11RenderWindowSwapChainBased::create(name, width, height, fullScreen, miscParams);
 
         HWND parentHWnd = 0;
+        WNDPROC windowProc = DefWindowProc;
         HWND externalHandle = 0;
         String title = name;
 
@@ -699,6 +700,9 @@ namespace Ogre
             opt = miscParams->find("parentWindowHandle");
             if(opt != miscParams->end())
                 parentHWnd = (HWND)StringConverter::parseSizeT(opt->second);
+            opt = miscParams->find("windowProc");
+            if (opt != miscParams->end())
+                windowProc = reinterpret_cast<WNDPROC>(StringConverter::parseSizeT(opt->second));
             // externalWindowHandle     -> externalHandle
             opt = miscParams->find("externalWindowHandle");
             if(opt != miscParams->end())
@@ -841,7 +845,7 @@ namespace Ogre
 			static TCHAR staticVar;
 			GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, &staticVar, &hInst);
 
-			WNDCLASS wc = { classStyle, DefWindowProc, 0, 0, hInst,
+			WNDCLASS wc = { classStyle, windowProc, 0, 0, hInst,
 				LoadIcon(0, IDI_APPLICATION), LoadCursor(NULL, IDC_ARROW),
 				(HBRUSH)GetStockObject(BLACK_BRUSH), 0, OGRE_D3D11_WIN_CLASS_NAME };
 			RegisterClass(&wc);

--- a/RenderSystems/Direct3D9/src/OgreD3D9RenderWindow.cpp
+++ b/RenderSystems/Direct3D9/src/OgreD3D9RenderWindow.cpp
@@ -75,6 +75,7 @@ namespace Ogre
         HINSTANCE hInst = mInstance;
     
         HWND parentHWnd = 0;
+        WNDPROC windowProc = DefWindowProc;
         HWND externalHandle = 0;
         mFSAAType = D3DMULTISAMPLE_NONE;
         mFSAAQuality = 0;
@@ -115,6 +116,9 @@ namespace Ogre
             opt = miscParams->find("parentWindowHandle");
             if(opt != miscParams->end())
                 parentHWnd = (HWND)StringConverter::parseSizeT(opt->second);
+            opt = miscParams->find("windowProc");
+            if (opt != miscParams->end())
+                windowProc = reinterpret_cast<WNDPROC>(StringConverter::parseSizeT(opt->second));
             // externalWindowHandle     -> externalHandle
             opt = miscParams->find("externalWindowHandle");
             if(opt != miscParams->end())
@@ -333,7 +337,7 @@ namespace Ogre
 
             // Register the window class
             // NB allow 4 bytes of window data for D3D9RenderWindow pointer
-            WNDCLASS wc = { classStyle, DefWindowProc, 0, 0, hInst,
+            WNDCLASS wc = { classStyle, windowProc, 0, 0, hInst,
                 LoadIcon(0, IDI_APPLICATION), LoadCursor(NULL, IDC_ARROW),
                 (HBRUSH)GetStockObject(BLACK_BRUSH), 0, "OgreD3D9Wnd" };
             RegisterClass(&wc);

--- a/RenderSystems/GLSupport/src/win32/OgreWin32Window.cpp
+++ b/RenderSystems/GLSupport/src/win32/OgreWin32Window.cpp
@@ -108,6 +108,7 @@ namespace Ogre {
         int left = -1; // Defaults to screen center
         int top = -1; // Defaults to screen center
         HWND parent = 0;
+        WNDPROC windowProc = DefWindowProc;
         String title = name;
         bool hidden = false;
         String border;
@@ -240,6 +241,8 @@ namespace Ogre {
             if ((opt = miscParams->find("parentWindowHandle")) != end)
                 parent = (HWND)StringConverter::parseSizeT(opt->second);
 
+            if ((opt = miscParams->find("windowProc")) != end)
+                windowProc = reinterpret_cast<WNDPROC>(StringConverter::parseSizeT(opt->second));
 
             // monitor index
             if ((opt = miscParams->find("monitorIndex")) != end)
@@ -380,7 +383,7 @@ namespace Ogre {
                 classStyle |= CS_DBLCLKS;
 
             // register class and create window
-            WNDCLASS wc = { classStyle, DefWindowProc, 0, 0, hInst,
+            WNDCLASS wc = { classStyle, windowProc, 0, 0, hInst,
                 LoadIcon(NULL, IDI_APPLICATION), LoadCursor(NULL, IDC_ARROW),
                 (HBRUSH)GetStockObject(BLACK_BRUSH), NULL, "OgreGLWindow" };
             RegisterClass(&wc);


### PR DESCRIPTION
Now users upgrading from 1.10 to 1.11 can keep using Ogre window system by providing the `_WndProc` in the `miscParams`:
```c++
Ogre::NameValuePairList miscParams;
miscParams["windowProc"] = Ogre::StringConverter::toString((size_t)OgreBites::WindowEventUtilities::_WndProc);
Ogre::RenderWindow* renderWindow = Ogre::Root::getSingleton().createRenderWindow(name, width, height, isFullScreen, &miscParams);
OgreBites::WindowEventUtilities::_addRenderWindow(renderWindow);
```