### PR TITLE
GLSupport: GLX - correctly handle windowMovedOrResized with parent win

### DIFF
--- a/Components/Bites/src/OgreApplicationContext.cpp
+++ b/Components/Bites/src/OgreApplicationContext.cpp
@@ -792,7 +792,6 @@ void ApplicationContext::pollEvents()
                     continue;
 
                 Ogre::RenderWindow* win = it->render;
-                win->resize(event.window.data1, event.window.data2);
                 win->windowMovedOrResized();
                 windowResized(win);
             }

--- a/RenderSystems/GLSupport/src/GLX/OgreGLXWindow.cpp
+++ b/RenderSystems/GLSupport/src/GLX/OgreGLXWindow.cpp
@@ -697,29 +697,33 @@ namespace Ogre
         Display* xDisplay = mGLSupport->getXDisplay();
         XWindowAttributes windowAttrib;
 
+        Window parent, root, *children;
+        uint nChildren;
+
+        XQueryTree(xDisplay, mWindow, &root, &parent, &children, &nChildren);
+
+        if (children)
+            XFree(children);
+
+        XGetWindowAttributes(xDisplay, parent, &windowAttrib);
+
         if (mIsTopLevel && !mIsFullScreen)
         {
-            Window parent, root, *children;
-            uint nChildren;
-
-            XQueryTree(xDisplay, mWindow, &root, &parent, &children, &nChildren);
-
-            if (children)
-                XFree(children);
-
-            XGetWindowAttributes(xDisplay, parent, &windowAttrib);
-
             mLeft = windowAttrib.x;
             mTop  = windowAttrib.y;
         }
-
-        XGetWindowAttributes(xDisplay, mWindow, &windowAttrib);
 
         if (mWidth == (size_t)windowAttrib.width && mHeight == (size_t)windowAttrib.height)
             return;
 
         mWidth = windowAttrib.width;
         mHeight = windowAttrib.height;
+
+        if(!mIsTopLevel)
+        {
+            XResizeWindow(xDisplay, mWindow, mWidth, mHeight);
+            XFlush(xDisplay);
+        }
 
         for (ViewportList::iterator it = mViewportList.begin(); it != mViewportList.end(); ++it)
             (*it).second->_updateDimensions();


### PR DESCRIPTION
and consequently remove superficial resize call in Bites