### PR TITLE
erase the element that should be existed in the map

### DIFF
--- a/OgreMain/src/Android/OgreAPKFileSystemArchive.cpp
+++ b/OgreMain/src/Android/OgreAPKFileSystemArchive.cpp
@@ -87,8 +87,10 @@ namespace {
 	APKFileSystemArchive::~APKFileSystemArchive()
 	{
 		std::map<String, std::vector< String > >::iterator iter = mFiles.find( mName );
-		iter->second.clear(); 
-		mFiles.erase( iter );  	
+		if (iter != mFiles.end()) {
+			iter->second.clear();
+			mFiles.erase( iter );
+		}
 		unload();
 	}
 


### PR DESCRIPTION
This fixed the crash issue in Android when ApplicationContext::closeApp() called