### PR TITLE
D3D9: drop actually unsupported RSC_AUTOMIPMAP_COMPRESSED

### DIFF
--- a/RenderSystems/Direct3D9/src/OgreD3D9RenderSystem.cpp
+++ b/RenderSystems/Direct3D9/src/OgreD3D9RenderSystem.cpp
@@ -927,7 +927,6 @@ namespace Ogre
         rsc->setNumTextureUnits(OGRE_MAX_TEXTURE_LAYERS);
         rsc->setNumVertexAttributes(14); // see D3DDECLUSAGE
         rsc->setCapability(RSC_ANISOTROPY);
-        rsc->setCapability(RSC_AUTOMIPMAP_COMPRESSED);
         rsc->setCapability(RSC_DOT3);
         rsc->setCapability(RSC_CUBEMAPPING);        
         rsc->setCapability(RSC_SCISSOR_TEST);       
@@ -1003,10 +1002,6 @@ namespace Ogre
             // Check for Anisotropy.
             if (rkCurCaps.MaxAnisotropy <= 1)
                 rsc->unsetCapability(RSC_ANISOTROPY);
-
-            // Check automatic mipmap generation.
-            if ((rkCurCaps.Caps2 & D3DCAPS2_CANAUTOGENMIPMAP) == 0)
-                rsc->unsetCapability(RSC_AUTOMIPMAP_COMPRESSED);
 
             // Check Dot product 3.
             if ((rkCurCaps.TextureOpCaps & D3DTEXOPCAPS_DOTPRODUCT3) == 0)


### PR DESCRIPTION
d3dx did some magic while loading. probably storing it uncompressed.