### PR TITLE
D3D9: do not crash when moving window to the second screen

### DIFF
--- a/RenderSystems/Direct3D9/src/OgreD3D9Texture.cpp
+++ b/RenderSystems/Direct3D9/src/OgreD3D9Texture.cpp
@@ -284,7 +284,13 @@ namespace Ogre
 
             preLoadImpl();
 
-            loadImpl();
+            // FIXME
+            // loadImpl();
+            // loadImpl calls this again via getBuffer causing a stackoverflow
+            // prefer an empty texture to crashing for now
+            // to fix this we should probably use the notify mechanism instead of
+            // recrating the texture in getBuffer..
+            createInternalResourcesImpl(d3d9Device);
 
             postLoadImpl();         
         }       


### PR DESCRIPTION
related #710 