### PR TITLE
D3D9: only disable texture loading from getBuffer

### DIFF
--- a/RenderSystems/Direct3D9/src/OgreD3D9Texture.cpp
+++ b/RenderSystems/Direct3D9/src/OgreD3D9Texture.cpp
@@ -284,13 +284,7 @@ namespace Ogre
 
             preLoadImpl();
 
-            // FIXME
-            // loadImpl();
-            // loadImpl calls this again via getBuffer causing a stackoverflow
-            // prefer an empty texture to crashing for now
-            // to fix this we should probably use the notify mechanism instead of
-            // recrating the texture in getBuffer..
-            createInternalResourcesImpl(d3d9Device);
+            loadImpl();
 
             postLoadImpl();         
         }       
@@ -1212,8 +1206,14 @@ namespace Ogre
         IDirect3DDevice9* d3d9Device = D3D9RenderSystem::getActiveD3D9Device();
         TextureResources* textureResources = getTextureResources(d3d9Device);
         if (textureResources == NULL || textureResources->pBaseTex == NULL)
-        {               
-            createTextureResources(d3d9Device);
+        {
+            // FIXME
+            // createTextureResources(d3d9Device);
+            // createTextureResources calls getBuffer again causing a stackoverflow
+            // prefer an empty texture to crashing for now
+            // to fix this we should probably use the notify mechanism instead of
+            // recrating the texture in here..
+            createInternalResourcesImpl(d3d9Device);
             textureResources = getTextureResources(d3d9Device);         
         }
         assert(textureResources != NULL);


### PR DESCRIPTION
as the other paths still should work fine