### PR TITLE
Added option for building legacy light lists

### DIFF
--- a/OgreMain/include/OgreSceneManager.h
+++ b/OgreMain/include/OgreSceneManager.h
@@ -489,6 +489,7 @@ namespace Ogre {
 
         ForwardPlusBase *mForwardPlusSystem;
         ForwardPlusBase *mForwardPlusImpl;
+        bool mBuildLegacyLightList;
 
         TexturePtr mDecalsDiffuseTex;
         TexturePtr mDecalsNormalsTex;
@@ -1338,6 +1339,14 @@ namespace Ogre {
         void setForwardClustered( bool bEnable, uint32 width, uint32 height, uint32 numSlices,
                                   uint32 lightsPerCell, uint32 decalsPerCell, float minDistance,
                                   float maxDistance );
+
+        /** Enables or disables the legace 1.9 way of building light lists which can be 
+            used by HlmsLowLevel materials.
+            This light list can be turned on regardless of any Forward* mode but it 
+            consumes a lot of performance and is only used by HlmsLowLevel materials 
+            that need ligting.
+        */
+        void setBuildLegacyLightList(bool bEnable);
 
         ForwardPlusBase* getForwardPlus(void)                       { return mForwardPlusSystem; }
         ForwardPlusBase* _getActivePassForwardPlus(void)            { return mForwardPlusImpl; }

--- a/OgreMain/src/OgreHlmsLowLevel.cpp
+++ b/OgreMain/src/OgreHlmsLowLevel.cpp
@@ -283,6 +283,7 @@ namespace Ogre
         mAutoParamDataSource->setCurrentRenderable( renderable );
         mAutoParamDataSource->setWorldMatrices( mTempXform, numMatrices );
         mAutoParamDataSource->setCurrentPass( pass );
+        mAutoParamDataSource->setCurrentLightList(&renderable->getLights());
 
         if( pass->getFogOverride() )
         {


### PR DESCRIPTION
Also setting light list auto-param in HlmsLowLevel material.

This optionally re-enables lighting of legacy materials, now implemented
with HlmsLowLevel.

Note that the legacy light lists cost a lot of performance and is not
used by real hlms materials.