### PR TITLE
Bites: add hacky workaround for black window on OSX

### DIFF
--- a/Components/Bites/src/OgreApplicationContext.cpp
+++ b/Components/Bites/src/OgreApplicationContext.cpp
@@ -798,6 +798,15 @@ void ApplicationContext::pollEvents()
             break;
         }
     }
+
+#   if OGRE_PLATFORM == OGRE_PLATFORM_APPLE
+    // hacky workaround for black window on OSX
+    for(const auto& win : mWindows)
+    {
+        SDL_SetWindowSize(win.native, win.render->getWidth(), win.render->getHeight());
+        win.render->windowMovedOrResized();
+    }
+#   endif
 #elif OGRE_PLATFORM == OGRE_PLATFORM_ANDROID
     for(WindowList::iterator it = mWindows.begin(); it != mWindows.end(); ++it)
     {


### PR DESCRIPTION
fixes #913 