### PR TITLE
Bites: extract ApplicationContextBase to allow multiple implementations

### DIFF
--- a/Components/Bites/CMakeLists.txt
+++ b/Components/Bites/CMakeLists.txt
@@ -69,13 +69,19 @@ list(APPEND HEADER_FILES
   ${CMAKE_CURRENT_SOURCE_DIR}/include/OgreBites.i)
 set(SOURCES 
   "${CMAKE_CURRENT_SOURCE_DIR}/src/OgreAdvancedRenderControls.cpp"
-  "${CMAKE_CURRENT_SOURCE_DIR}/src/OgreApplicationContext.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/OgreApplicationContextBase.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/OgreBitesConfigDialog.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/OgreCameraMan.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/OgreSGTechniqueResolverListener.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/OgreStaticPluginLoader.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/OgreTrays.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/OgreWindowEventUtilities.cpp")
+
+if(SDL2_FOUND OR EMSCRIPTEN)
+  list(APPEND SOURCES  "${CMAKE_CURRENT_SOURCE_DIR}/src/OgreApplicationContextSDL.cpp")
+elseif(ANDROID)
+  list(APPEND SOURCES  "${CMAKE_CURRENT_SOURCE_DIR}/src/OgreApplicationContextAndroid.cpp")
+endif()
 
 if(ANDROID OR EMSCRIPTEN OR APPLE_IOS OR WINDOWS_STORE OR WINDOWS_PHONE)
   # no config dialog available

--- a/Components/Bites/include/OgreApplicationContextBase.h
+++ b/Components/Bites/include/OgreApplicationContextBase.h
@@ -1,0 +1,307 @@
+/*
+ -----------------------------------------------------------------------------
+ This source file is part of OGRE
+ (Object-oriented Graphics Rendering Engine)
+ For the latest info, see http://www.ogre3d.org/
+
+ Copyright (c) 2000-2014 Torus Knot Software Ltd
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ -----------------------------------------------------------------------------
+ */
+#ifndef __ApplicationContextBase_H__
+#define __ApplicationContextBase_H__
+
+#include "OgreBitesPrerequisites.h"
+#include "OgreBuildSettings.h"
+#include "OgreLogManager.h"
+#include "OgrePlugin.h"
+#include "OgreFileSystemLayer.h"
+#include "OgreFrameListener.h"
+#include "OgreStaticPluginLoader.h"
+
+#ifdef OGRE_BUILD_COMPONENT_RTSHADERSYSTEM
+#include "OgreSGTechniqueResolverListener.h"
+#endif // INCLUDE_RTSHADER_SYSTEM
+
+// forward declarations
+extern "C" struct SDL_Window;
+
+namespace Ogre {
+    class OverlaySystem;
+}
+
+#if OGRE_PLATFORM == OGRE_PLATFORM_ANDROID
+#include <android/native_window.h>
+#endif
+
+#include "OgreInput.h"
+
+/** \addtogroup Optional Optional Components
+*  @{
+*/
+/** \defgroup Bites Bites
+* reusable utilities for rapid prototyping
+*  @{
+*/
+namespace OgreBites
+{
+#if OGRE_PLATFORM == OGRE_PLATFORM_ANDROID
+    typedef ANativeWindow NativeWindowType;
+#else
+    typedef SDL_Window NativeWindowType;
+#endif
+
+    /**
+     * link between a renderwindow and a platform specific window
+     */
+    struct NativeWindowPair
+    {
+        Ogre::RenderWindow* render;
+        NativeWindowType* native;
+    };
+
+    /**
+    Base class responsible for setting up a common context for applications.
+    Subclass to implement specific event callbacks.
+    */
+    class _OgreBitesExport ApplicationContextBase : public Ogre::FrameListener
+    {
+    public:
+        explicit ApplicationContextBase(const Ogre::String& appName = OGRE_VERSION_NAME);
+
+        virtual ~ApplicationContextBase();
+
+        /**
+         * get the main RenderWindow
+         * owns the context on OpenGL
+         */
+        Ogre::RenderWindow* getRenderWindow() const
+        {
+            return mWindows.empty() ? NULL : mWindows[0].render;
+        }
+
+        Ogre::Root* getRoot() const {
+            return mRoot;
+        }
+
+        Ogre::OverlaySystem* getOverlaySystem() const {
+            return mOverlaySystem;
+        }
+
+        /**
+        This function initializes the render system and resources.
+        */
+        void initApp();
+
+        /**
+        This function closes down the application - saves the configuration then
+        shutdowns.
+        */
+        void closeApp();
+
+        // callback interface copied from various listeners to be used by ApplicationContext
+        virtual bool frameStarted(const Ogre::FrameEvent& evt) {
+            pollEvents();
+            return true;
+        }
+        virtual bool frameRenderingQueued(const Ogre::FrameEvent& evt);
+        virtual bool frameEnded(const Ogre::FrameEvent& evt) { return true; }
+        virtual void windowMoved(Ogre::RenderWindow* rw) {}
+        virtual void windowResized(Ogre::RenderWindow* rw) {}
+        virtual bool windowClosing(Ogre::RenderWindow* rw) { return true; }
+        virtual void windowClosed(Ogre::RenderWindow* rw) {}
+        virtual void windowFocusChange(Ogre::RenderWindow* rw) {}
+
+        /**
+         * inspect the event and call one of the corresponding functions on the registered InputListener
+         * @param event Input Event
+         * @param windowID only call listeners of this window
+         */
+        void _fireInputEvent(const Event& event, uint32_t windowID) const;
+
+        /**
+          Initialize the RT Shader system.
+          */
+        bool initialiseRTShaderSystem();
+
+        /**
+         * make the RTSS write out the generated shaders for caching and debugging
+         *
+         * by default all shaders are generated to system memory.
+         * Must be called before loadResources
+         * @param write
+         */
+        void setRTSSWriteShadersToDisk(bool write);
+
+        /**
+        Destroy the RT Shader system.
+          */
+        void destroyRTShaderSystem();
+
+        /**
+         Sets up the context after configuration.
+         */
+        virtual void setup();
+
+        /**
+        Creates the OGRE root.
+        */
+        virtual void createRoot();
+
+        /**
+        Configures the startup settings for OGRE. I use the config dialog here,
+        but you can also restore from a config file. Note that this only happens
+        when you start the context, and not when you reset it.
+        */
+        virtual bool oneTimeConfig();
+
+        /**
+        When input is grabbed the mouse is confined to the window.
+        */
+        virtual void setWindowGrab(NativeWindowType* win, bool grab = true) {}
+
+        /// @overload
+        void setWindowGrab(bool grab = true) {
+            OgreAssert(!mWindows.empty(), "create a window first");
+            setWindowGrab(mWindows[0].native, grab);
+        }
+
+        /**
+        Finds context-wide resource groups. I load paths from a config file here,
+        but you can choose your resource locations however you want.
+        */
+        virtual void locateResources();
+
+        /**
+        Loads context-wide resource groups. I chose here to simply initialise all
+        groups, but you can fully load specific ones if you wish.
+        */
+        virtual void loadResources();
+
+        /**
+        Reconfigures the context. Attempts to preserve the current sample state.
+        */
+        virtual void reconfigure(const Ogre::String& renderer, Ogre::NameValuePairList& options);
+
+
+        /**
+        Cleans up and shuts down the context.
+        */
+        virtual void shutdown();
+
+        /**
+        process all window events since last call
+        */
+        virtual void pollEvents();
+
+        /**
+        Creates dummy scene to allow rendering GUI in viewport.
+          */
+        void createDummyScene();
+
+        /**
+        Destroys dummy scene.
+          */
+        void destroyDummyScene();
+
+        /**
+         * enables the caching of compiled shaders to file
+         *
+         * also loads any existing cache
+         */
+        void enableShaderCache() const;
+
+        /** attach input listener
+         *
+         * @param lis the listener
+         * @param win the window to receive the events for.
+         */
+        virtual void addInputListener(NativeWindowType* win, InputListener* lis);
+
+        /// @overload
+        void addInputListener(InputListener* lis) {
+            OgreAssert(!mWindows.empty(), "create a window first");
+            addInputListener(mWindows[0].native, lis);
+        }
+
+        /** detatch input listener
+         *
+         * @param lis the listener
+         * @param win the window to receive the events for.
+         */
+        virtual void removeInputListener(NativeWindowType* win, InputListener* lis);
+
+        /// @overload
+        void removeInputListener(InputListener* lis) {
+            OgreAssert(!mWindows.empty(), "called after all windows were deleted");
+            removeInputListener(mWindows[0].native, lis);
+        }
+
+        void parseWindowOptions(uint32_t& w, uint32_t& h, Ogre::NameValuePairList& miscParams);
+
+        /**
+         * Create a new render window
+         *
+         * You must use SDL and not an auto-created window as SDL does not get the events
+         * otherwise.
+         *
+         * By default the values from ogre.cfg are used for w, h and miscParams.
+         */
+        virtual NativeWindowPair
+        createWindow(const Ogre::String& name, uint32_t w = 0, uint32_t h = 0,
+                     Ogre::NameValuePairList miscParams = Ogre::NameValuePairList());
+
+        /**
+         * get the FileSystemLayer instace pointing to an application specific directory
+         */
+        Ogre::FileSystemLayer& getFSLayer() { return *mFSLayer; }
+
+        /**
+         * the directory where the media files were installed
+         *
+         * same as OGRE_MEDIA_DIR in CMake
+         */
+        static Ogre::String getDefaultMediaDir();
+    protected:
+        Ogre::OverlaySystem* mOverlaySystem;  // Overlay system
+
+        Ogre::FileSystemLayer* mFSLayer; // File system abstraction layer
+        Ogre::Root* mRoot;              // OGRE root
+        StaticPluginLoader mStaticPluginLoader;
+        bool mFirstRun;
+        Ogre::String mNextRenderer;     // name of renderer used for next run
+        Ogre::String mAppName;
+
+        typedef std::vector<NativeWindowPair> WindowList;
+        WindowList mWindows; // all windows
+
+        typedef std::set<std::pair<uint32_t, InputListener*> > InputListenerList;
+        InputListenerList mInputListeners;
+
+#ifdef OGRE_BUILD_COMPONENT_RTSHADERSYSTEM
+        Ogre::RTShader::ShaderGenerator*       mShaderGenerator; // The Shader generator instance.
+        SGTechniqueResolverListener*       mMaterialMgrListener; // Shader generator material manager listener.
+        Ogre::String                           mRTShaderLibPath;
+#endif // INCLUDE_RTSHADER_SYSTEM
+    };
+}
+/** @} */
+/** @} */
+#endif

--- a/Components/Bites/include/OgreBites.i
+++ b/Components/Bites/include/OgreBites.i
@@ -3,6 +3,7 @@
 /* Includes the header in the wrapper code */
 #include "Ogre.h"
 #include "OgreBuildSettings.h"
+#include "OgreApplicationContextBase.h"
 #include "OgreApplicationContext.h"
 #include "OgreSGTechniqueResolverListener.h"
 #include "OgreCameraMan.h"
@@ -32,9 +33,9 @@
 JNIEnv* OgreJNIGetEnv();
 %}
 
-%ignore OgreBites::ApplicationContext::initApp;
-%ignore OgreBites::ApplicationContext::initAppForAndroid(AAssetManager*, ANativeWindow*);
-%extend OgreBites::ApplicationContext {
+%ignore OgreBites::ApplicationContextAndroid::initApp;
+%ignore OgreBites::ApplicationContextAndroid::initAppForAndroid(AAssetManager*, ANativeWindow*);
+%extend OgreBites::ApplicationContextAndroid {
     void initAppForAndroid(jobject assetManager, jobject surface) {
         OgreAssert(assetManager, "assetManager is NULL");
         OgreAssert(surface, "surface is NULL");
@@ -44,8 +45,12 @@ JNIEnv* OgreJNIGetEnv();
         $self->initAppForAndroid(assetMgr, nativeWnd);
     }
 }
+%rename(ApplicationContext) ApplicationContextAndroid;
+#else
+%rename(ApplicationContext) ApplicationContextSDL; // keep the pre 1.12 name
 #endif
 
+%include "OgreApplicationContextBase.h"
 %include "OgreApplicationContext.h"
 %include "OgreCameraMan.h"
 // deprecated

--- a/Components/Bites/src/OgreApplicationContextAndroid.cpp
+++ b/Components/Bites/src/OgreApplicationContextAndroid.cpp
@@ -1,0 +1,124 @@
+// This file is part of the OGRE project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at https://www.ogre3d.org/licensing.
+
+#include "OgreApplicationContext.h"
+
+#include "OgreRoot.h"
+#include "OgreRenderWindow.h"
+
+#include "OgreArchiveManager.h"
+#include "OgreFileSystem.h"
+#include "OgreZip.h"
+
+namespace OgreBites {
+
+ApplicationContextAndroid::ApplicationContextAndroid(const Ogre::String& appName) : ApplicationContextBase(appName)
+{
+    mAAssetMgr = NULL;
+    mAConfig = NULL;
+}
+
+NativeWindowPair ApplicationContextAndroid::createWindow(const Ogre::String& name, Ogre::uint32 w, Ogre::uint32 h, Ogre::NameValuePairList miscParams)
+{
+    miscParams["externalWindowHandle"] = Ogre::StringConverter::toString(reinterpret_cast<size_t>(mWindows[0].native));
+    miscParams["androidConfig"] = Ogre::StringConverter::toString(reinterpret_cast<size_t>(mAConfig));
+    miscParams["preserveContext"] = "true"; //Optionally preserve the gl context, prevents reloading all resources, this is false by default
+
+    mWindows[0].render = Ogre::Root::getSingleton().createRenderWindow(name, 0, 0, false, &miscParams);
+    return mWindows[0];
+}
+
+void ApplicationContextAndroid::initAppForAndroid(AAssetManager* assetMgr, ANativeWindow* window)
+{
+    mAConfig = AConfiguration_new();
+    AConfiguration_fromAssetManager(mAConfig, assetMgr);
+    mAAssetMgr = assetMgr;
+
+    mWindows.resize(1);
+    mWindows[0].native = window;
+
+    initApp();
+}
+
+void ApplicationContextAndroid::_fireInputEventAndroid(AInputEvent* event, int wheel) {
+    Event evt = {0};
+
+    static TouchFingerEvent lastTouch = {0};
+
+    if(wheel) {
+        evt.type = MOUSEWHEEL;
+        evt.wheel.y = wheel;
+        _fireInputEvent(evt, 0);
+        lastTouch.fingerId = -1; // prevent move-jump after pinch is over
+        return;
+    }
+
+    if (AInputEvent_getType(event) == AINPUT_EVENT_TYPE_MOTION) {
+        int32_t action = AMOTION_EVENT_ACTION_MASK & AMotionEvent_getAction(event);
+
+        switch (action) {
+        case AMOTION_EVENT_ACTION_DOWN:
+            evt.type = FINGERDOWN;
+            break;
+        case AMOTION_EVENT_ACTION_UP:
+            evt.type = FINGERUP;
+            break;
+        case AMOTION_EVENT_ACTION_MOVE:
+            evt.type = FINGERMOTION;
+            break;
+        default:
+            return;
+        }
+
+        Ogre::RenderWindow* win = getRenderWindow();
+
+        evt.tfinger.fingerId = AMotionEvent_getPointerId(event, 0);
+        evt.tfinger.x = AMotionEvent_getRawX(event, 0) / win->getWidth();
+        evt.tfinger.y = AMotionEvent_getRawY(event, 0) / win->getHeight();
+
+        if(evt.type == FINGERMOTION) {
+            if(evt.tfinger.fingerId != lastTouch.fingerId)
+                return; // wrong finger
+
+            evt.tfinger.dx = evt.tfinger.x - lastTouch.x;
+            evt.tfinger.dy = evt.tfinger.y - lastTouch.y;
+        }
+
+        lastTouch = evt.tfinger;
+    } else {
+        if(AKeyEvent_getKeyCode(event) != AKEYCODE_BACK)
+            return;
+
+        evt.type = AKeyEvent_getAction(event) == AKEY_EVENT_ACTION_DOWN ? KEYDOWN : KEYUP;
+        evt.key.keysym.sym = SDLK_ESCAPE;
+    }
+
+    _fireInputEvent(evt, 0);
+}
+
+void ApplicationContextAndroid::locateResources()
+{
+    Ogre::ArchiveManager::getSingleton().addArchiveFactory( new Ogre::APKFileSystemArchiveFactory(mAAssetMgr) );
+    Ogre::ArchiveManager::getSingleton().addArchiveFactory( new Ogre::APKZipArchiveFactory(mAAssetMgr) );
+    ApplicationContextBase::locateResources();
+}
+
+void ApplicationContextAndroid::shutdown()
+{
+    ApplicationContextBase::shutdown();
+    mWindows.clear();
+    AConfiguration_delete(mAConfig);
+}
+
+void ApplicationContextAndroid::pollEvents()
+{
+    for(WindowList::iterator it = mWindows.begin(); it != mWindows.end(); ++it)
+    {
+        Ogre::RenderWindow* win = it->render;
+        win->windowMovedOrResized();
+        windowResized(win);
+    }
+}
+
+}

--- a/Components/Bites/src/OgreApplicationContextSDL.cpp
+++ b/Components/Bites/src/OgreApplicationContextSDL.cpp
@@ -1,0 +1,148 @@
+// This file is part of the OGRE project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at https://www.ogre3d.org/licensing.
+
+#include "OgreApplicationContext.h"
+
+#include "OgreRoot.h"
+#include "OgreRenderWindow.h"
+
+#include <SDL.h>
+#include <SDL_video.h>
+#include <SDL_syswm.h>
+
+#include "SDLInputMapping.h"
+
+namespace OgreBites {
+
+ApplicationContextSDL::ApplicationContextSDL(const Ogre::String& appName) : ApplicationContextBase(appName)
+{
+}
+
+void ApplicationContextSDL::addInputListener(NativeWindowType* win, InputListener* lis)
+{
+    mInputListeners.insert(std::make_pair(SDL_GetWindowID(win), lis));
+}
+
+
+void ApplicationContextSDL::removeInputListener(NativeWindowType* win, InputListener* lis)
+{
+    mInputListeners.erase(std::make_pair(SDL_GetWindowID(win), lis));
+}
+
+NativeWindowPair ApplicationContextSDL::createWindow(const Ogre::String& name, Ogre::uint32 w, Ogre::uint32 h, Ogre::NameValuePairList miscParams)
+{
+    NativeWindowPair ret = {NULL, NULL};
+    parseWindowOptions(w, h, miscParams);
+
+    Ogre::ConfigOptionMap& ropts = mRoot->getRenderSystem()->getConfigOptions();
+
+    if(!SDL_WasInit(SDL_INIT_VIDEO)) {
+        SDL_InitSubSystem(SDL_INIT_VIDEO);
+    }
+
+    Uint32 flags = SDL_WINDOW_RESIZABLE;
+
+    if(ropts["Full Screen"].currentValue == "Yes"){
+       flags = SDL_WINDOW_FULLSCREEN;
+    } else {
+       flags = SDL_WINDOW_RESIZABLE;
+    }
+
+    ret.native = SDL_CreateWindow(name.c_str(),
+                                SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, w, h, flags);
+
+#if OGRE_PLATFORM == OGRE_PLATFORM_EMSCRIPTEN
+    SDL_GL_CreateContext(ret.native);
+    miscParams["currentGLContext"] = "true";
+#else
+    SDL_SysWMinfo wmInfo;
+    SDL_VERSION(&wmInfo.version);
+    SDL_GetWindowWMInfo(ret.native, &wmInfo);
+#endif
+
+#if OGRE_PLATFORM == OGRE_PLATFORM_LINUX
+    miscParams["parentWindowHandle"] = Ogre::StringConverter::toString(size_t(wmInfo.info.x11.window));
+#elif OGRE_PLATFORM == OGRE_PLATFORM_WIN32
+    miscParams["externalWindowHandle"] = Ogre::StringConverter::toString(size_t(wmInfo.info.win.window));
+#elif OGRE_PLATFORM == OGRE_PLATFORM_APPLE
+    assert(wmInfo.subsystem == SDL_SYSWM_COCOA);
+    miscParams["externalWindowHandle"] = Ogre::StringConverter::toString(size_t(wmInfo.info.cocoa.window));
+#endif
+
+    ret.render = mRoot->createRenderWindow(name, w, h, false, &miscParams);
+    mWindows.push_back(ret);
+    return ret;
+}
+
+void ApplicationContextSDL::setWindowGrab(NativeWindowType* win, bool _grab)
+{
+    SDL_bool grab = SDL_bool(_grab);
+
+    SDL_SetWindowGrab(win, grab);
+    SDL_SetRelativeMouseMode(grab);
+}
+
+void ApplicationContextSDL::shutdown()
+{
+    ApplicationContextBase::shutdown();
+
+    for(WindowList::iterator it = mWindows.begin(); it != mWindows.end(); ++it)
+    {
+        if(it->native)
+            SDL_DestroyWindow(it->native);
+    }
+    if(!mWindows.empty()) {
+        SDL_QuitSubSystem(SDL_INIT_VIDEO);
+    }
+
+    mWindows.clear();
+}
+
+void ApplicationContextSDL::pollEvents()
+{
+    if(mWindows.empty())
+    {
+        // SDL events not initialized
+        return;
+    }
+
+    SDL_Event event;
+    while (SDL_PollEvent(&event))
+    {
+        switch (event.type)
+        {
+        case SDL_QUIT:
+            mRoot->queueEndRendering();
+            break;
+        case SDL_WINDOWEVENT:
+            if(event.window.event != SDL_WINDOWEVENT_RESIZED)
+                continue;
+
+            for(WindowList::iterator it = mWindows.begin(); it != mWindows.end(); ++it)
+            {
+                if(event.window.windowID != SDL_GetWindowID(it->native))
+                    continue;
+
+                Ogre::RenderWindow* win = it->render;
+                win->windowMovedOrResized();
+                windowResized(win);
+            }
+            break;
+        default:
+            _fireInputEvent(convert(event), event.window.windowID);
+            break;
+        }
+    }
+
+#if OGRE_PLATFORM == OGRE_PLATFORM_APPLE
+    // hacky workaround for black window on OSX
+    for(const auto& win : mWindows)
+    {
+        SDL_SetWindowSize(win.native, win.render->getWidth(), win.render->getHeight());
+        win.render->windowMovedOrResized();
+    }
+#endif
+}
+
+}


### PR DESCRIPTION
and move SDL2 and Android code into deriving classes