### PR TITLE
move OgreUTFString to Overlay component

### DIFF
--- a/Components/Bites/src/OgreTrays.cpp
+++ b/Components/Bites/src/OgreTrays.cpp
@@ -7,12 +7,6 @@
 
 #include "OgreTrays.h"
 
-#if OGRE_UNICODE_SUPPORT
-    #define DISPLAY_STRING_TO_STRING(DS) (DS.asUTF8())
-#else
-    #define DISPLAY_STRING_TO_STRING(DS) (DS)
-#endif
-
 namespace OgreBites
 {
 
@@ -77,7 +71,7 @@ Ogre::Vector2 Widget::cursorOffset(Ogre::OverlayElement *element, const Ogre::Ve
 Ogre::Real Widget::getCaptionWidth(const Ogre::DisplayString &caption, Ogre::TextAreaOverlayElement *area)
 {
     Ogre::FontPtr font = area->getFont();
-    Ogre::String current = DISPLAY_STRING_TO_STRING(caption);
+    Ogre::String current = caption.asUTF8();
     Ogre::Real lineWidth = 0;
 
     for (unsigned int i = 0; i < current.length(); i++)
@@ -99,7 +93,7 @@ Ogre::Real Widget::getCaptionWidth(const Ogre::DisplayString &caption, Ogre::Tex
 void Widget::fitCaptionToArea(const Ogre::DisplayString &caption, Ogre::TextAreaOverlayElement *area, Ogre::Real maxWidth)
 {
     Ogre::FontPtr f = area->getFont();
-    Ogre::String s = DISPLAY_STRING_TO_STRING(caption);
+    Ogre::String s = caption.asUTF8();
 
     size_t nl = s.find('\n');
     if (nl != Ogre::String::npos) s = s.substr(0, nl);
@@ -238,7 +232,7 @@ void TextBox::setText(const Ogre::DisplayString &text)
 
     Ogre::FontPtr font = mTextArea->getFont();
 
-    Ogre::String current = DISPLAY_STRING_TO_STRING(text);
+    Ogre::String current = text.asUTF8();
     bool firstWord = true;
     unsigned int lastSpace = 0;
     unsigned int lineBegin = 0;
@@ -961,15 +955,15 @@ void ParamsPanel::setParamValue(const Ogre::DisplayString &paramName, const Ogre
 {
     for (unsigned int i = 0; i < mNames.size(); i++)
     {
-        if (mNames[i] == DISPLAY_STRING_TO_STRING(paramName))
+        if (mNames[i] == paramName.asUTF8())
         {
-            mValues[i] = DISPLAY_STRING_TO_STRING(paramValue);
+            mValues[i] = paramValue.asUTF8();
             updateText();
             return;
         }
     }
 
-    Ogre::String desc = "ParamsPanel \"" + getName() + "\" has no parameter \"" + DISPLAY_STRING_TO_STRING(paramName) + "\".";
+    Ogre::String desc = "ParamsPanel \"" + getName() + "\" has no parameter \"" + paramName.asUTF8() + "\".";
     OGRE_EXCEPT(Ogre::Exception::ERR_ITEM_NOT_FOUND, desc, "ParamsPanel::setParamValue");
 }
 
@@ -982,7 +976,7 @@ void ParamsPanel::setParamValue(unsigned int index, const Ogre::DisplayString &p
         OGRE_EXCEPT(Ogre::Exception::ERR_ITEM_NOT_FOUND, desc, "ParamsPanel::setParamValue");
     }
 
-    mValues[index] = DISPLAY_STRING_TO_STRING(paramValue);
+    mValues[index] = paramValue.asUTF8();
     updateText();
 }
 
@@ -990,10 +984,10 @@ Ogre::DisplayString ParamsPanel::getParamValue(const Ogre::DisplayString &paramN
 {
     for (unsigned int i = 0; i < mNames.size(); i++)
     {
-        if (mNames[i] == DISPLAY_STRING_TO_STRING(paramName)) return mValues[i];
+        if (mNames[i] == paramName.asUTF8()) return mValues[i];
     }
 
-    Ogre::String desc = "ParamsPanel \"" + getName() + "\" has no parameter \"" + DISPLAY_STRING_TO_STRING(paramName) + "\".";
+    Ogre::String desc = "ParamsPanel \"" + getName() + "\" has no parameter \"" + paramName.asUTF8() + "\".";
     OGRE_EXCEPT(Ogre::Exception::ERR_ITEM_NOT_FOUND, desc, "ParamsPanel::getParamValue");
     return "";
 }

--- a/Components/Overlay/include/OgreOverlayElement.h
+++ b/Components/Overlay/include/OgreOverlayElement.h
@@ -47,13 +47,8 @@ namespace Ogre {
     *  @{
     */
 
-#if OGRE_UNICODE_SUPPORT
     typedef UTFString DisplayString;
-#   define OGRE_DEREF_DISPLAYSTRING_ITERATOR(it) it.getCharacter()
-#else
-    typedef String DisplayString;
-#   define OGRE_DEREF_DISPLAYSTRING_ITERATOR(it) *it
-#endif
+
     /** Enum describing how the position / size of an element is to be recorded. 
     */
     enum GuiMetricsMode

--- a/Components/Overlay/include/OgreUTFString.h
+++ b/Components/Overlay/include/OgreUTFString.h
@@ -27,11 +27,8 @@
 #ifndef __OGRE_UTFSTRING_H__
 #define __OGRE_UTFSTRING_H__
 
-
+#include "OgreOverlayPrerequisites.h"
 #include "OgrePrerequisites.h"
-#include "OgreHeaderPrefix.h"
-
-#if OGRE_UNICODE_SUPPORT 
 
 // these are explained later
 #include <iterator>
@@ -166,7 +163,7 @@ namespace Ogre {
     - For additional information on UTF-8 encoding: http://en.wikipedia.org/wiki/UTF-8
     - For additional information on UTF-32 encoding: http://en.wikipedia.org/wiki/UTF-32
     */
-    class _OgreExport UTFString {
+    class _OgreOverlayExport UTFString {
         // constants used in UTF-8 conversions
         static const unsigned char _lead1 = 0xC0;      //110xxxxx
         static const unsigned char _lead1_mask = 0x1F; //00011111
@@ -202,7 +199,7 @@ namespace Ogre {
         typedef std::basic_string<unicode_char> utf32string;
 
         //! This exception is used when invalid data streams are encountered
-    class _OgreExport invalid_data: public std::runtime_error { /* i don't know why the beautifier is freaking out on this line */
+    class _OgreOverlayExport invalid_data: public std::runtime_error { /* i don't know why the beautifier is freaking out on this line */
         public:
             //! constructor takes a string message that can be later retrieved by the what() function
             explicit invalid_data( const std::string& _Message ): std::runtime_error( _Message ) {
@@ -212,7 +209,7 @@ namespace Ogre {
 
         //#########################################################################
         //! base iterator class for UTFString
-    class _OgreExport _base_iterator: public std::iterator<std::random_access_iterator_tag, value_type> { /* i don't know why the beautifier is freaking out on this line */
+    class _OgreOverlayExport _base_iterator: public std::iterator<std::random_access_iterator_tag, value_type> { /* i don't know why the beautifier is freaking out on this line */
             friend class UTFString;
         protected:
             _base_iterator();
@@ -241,7 +238,7 @@ namespace Ogre {
         class _const_fwd_iterator; // forward declaration
 
         //! forward iterator for UTFString
-    class _OgreExport _fwd_iterator: public _base_iterator { /* i don't know why the beautifier is freaking out on this line */
+    class _OgreOverlayExport _fwd_iterator: public _base_iterator { /* i don't know why the beautifier is freaking out on this line */
             friend class _const_fwd_iterator;
         public:
             _fwd_iterator();
@@ -287,7 +284,7 @@ namespace Ogre {
 
         //#########################################################################
         //! const forward iterator for UTFString
-    class _OgreExport _const_fwd_iterator: public _base_iterator { /* i don't know why the beautifier is freaking out on this line */
+    class _OgreOverlayExport _const_fwd_iterator: public _base_iterator { /* i don't know why the beautifier is freaking out on this line */
         public:
             _const_fwd_iterator();
             _const_fwd_iterator( const _const_fwd_iterator& i );
@@ -348,7 +345,7 @@ namespace Ogre {
         //#########################################################################
         class _const_rev_iterator; // forward declaration
         //! forward iterator for UTFString
-    class _OgreExport _rev_iterator: public _base_iterator { /* i don't know why the beautifier is freaking out on this line */
+    class _OgreOverlayExport _rev_iterator: public _base_iterator { /* i don't know why the beautifier is freaking out on this line */
             friend class _const_rev_iterator;
         public:
             _rev_iterator();
@@ -382,7 +379,7 @@ namespace Ogre {
         };
         //#########################################################################
         //! const reverse iterator for UTFString
-    class _OgreExport _const_rev_iterator: public _base_iterator { /* i don't know why the beautifier is freaking out on this line */
+    class _OgreOverlayExport _const_rev_iterator: public _base_iterator { /* i don't know why the beautifier is freaking out on this line */
         public:
             _const_rev_iterator();
             _const_rev_iterator( const _const_rev_iterator& i );
@@ -1101,9 +1098,5 @@ namespace Ogre {
 
 
 } // namespace Ogre{
-
-#endif // OGRE_UNICODE_SUPPORT
-
-#include "OgreHeaderSuffix.h"
 
 #endif 

--- a/Components/Overlay/src/OgreTextAreaOverlayElement.cpp
+++ b/Components/Overlay/src/OgreTextAreaOverlayElement.cpp
@@ -211,7 +211,7 @@ namespace Ogre {
                 Real len = 0.0f;
                 for( DisplayString::iterator j = i; j != iend; j++ )
                 {
-                    Font::CodePoint character = OGRE_DEREF_DISPLAYSTRING_ITERATOR(j);
+                    Font::CodePoint character = j.getCharacter();
                     if (character == UNICODE_CR
                         || character == UNICODE_NEL
                         || character == UNICODE_LF) 
@@ -236,7 +236,7 @@ namespace Ogre {
                 newLine = false;
             }
 
-            Font::CodePoint character = OGRE_DEREF_DISPLAYSTRING_ITERATOR(i);
+            Font::CodePoint character = i.getCharacter();
             if (character == UNICODE_CR
                 || character == UNICODE_NEL
                 || character == UNICODE_LF)
@@ -252,7 +252,7 @@ namespace Ogre {
                 {
                     DisplayString::iterator peeki = i;
                     peeki++;
-                    if (peeki != iend && OGRE_DEREF_DISPLAYSTRING_ITERATOR(peeki) == UNICODE_LF)
+                    if (peeki != iend && peeki.getCharacter() == UNICODE_LF)
                     {
                         i = peeki; // skip both as one newline
                         // Also reduce tri count

--- a/Components/Overlay/src/OgreUTFString.cpp
+++ b/Components/Overlay/src/OgreUTFString.cpp
@@ -25,10 +25,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -----------------------------------------------------------------------------
 */
-#include "OgreStableHeaders.h"
 #include "OgreUTFString.h"
-
-#if OGRE_UNICODE_SUPPORT
 
 namespace Ogre {
 
@@ -2023,5 +2020,3 @@ namespace Ogre {
     }
 
 }
-
-#endif

--- a/OgreMain/include/OgreDynLib.h
+++ b/OgreMain/include/OgreDynLib.h
@@ -42,7 +42,7 @@ typedef struct HINSTANCE__* hInstance;
 
 #elif OGRE_PLATFORM == OGRE_PLATFORM_WINRT
 #    define DYNLIB_HANDLE hInstance
-#    define DYNLIB_LOAD( a ) LoadPackagedLibrary( UTFString(a).asWStr_c_str(), 0 )
+#    define DYNLIB_LOAD( a ) LoadPackagedLibrary( stringToWstring(a), 0 )
 #    define DYNLIB_GETSYM( a, b ) GetProcAddress( a, b )
 #    define DYNLIB_UNLOAD( a ) !FreeLibrary( a )
 

--- a/OgreMain/include/OgrePlatform.h
+++ b/OgreMain/include/OgrePlatform.h
@@ -210,41 +210,7 @@ namespace Ogre {
 #       define OGRE_DEBUG_MODE 0
 #   endif
 
-// Disable unicode support on MingW for GCC 3, poorly supported in stdlibc++
-// STLPORT fixes this though so allow if found
-// MinGW C++ Toolkit supports unicode and sets the define __MINGW32_TOOLBOX_UNICODE__ in _mingw.h
-// GCC 4 is also fine
-#if defined(__MINGW32__)
-# if OGRE_COMP_VER < 400
-#  if !defined(_STLPORT_VERSION)
-#   include<_mingw.h>
-#   if defined(__MINGW32_TOOLBOX_UNICODE__) || OGRE_COMP_VER > 345
-#    define OGRE_UNICODE_SUPPORT 1
-#   else
-#    define OGRE_UNICODE_SUPPORT 0
-#   endif
-#  else
-#   define OGRE_UNICODE_SUPPORT 1
-#  endif
-# else
-#  define OGRE_UNICODE_SUPPORT 1
-# endif
-#else
-#  define OGRE_UNICODE_SUPPORT 1
-#endif
-
 #endif // OGRE_PLATFORM == OGRE_PLATFORM_WIN32 || OGRE_PLATFORM == OGRE_PLATFORM_WINRT
-
-//----------------------------------------------------------------------------
-// Linux/Apple/iOS/Android/NaCl/Emscripten Settings
-#if OGRE_PLATFORM == OGRE_PLATFORM_LINUX || OGRE_PLATFORM == OGRE_PLATFORM_APPLE || OGRE_PLATFORM == OGRE_PLATFORM_APPLE_IOS || \
-    OGRE_PLATFORM == OGRE_PLATFORM_ANDROID || OGRE_PLATFORM == OGRE_PLATFORM_EMSCRIPTEN
-
-// Always enable unicode support for the moment
-// Perhaps disable in old versions of gcc if necessary
-#define OGRE_UNICODE_SUPPORT 1
-
-#endif
 
 //----------------------------------------------------------------------------
 // Android Settings

--- a/OgreMain/src/OgreDynLib.cpp
+++ b/OgreMain/src/OgreDynLib.cpp
@@ -39,7 +39,14 @@ THE SOFTWARE.
 #endif
 
 #if OGRE_PLATFORM == OGRE_PLATFORM_WINRT
-#include "OgreUTFString.h"
+static std::wstring stringToWstring(const std::string& s)
+{
+	int len = MultiByteToWideChar(CP_UTF8, 0, s.c_str(), s.length(), NULL, 0);
+	std::wstring ws(L"", len);
+	wchar_t* pWSBuf = const_cast<wchar_t*>(ws.c_str());
+	MultiByteToWideChar(CP_UTF8, 0, s.c_str(), -1, pWSBuf, len);
+	return ws;
+}
 #endif
 
 #if OGRE_PLATFORM == OGRE_PLATFORM_APPLE || OGRE_PLATFORM == OGRE_PLATFORM_APPLE_IOS


### PR DESCRIPTION
also get rid of no longer needed OGRE_UNICODE_SUPPORT: since it was set to 0 only for the gcc3 on mingw, which is no longer supported (no C++11)