### PR TITLE
allow compiling shaders directly so apps can implement background asset streaming, provide auto updating camera world position data source when camera relative rendering is enabled.

### DIFF
--- a/OgreMain/include/OgreAutoParamDataSource.h
+++ b/OgreMain/include/OgreAutoParamDataSource.h
@@ -170,6 +170,7 @@ namespace Ogre {
         const Matrix4& getInverseTransposeWorldViewMatrix(void) const;
         const Vector4& getCameraPosition(void) const;
         const Vector4& getCameraPositionObjectSpace(void) const;
+        const Vector4& getCameraPositionWorldSpace(void) const;
         const Vector4& getLodCameraPosition(void) const;
         const Vector4& getLodCameraPositionObjectSpace(void) const;
         bool hasLightList() const { return mCurrentLightList != 0; }

--- a/OgreMain/include/OgreGpuProgramParams.h
+++ b/OgreMain/include/OgreGpuProgramParams.h
@@ -975,6 +975,8 @@ namespace Ogre {
             ACT_CAMERA_POSITION,
             /// The current camera's position in object space
             ACT_CAMERA_POSITION_OBJECT_SPACE,
+            /// The current camera's position in world space even when camera relative rendering is enabled.
+            ACT_CAMERA_POSITION_WORLD_SPACE,
             /** The view/projection matrix of the assigned texture projection frustum
 
              Applicable to vertex programs which have been specified as the ’shadow receiver’ vertex

--- a/OgreMain/include/OgreHighLevelGpuProgram.h
+++ b/OgreMain/include/OgreHighLevelGpuProgram.h
@@ -73,8 +73,13 @@ namespace Ogre {
         /// Preprocessor options
         String mPreprocessorDefines;
 
-        /// Internal load high-level portion if not loaded
+    public:
+
+        // Allow compiling shaders directly so apps can implement background asset streaming.
         virtual void loadHighLevel(void);
+
+    protected:
+
         /// Internal unload high-level portion if loaded
         virtual void unloadHighLevel(void);
         /** Internal load implementation, loads just the high-level portion, enough to 

--- a/OgreMain/include/OgreHighLevelGpuProgram.h
+++ b/OgreMain/include/OgreHighLevelGpuProgram.h
@@ -73,13 +73,8 @@ namespace Ogre {
         /// Preprocessor options
         String mPreprocessorDefines;
 
-    public:
-
-        // Allow compiling shaders directly so apps can implement background asset streaming.
+        /// Internal load high-level portion if not loaded
         virtual void loadHighLevel(void);
-
-    protected:
-
         /// Internal unload high-level portion if loaded
         virtual void unloadHighLevel(void);
         /** Internal load implementation, loads just the high-level portion, enough to 

--- a/OgreMain/src/OgreAutoParamDataSource.cpp
+++ b/OgreMain/src/OgreAutoParamDataSource.cpp
@@ -463,6 +463,23 @@ namespace Ogre {
         return mCameraPositionObjectSpace;
     }
     //-----------------------------------------------------------------------------
+    const Vector4& AutoParamDataSource::getCameraPositionWorldSpace(void) const
+    {
+        if (mCameraPositionDirty)
+        {
+            Vector3 vec3 = mCurrentCamera->getDerivedPosition();
+            // We don't include the offset for camera relative rendering.
+            // This is intended for use when camera relative rendering is enabled
+            //   and the true world position is needed by a shader.
+            mCameraPosition[0] = vec3[0];
+            mCameraPosition[1] = vec3[1];
+            mCameraPosition[2] = vec3[2];
+            mCameraPosition[3] = 1.0;
+            mCameraPositionDirty = false;
+        }
+        return mCameraPosition;
+    }
+    //-----------------------------------------------------------------------------
     const Vector4& AutoParamDataSource::getLodCameraPosition(void) const
     {
         if(mLodCameraPositionDirty)

--- a/OgreMain/src/OgreGpuProgramParams.cpp
+++ b/OgreMain/src/OgreGpuProgramParams.cpp
@@ -131,6 +131,7 @@ namespace Ogre
         AutoConstantDefinition(ACT_SHADOW_EXTRUSION_DISTANCE,     "shadow_extrusion_distance",    1, ET_REAL, ACDT_INT),
         AutoConstantDefinition(ACT_CAMERA_POSITION,               "camera_position",              3, ET_REAL, ACDT_NONE),
         AutoConstantDefinition(ACT_CAMERA_POSITION_OBJECT_SPACE,  "camera_position_object_space", 3, ET_REAL, ACDT_NONE),
+        AutoConstantDefinition(ACT_CAMERA_POSITION_WORLD_SPACE,   "camera_position_world_space",  3, ET_REAL, ACDT_NONE),
         AutoConstantDefinition(ACT_TEXTURE_VIEWPROJ_MATRIX,       "texture_viewproj_matrix",     16, ET_REAL, ACDT_INT),
         AutoConstantDefinition(ACT_TEXTURE_VIEWPROJ_MATRIX_ARRAY, "texture_viewproj_matrix_array", 16, ET_REAL, ACDT_INT),
         AutoConstantDefinition(ACT_TEXTURE_WORLDVIEWPROJ_MATRIX,  "texture_worldviewproj_matrix",16, ET_REAL, ACDT_INT),
@@ -1237,6 +1238,7 @@ namespace Ogre
         case ACT_SURFACE_SHININESS:
         case ACT_SURFACE_ALPHA_REJECTION_VALUE:
         case ACT_CAMERA_POSITION:
+        case ACT_CAMERA_POSITION_WORLD_SPACE:
         case ACT_TIME:
         case ACT_TIME_0_X:
         case ACT_COSTIME_0_X:
@@ -1986,6 +1988,9 @@ namespace Ogre
 
                 case ACT_CAMERA_POSITION:
                     _writeRawConstant(i->physicalIndex, source->getCameraPosition(), i->elementCount);
+                    break;
+                case ACT_CAMERA_POSITION_WORLD_SPACE:
+                    _writeRawConstant (i->physicalIndex, source->getCameraPositionWorldSpace(), i->elementCount);
                     break;
                 case ACT_TIME:
                     _writeRawConstant(i->physicalIndex, source->getTime() * i->fData);


### PR DESCRIPTION
i use this to compile dx9 shaders on background threads.