### PR TITLE
Main: fix default texture filtering value set to the value other than…

### DIFF
--- a/OgreMain/src/OgreTextureUnitState.cpp
+++ b/OgreMain/src/OgreTextureUnitState.cpp
@@ -277,6 +277,7 @@ namespace Ogre {
         if (texPtr->getTextureType() == TEX_TYPE_EXTERNAL_OES || texPtr->getTextureType() == TEX_TYPE_2D_RECT)
         {
             setTextureAddressingMode( TAM_CLAMP );
+            setTextureFiltering(FT_MIP, FO_NONE);
         }
 
         mFramePtrs.resize(1);


### PR DESCRIPTION
… FO_NONE for TEX_TYPE_EXTERNAL_OES and TEX_TYPE_2D_RECT
