### PR TITLE
Bites: ApplicationContext - windows must be destroyed in reverse order

### DIFF
--- a/Components/Bites/src/OgreApplicationContextBase.cpp
+++ b/Components/Bites/src/OgreApplicationContextBase.cpp
@@ -528,7 +528,7 @@ void ApplicationContextBase::shutdown()
     destroyRTShaderSystem();
 #endif
 
-    for(WindowList::iterator it = mWindows.begin(); it != mWindows.end(); ++it)
+    for(auto it = mWindows.rbegin(); it != mWindows.rend(); ++it)
     {
 #if !OGRE_BITES_HAVE_SDL
         // remove window event listener before destroying it


### PR DESCRIPTION
as the first window owns the GL context