### PR TITLE
VTests: drop superficial calls to buildTangentVectors on knot.mesh

### DIFF
--- a/Tests/VisualTests/PlayPen/src/PlayPenTests.cpp
+++ b/Tests/VisualTests/PlayPen/src/PlayPenTests.cpp
@@ -2395,10 +2395,7 @@ void PlayPen_CompositorTextureShadows::setupContent()
     mTestNode[3] = mSceneMgr->getRootSceneNode()->createChildSceneNode(Vector3(350, 0, -200));
     mTestNode[3]->attachObject( pEnt );
 
-    MeshPtr msh = MeshManager::getSingleton().load("knot.mesh", ASSETS_RESOURCE_GROUP);
-    msh->buildTangentVectors(VES_TANGENT, 0, 0);
     pEnt = mSceneMgr->createEntity( "4", "knot.mesh" );
-    //pEnt->setMaterialName("Examples/BumpMapping/MultiLightSpecular");
     mTestNode[2] = mSceneMgr->getRootSceneNode()->createChildSceneNode(Vector3(100, 0, 200));
     mTestNode[2]->attachObject( pEnt );
 
@@ -3677,10 +3674,7 @@ void PlayPen_LiSPSM::setupContent()
     mTestNode[3] = mSceneMgr->getRootSceneNode()->createChildSceneNode(Vector3(350, 0, -200));
     mTestNode[3]->attachObject( pEnt );
 
-    MeshPtr msh = MeshManager::getSingleton().load("knot.mesh", ASSETS_RESOURCE_GROUP);
-    msh->buildTangentVectors(VES_TANGENT, 0, 0);
     pEnt = mSceneMgr->createEntity( "4", "knot.mesh" );
-    //pEnt->setMaterialName("Examples/BumpMapping/MultiLightSpecular");
     mTestNode[2] = mSceneMgr->getRootSceneNode()->createChildSceneNode(Vector3(100, 0, 200));
     mTestNode[2]->attachObject( pEnt );
 
@@ -6589,10 +6583,7 @@ void PlayPen_TextureShadows::setupContent()
     mTestNode[3] = mSceneMgr->getRootSceneNode()->createChildSceneNode(Vector3(350, 0, -200));
     mTestNode[3]->attachObject( pEnt );
 
-    MeshPtr msh = MeshManager::getSingleton().load("knot.mesh", ASSETS_RESOURCE_GROUP);
-    msh->buildTangentVectors(VES_TANGENT, 0, 0);
     pEnt = mSceneMgr->createEntity( "4", "knot.mesh" );
-    //pEnt->setMaterialName("Examples/BumpMapping/MultiLightSpecular");
     mTestNode[2] = mSceneMgr->getRootSceneNode()->createChildSceneNode(Vector3(100, 0, 200));
     mTestNode[2]->attachObject( pEnt );
 


### PR DESCRIPTION
that somehow corrupted the vertex arrays in later tests on GL3+/ GLES2