### PR TITLE
D3D9: Small fix for FFP params

### DIFF
--- a/RenderSystems/Direct3D9/src/OgreD3D9RenderSystem.cpp
+++ b/RenderSystems/Direct3D9/src/OgreD3D9RenderSystem.cpp
@@ -161,7 +161,7 @@ namespace Ogre
             // Only update needed slots
             if (ac.variability & mask)
             {
-                HRESULT hr;
+                HRESULT hr = S_OK;
                 const float* ptr = params->getFloatPointer(ac.physicalIndex);
                 switch(ac.paramType)
                 {


### PR DESCRIPTION
This initializes a HRESULT value that may not be initialized.
If this value is not changed, it may fail on this [lines](https://github.com/OGRECave/ogre/blob/25f5808a8e27c6ae511ebec1c98b104e22840fd7/RenderSystems/Direct3D9/src/OgreD3D9RenderSystem.cpp#L256-L257).