### PR TITLE
Overlay buffer mapping workaround

### DIFF
--- a/Components/Overlay/src/OgreBorderPanelOverlayElement.cpp
+++ b/Components/Overlay/src/OgreBorderPanelOverlayElement.cpp
@@ -133,7 +133,7 @@ namespace Ogre {
             HardwareBufferManager::getSingleton().createVertexBuffer(
                 decl->getVertexSize(POSITION_BINDING), 
                 mRenderOp2.vertexData->vertexCount,
-                HardwareBuffer::HBU_DYNAMIC_WRITE_ONLY, 
+                HardwareBuffer::HBU_DYNAMIC_WRITE_ONLY,
                 true);//Workaround, using shadow buffer to avoid stall due to buffer mapping
         // bind position
         VertexBufferBinding* binding = mRenderOp2.vertexData->vertexBufferBinding;
@@ -143,7 +143,7 @@ namespace Ogre {
         vbuf = HardwareBufferManager::getSingleton().createVertexBuffer(
                 decl->getVertexSize(TEXCOORD_BINDING), 
                 mRenderOp2.vertexData->vertexCount,
-                HardwareBuffer::HBU_DYNAMIC_WRITE_ONLY, 
+                HardwareBuffer::HBU_DYNAMIC_WRITE_ONLY,
                 true);//Workaround, using shadow buffer to avoid stall due to buffer mapping
         // bind texcoord
         binding->setBinding(TEXCOORD_BINDING, vbuf);
@@ -162,7 +162,7 @@ namespace Ogre {
             HardwareBufferManager::getSingleton().createIndexBuffer(
                 HardwareIndexBuffer::IT_16BIT, 
                 mRenderOp2.indexData->indexCount, 
-                HardwareBuffer::HBU_DYNAMIC_WRITE_ONLY, 
+                HardwareBuffer::HBU_DYNAMIC_WRITE_ONLY,
                 true);//Workaround, using shadow buffer to avoid stall due to buffer mapping
 
         HardwareBufferLockGuard indexLock(mRenderOp2.indexData->indexBuffer, HardwareBuffer::HBL_DISCARD);

--- a/Components/Overlay/src/OgreBorderPanelOverlayElement.cpp
+++ b/Components/Overlay/src/OgreBorderPanelOverlayElement.cpp
@@ -133,7 +133,7 @@ namespace Ogre {
             HardwareBufferManager::getSingleton().createVertexBuffer(
                 decl->getVertexSize(POSITION_BINDING), 
                 mRenderOp2.vertexData->vertexCount,
-                HardwareBuffer::HBU_STATIC_WRITE_ONLY, 
+                HardwareBuffer::HBU_DYNAMIC_WRITE_ONLY, 
                 true);//Workaround, using shadow buffer to avoid stall due to buffer mapping
         // bind position
         VertexBufferBinding* binding = mRenderOp2.vertexData->vertexBufferBinding;
@@ -143,7 +143,7 @@ namespace Ogre {
         vbuf = HardwareBufferManager::getSingleton().createVertexBuffer(
                 decl->getVertexSize(TEXCOORD_BINDING), 
                 mRenderOp2.vertexData->vertexCount,
-                HardwareBuffer::HBU_STATIC_WRITE_ONLY, 
+                HardwareBuffer::HBU_DYNAMIC_WRITE_ONLY, 
                 true);//Workaround, using shadow buffer to avoid stall due to buffer mapping
         // bind texcoord
         binding->setBinding(TEXCOORD_BINDING, vbuf);
@@ -162,7 +162,8 @@ namespace Ogre {
             HardwareBufferManager::getSingleton().createIndexBuffer(
                 HardwareIndexBuffer::IT_16BIT, 
                 mRenderOp2.indexData->indexCount, 
-                HardwareBuffer::HBU_STATIC_WRITE_ONLY);
+                HardwareBuffer::HBU_DYNAMIC_WRITE_ONLY, 
+                true);//Workaround, using shadow buffer to avoid stall due to buffer mapping
 
         HardwareBufferLockGuard indexLock(mRenderOp2.indexData->indexBuffer, HardwareBuffer::HBL_DISCARD);
         ushort* pIdx = static_cast<ushort*>(indexLock.pData);

--- a/Components/Overlay/src/OgreBorderPanelOverlayElement.cpp
+++ b/Components/Overlay/src/OgreBorderPanelOverlayElement.cpp
@@ -133,7 +133,8 @@ namespace Ogre {
             HardwareBufferManager::getSingleton().createVertexBuffer(
                 decl->getVertexSize(POSITION_BINDING), 
                 mRenderOp2.vertexData->vertexCount,
-                HardwareBuffer::HBU_STATIC_WRITE_ONLY);
+                HardwareBuffer::HBU_STATIC_WRITE_ONLY, 
+                true);//Workaround, using shadow buffer to avoid stall due to buffer mapping
         // bind position
         VertexBufferBinding* binding = mRenderOp2.vertexData->vertexBufferBinding;
         binding->setBinding(POSITION_BINDING, vbuf);
@@ -142,7 +143,8 @@ namespace Ogre {
         vbuf = HardwareBufferManager::getSingleton().createVertexBuffer(
                 decl->getVertexSize(TEXCOORD_BINDING), 
                 mRenderOp2.vertexData->vertexCount,
-                HardwareBuffer::HBU_STATIC_WRITE_ONLY, true);
+                HardwareBuffer::HBU_STATIC_WRITE_ONLY, 
+                true);//Workaround, using shadow buffer to avoid stall due to buffer mapping
         // bind texcoord
         binding->setBinding(TEXCOORD_BINDING, vbuf);
 

--- a/Components/Overlay/src/OgrePanelOverlayElement.cpp
+++ b/Components/Overlay/src/OgrePanelOverlayElement.cpp
@@ -115,8 +115,8 @@ namespace Ogre {
         HardwareVertexBufferSharedPtr vbuf =
             HardwareBufferManager::getSingleton().createVertexBuffer(
             decl->getVertexSize(POSITION_BINDING), mRenderOp.vertexData->vertexCount,
-            HardwareBuffer::HBU_STATIC_WRITE_ONLY// mostly static except during resizing
-            );
+            HardwareBuffer::HBU_STATIC_WRITE_ONLY,// mostly static except during resizing
+            true);//Workaround, using shadow buffer to avoid stall due to buffer mapping
         // Bind buffer
         mRenderOp.vertexData->vertexBufferBinding->setBinding(POSITION_BINDING, vbuf);
 
@@ -316,8 +316,8 @@ namespace Ogre {
                 HardwareVertexBufferSharedPtr newbuf =
                     HardwareBufferManager::getSingleton().createVertexBuffer(
                     decl->getVertexSize(TEXCOORD_BINDING), mRenderOp.vertexData->vertexCount,
-                    HardwareBuffer::HBU_STATIC_WRITE_ONLY // mostly static except during resizing
-                    );
+                    HardwareBuffer::HBU_STATIC_WRITE_ONLY, // mostly static except during resizing
+                    true);//Workaround, using shadow buffer to avoid stall due to buffer mapping
                 // Bind buffer, note this will unbind the old one and destroy the buffer it had
                 mRenderOp.vertexData->vertexBufferBinding->setBinding(TEXCOORD_BINDING, newbuf);
                 // Set num tex coords in use now

--- a/Components/Overlay/src/OgrePanelOverlayElement.cpp
+++ b/Components/Overlay/src/OgrePanelOverlayElement.cpp
@@ -115,7 +115,7 @@ namespace Ogre {
         HardwareVertexBufferSharedPtr vbuf =
             HardwareBufferManager::getSingleton().createVertexBuffer(
             decl->getVertexSize(POSITION_BINDING), mRenderOp.vertexData->vertexCount,
-            HardwareBuffer::HBU_STATIC_WRITE_ONLY,// mostly static except during resizing
+            HardwareBuffer::HBU_DYNAMIC_WRITE_ONLY,// mostly static except during resizing
             true);//Workaround, using shadow buffer to avoid stall due to buffer mapping
         // Bind buffer
         mRenderOp.vertexData->vertexBufferBinding->setBinding(POSITION_BINDING, vbuf);
@@ -316,7 +316,7 @@ namespace Ogre {
                 HardwareVertexBufferSharedPtr newbuf =
                     HardwareBufferManager::getSingleton().createVertexBuffer(
                     decl->getVertexSize(TEXCOORD_BINDING), mRenderOp.vertexData->vertexCount,
-                    HardwareBuffer::HBU_STATIC_WRITE_ONLY, // mostly static except during resizing
+                    HardwareBuffer::HBU_DYNAMIC_WRITE_ONLY, // mostly static except during resizing
                     true);//Workaround, using shadow buffer to avoid stall due to buffer mapping
                 // Bind buffer, note this will unbind the old one and destroy the buffer it had
                 mRenderOp.vertexData->vertexBufferBinding->setBinding(TEXCOORD_BINDING, newbuf);

--- a/Components/Overlay/src/OgreTextAreaOverlayElement.cpp
+++ b/Components/Overlay/src/OgreTextAreaOverlayElement.cpp
@@ -142,7 +142,7 @@ namespace Ogre {
                 createVertexBuffer(
                     decl->getVertexSize(POS_TEX_BINDING), 
                     allocatedVertexCount,
-                    HardwareBuffer::HBU_DYNAMIC_WRITE_ONLY, 
+                    HardwareBuffer::HBU_DYNAMIC_WRITE_ONLY,
                     true);//Workaround, using shadow buffer to avoid stall due to buffer mapping
         bind->setBinding(POS_TEX_BINDING, vbuf);
 
@@ -151,7 +151,7 @@ namespace Ogre {
                 createVertexBuffer(
                     decl->getVertexSize(COLOUR_BINDING), 
                     allocatedVertexCount,
-                    HardwareBuffer::HBU_DYNAMIC_WRITE_ONLY, 
+                    HardwareBuffer::HBU_DYNAMIC_WRITE_ONLY,
                     true);//Workaround, using shadow buffer to avoid stall due to buffer mapping
         bind->setBinding(COLOUR_BINDING, vbuf);
 

--- a/Components/Overlay/src/OgreTextAreaOverlayElement.cpp
+++ b/Components/Overlay/src/OgreTextAreaOverlayElement.cpp
@@ -142,7 +142,8 @@ namespace Ogre {
                 createVertexBuffer(
                     decl->getVertexSize(POS_TEX_BINDING), 
                     allocatedVertexCount,
-                    HardwareBuffer::HBU_DYNAMIC_WRITE_ONLY);
+                    HardwareBuffer::HBU_DYNAMIC_WRITE_ONLY, 
+                    true);//Workaround, using shadow buffer to avoid stall due to buffer mapping
         bind->setBinding(POS_TEX_BINDING, vbuf);
 
         // colours
@@ -150,7 +151,8 @@ namespace Ogre {
                 createVertexBuffer(
                     decl->getVertexSize(COLOUR_BINDING), 
                     allocatedVertexCount,
-                    HardwareBuffer::HBU_DYNAMIC_WRITE_ONLY);
+                    HardwareBuffer::HBU_DYNAMIC_WRITE_ONLY, 
+                    true);//Workaround, using shadow buffer to avoid stall due to buffer mapping
         bind->setBinding(COLOUR_BINDING, vbuf);
 
         // Buffers are restored, but with trash within

--- a/RenderSystems/GL3Plus/src/OgreGL3PlusHardwareBuffer.cpp
+++ b/RenderSystems/GL3Plus/src/OgreGL3PlusHardwareBuffer.cpp
@@ -89,6 +89,7 @@ namespace Ogre {
             access |= GL_MAP_READ_BIT | GL_MAP_WRITE_BIT;
 
         // FIXME: Big stall here
+        // NOTE: Stall happens, when using modern drivers, with multi threading enabled driver
         void* pBuffer;
         OGRE_CHECK_GL_ERROR(pBuffer = glMapBufferRange(mTarget, offset, length, access));
 


### PR DESCRIPTION
Changed Overlay components buffers to use shadowbuffer. This will avoid the buffer mapping path in rendersystems, which caused stalls in multithread enabled drivers.