### PR TITLE
Update OgreD3D9RenderSystem.cpp

### DIFF
--- a/RenderSystems/Direct3D9/src/OgreD3D9RenderSystem.cpp
+++ b/RenderSystems/Direct3D9/src/OgreD3D9RenderSystem.cpp
@@ -154,6 +154,7 @@ namespace Ogre
     {
         D3DMATERIAL9 material;
         D3DLIGHT9 d3dLight;
+        ZeroMemory(&d3dLight, sizeof(D3DLIGHT9));
 
         // Autoconstant index is not a physical index
         for (const auto& ac : params->getAutoConstants())


### PR DESCRIPTION
fixes incorrect lighting when the ambiant value of D3DLIGHT9 is left unitialised.