### PR TITLE
Docs: update building instructions for android

### DIFF
--- a/BuildingOgre.md
+++ b/BuildingOgre.md
@@ -128,6 +128,35 @@ For Makefile based generators, type:
 On Linux Ogre will be installed to `/usr/local` by default. On Windows this will create the folder `sdk` inside your build directory and copy all the
 required libraries there. You can change the install location by changing the variable `CMAKE_INSTALL_PREFIX` in CMake.
 
+Building on Ubuntu for Android
+--------------------------------------------
+
+To build Ogre for Android, you need to specify the android cross toolchain to cmake as
+
+    cmake -DCMAKE_TOOLCHAIN_FILE=path/to/android-ndk/build/cmake/android.toolchain.cmake -DANDROID_NDK=path/to/android-ndk .
+
+this will build the core Ogre libraries. Additionally it will create gradle projects `OgreJNI` for using Java bindings and `SampleBrowserNDK` for the C++ only Sample Browser.
+
+You can now import these projects in Android Studio or manually trigger the APK creation by changing into the project folders and running
+
+    gradle assembleRelease
+
+Building for WebAssembly (using Emscripten)
+-----------------------------------------
+Install the Emscripten SDK (see full documentation on [www.emscripten.org](https://emscripten.org/docs/getting_started/downloads.html)), and make sure
+that the environment variables are correctly set (eg. run source <emsdk_path>/emsdk_env.sh before attempting to build)
+
+Run cmake in cross compile mode using emscripten as following:
+
+    mkdir build-wasm
+    emcmake cmake .. -DCMAKE_BUILD_TYPE=Release
+    emmake make
+
+NB: to simplify the process, 'emcmake' and 'emmake' wrappers are used. These tools are provided by Emscripten to correctly setup the cross compilation environment
+
+This will not build the full SampleBrowser, but just a minimal Sample. The resulting `EmscriptenSample.html` will be placed in `${CMAKE_BINARY_DIR}/bin/`.
+
+To prevent any cross-origin issues, start a local webserver as `python3 -m http.server 8000` and visit http://localhost:8000.
 
 Building on Mac OS X for iOS OS
 -------------------------------
@@ -205,33 +234,3 @@ file .vmx and add the parameter: hypervisor.cpuid.v0 = "FALSE"
 All versions of Visual Studio 2012 have a window refresh issue when running
 in VMware and the window is maximized, the solution is just to change the
 size of the Visual Studio window to be less the the screen width and height.
-
-Building on Ubuntu for Android
---------------------------------------------
-
-To build Ogre for Android, you need to specify the ios cross toolchain to cmake as
-
-    cmake -DCMAKE_TOOLCHAIN_FILE=CMake/toolchain/android.toolchain.cmake -DANDROID_NDK=path/to/android-ndk .
-
-this will build the core Ogre libraries. Also if your `PATH` contains the `android` executable it will generate the SampleBrowser APK.
-
-To manually generate the APK and install it on your device, run
-
-    ant debug install
-
-Building for WebAssembly (using Emscripten)
------------------------------------------
-Install the Emscripten SDK (see full documentation on [www.emscripten.org](https://emscripten.org/docs/getting_started/downloads.html)), and make sure
-that the environment variables are correctly set (eg. run source <emsdk_path>/emsdk_env.sh before attempting to build)
-
-Run cmake in cross compile mode using emscripten as following:
-
-    mkdir build-wasm
-    emcmake cmake .. -DCMAKE_BUILD_TYPE=Release
-    emmake make
-
-NB: to simplify the process, 'emcmake' and 'emmake' wrappers are used. These tools are provided by Emscripten to correctly setup the cross compilation environment
-
-This will not build the full SampleBrowser, but just a minimal Sample. The resulting `EmscriptenSample.html` will be placed in `${CMAKE_BINARY_DIR}/bin/`.
-
-To prevent any cross-origin issues, start a local webserver as `python3 -m http.server 8000` and visit `localhost:8000`.


### PR DESCRIPTION
and move Windows Phone instructions to bottom