### PR TITLE
Add missing nullptr_t constructor for SharedPtr

### DIFF
--- a/OgreMain/include/OgreSharedPtr.h
+++ b/OgreMain/include/OgreSharedPtr.h
@@ -57,6 +57,7 @@ namespace Ogre {
     template<class T> class SharedPtr : public shared_ptr<T>
     {
     public:
+        SharedPtr(std::nullptr_t) {}
         SharedPtr() {}
         template< class Y>
         explicit SharedPtr(Y* ptr) : shared_ptr<T>(ptr) {}


### PR DESCRIPTION
This allows code like
```cpp
Ogre::MeshPtr maybeGetMyMesh() {
  // Do stuff
  if (someFailure) return nullptr;
  // Do stuff
}
```
which would otherwise work with `std::shared_ptr`.