### PR TITLE
D3D11: Replaced the use of getCustomAttribute() methods by new D3D11RenderTarget interface

### DIFF
--- a/RenderSystems/Direct3D11/include/OgreD3D11MultiRenderTarget.h
+++ b/RenderSystems/Direct3D11/include/OgreD3D11MultiRenderTarget.h
@@ -48,7 +48,6 @@ namespace Ogre {
 
         bool requiresTextureFlipping() const { return false; }
     private:
-        D3D11HardwarePixelBuffer *targets[OGRE_MAX_MULTIPLE_RENDER_TARGETS];
         ID3D11RenderTargetView* mRenderTargetViews[OGRE_MAX_MULTIPLE_RENDER_TARGETS];   // Store views to accelerate bind
         uint mNumberOfViews;                                                            // Store number of views to accelerate bind
 

--- a/RenderSystems/Direct3D11/include/OgreD3D11MultiRenderTarget.h
+++ b/RenderSystems/Direct3D11/include/OgreD3D11MultiRenderTarget.h
@@ -46,8 +46,6 @@ namespace Ogre {
         virtual ID3D11Texture2D* getSurface(uint index = 0) const;
         virtual ID3D11RenderTargetView* getRenderTargetView(uint index = 0) const;
 
-        virtual void getCustomAttribute( const String& name, void *pData );
-
         bool requiresTextureFlipping() const { return false; }
     private:
         D3D11HardwarePixelBuffer *targets[OGRE_MAX_MULTIPLE_RENDER_TARGETS];

--- a/RenderSystems/Direct3D11/include/OgreD3D11MultiRenderTarget.h
+++ b/RenderSystems/Direct3D11/include/OgreD3D11MultiRenderTarget.h
@@ -29,16 +29,22 @@ THE SOFTWARE.
 #define __D3D11MULTIRENDERTARGET_H__
 
 #include "OgreD3D11Prerequisites.h"
+#include "OgreD3D11RenderTarget.h"
 #include "OgreRenderTexture.h"
 
 namespace Ogre {
-    class _OgreD3D11Export D3D11MultiRenderTarget : public MultiRenderTarget
+    class _OgreD3D11Export D3D11MultiRenderTarget : public MultiRenderTarget,
+        public D3D11RenderTarget
     {
     public:
         D3D11MultiRenderTarget(const String &name);
         ~D3D11MultiRenderTarget();
 
         virtual void update(void);
+
+        virtual uint getNumberOfViews() const;
+        virtual ID3D11Texture2D* getSurface(uint index = 0) const;
+        virtual ID3D11RenderTargetView* getRenderTargetView(uint index = 0) const;
 
         virtual void getCustomAttribute( const String& name, void *pData );
 

--- a/RenderSystems/Direct3D11/include/OgreD3D11Prerequisites.h
+++ b/RenderSystems/Direct3D11/include/OgreD3D11Prerequisites.h
@@ -109,6 +109,7 @@ namespace Ogre
     class D3D11Device;
     class D3D11HardwareBuffer;
     class D3D11HardwarePixelBuffer;
+    class D3D11RenderTarget;
 
     typedef SharedPtr<D3D11HLSLProgram> D3D11HLSLProgramPtr;
     typedef SharedPtr<D3D11Texture>     D3D11TexturePtr;

--- a/RenderSystems/Direct3D11/include/OgreD3D11RenderTarget.h
+++ b/RenderSystems/Direct3D11/include/OgreD3D11RenderTarget.h
@@ -1,0 +1,23 @@
+#ifndef __D3D11RENDERTARGET_H__
+#define __D3D11RENDERTARGET_H__
+
+#include "OgreD3D11Prerequisites.h"
+
+namespace Ogre
+{
+    class D3D11RenderTarget
+    {
+    public:
+        virtual ~D3D11RenderTarget() {}
+
+        virtual uint getNumberOfViews() const = 0;
+        virtual ID3D11Texture2D* getSurface(uint index = 0) const = 0;
+        virtual ID3D11RenderTargetView* getRenderTargetView(uint index = 0) const = 0;
+
+    protected:
+        D3D11RenderTarget() {}
+    };
+
+} // namespace Ogre
+
+#endif

--- a/RenderSystems/Direct3D11/include/OgreD3D11RenderWindow.h
+++ b/RenderSystems/Direct3D11/include/OgreD3D11RenderWindow.h
@@ -32,6 +32,7 @@ THE SOFTWARE.
 #include "OgreD3D11Prerequisites.h"
 #include "OgreD3D11DeviceResource.h"
 #include "OgreD3D11Mappings.h"
+#include "OgreD3D11RenderTarget.h"
 #include "OgreRenderWindow.h"
 
 #if OGRE_PLATFORM == OGRE_PLATFORM_WINRT 
@@ -47,7 +48,7 @@ THE SOFTWARE.
 namespace Ogre 
 {
     class _OgreD3D11Export D3D11RenderWindowBase
-        : public RenderWindow
+        : public RenderWindow, public D3D11RenderTarget
         , protected D3D11DeviceResource
     {
     public:
@@ -63,6 +64,10 @@ namespace Ogre
 
         bool isClosed() const                                   { return mClosed; }
         bool isHidden() const                                   { return mHidden; }
+
+        virtual uint getNumberOfViews() const;
+        virtual ID3D11Texture2D* getSurface(uint index = 0) const;
+        virtual ID3D11RenderTargetView* getRenderTargetView(uint index = 0) const;
 
         void getCustomAttribute( const String& name, void* pData );
         /** Overridden - see RenderTarget. */

--- a/RenderSystems/Direct3D11/include/OgreD3D11Texture.h
+++ b/RenderSystems/Direct3D11/include/OgreD3D11Texture.h
@@ -149,8 +149,6 @@ namespace Ogre {
         virtual ID3D11Texture2D* getSurface(uint index = 0) const;
         virtual ID3D11RenderTargetView* getRenderTargetView(uint index = 0) const;
 
-        virtual void getCustomAttribute( const String& name, void *pData );
-
         bool requiresTextureFlipping() const { return false; }
 
     protected:

--- a/RenderSystems/Direct3D11/include/OgreD3D11Texture.h
+++ b/RenderSystems/Direct3D11/include/OgreD3D11Texture.h
@@ -31,6 +31,7 @@ THE SOFTWARE.
 #include "OgreD3D11Prerequisites.h"
 #include "OgreD3D11Device.h"
 #include "OgreD3D11DeviceResource.h"
+#include "OgreD3D11RenderTarget.h"
 #include "OgreTexture.h"
 #include "OgreRenderTexture.h"
 #include "OgreSharedPtr.h"
@@ -133,7 +134,7 @@ namespace Ogre {
 
     /// RenderTexture implementation for D3D11
     class _OgreD3D11Export D3D11RenderTexture
-        : public RenderTexture
+        : public RenderTexture, public D3D11RenderTarget
         , protected D3D11DeviceResource
     {
         D3D11Device & mDevice;
@@ -143,6 +144,10 @@ namespace Ogre {
         virtual ~D3D11RenderTexture();
 
         void rebind(D3D11HardwarePixelBuffer *buffer);
+
+        virtual uint getNumberOfViews() const;
+        virtual ID3D11Texture2D* getSurface(uint index = 0) const;
+        virtual ID3D11RenderTargetView* getRenderTargetView(uint index = 0) const;
 
         virtual void getCustomAttribute( const String& name, void *pData );
 

--- a/RenderSystems/Direct3D11/src/OgreD3D11DepthBuffer.cpp
+++ b/RenderSystems/Direct3D11/src/OgreD3D11DepthBuffer.cpp
@@ -29,6 +29,7 @@ THE SOFTWARE.
 #include "OgreD3D11HardwarePixelBuffer.h"
 #include "OgreD3D11Texture.h"
 #include "OgreD3D11Mappings.h"
+#include "OgreD3D11RenderTarget.h"
 
 namespace Ogre
 {
@@ -59,40 +60,20 @@ namespace Ogre
     {
         D3D11_TEXTURE2D_DESC BBDesc;
 
-        bool isTexture = false;
-        renderTarget->getCustomAttribute( "isTexture", &isTexture );
-
-        if(isTexture)
+        D3D11RenderTarget* d3d11RenderTarget = dynamic_cast<D3D11RenderTarget*>(renderTarget);
+        if (!d3d11RenderTarget)
         {
-            ID3D11Texture2D *D3D11texture;
-            D3D11HardwarePixelBuffer *pBuffer;
-            renderTarget->getCustomAttribute( "BUFFER", &pBuffer );
-            D3D11texture = static_cast<ID3D11Texture2D*>( pBuffer->getParentTexture()->getTextureResource() );
-            D3D11texture->GetDesc(&BBDesc);
-        }
-        else
-        {
-            ID3D11Texture2D* pBack[OGRE_MAX_MULTIPLE_RENDER_TARGETS] = {0};
-            renderTarget->getCustomAttribute( "DDBACKBUFFER", &pBack );
-            
-            if( pBack[0] )
-            {
-                pBack[0]->GetDesc(&BBDesc);
-            }
-            else
-            {
-                ID3D11Texture2D *D3D11texture;
-                renderTarget->getCustomAttribute( "ID3D11Texture2D", &D3D11texture );
-                D3D11texture->GetDesc( &BBDesc );
-            }
+            return false;
         }
 
-        /*
-        ID3D11Texture2D *D3D11texture = NULL;
-        renderTarget->getCustomAttribute( "ID3D11Texture2D", &D3D11texture );
-        D3D11_TEXTURE2D_DESC BBDesc;
-        D3D11texture->GetDesc( &BBDesc );
-        */
+        ID3D11Texture2D* d3d11texture = d3d11RenderTarget->getSurface();
+        if (!d3d11texture)
+        {
+            return false;
+        }
+
+        d3d11texture->GetDesc(&BBDesc);
+
         //RenderSystem will determine if bitdepths match (i.e. 32 bit RT don't like 16 bit Depth)
         //This is the same function used to create them. Note results are usually cached so this should
         //be quick

--- a/RenderSystems/Direct3D11/src/OgreD3D11MultiRenderTarget.cpp
+++ b/RenderSystems/Direct3D11/src/OgreD3D11MultiRenderTarget.cpp
@@ -122,34 +122,6 @@ namespace Ogre
         return renderTarget ? renderTarget->getRenderTargetView() : NULL;
     }
 
-    //---------------------------------------------------------------------
-    void D3D11MultiRenderTarget::getCustomAttribute(const String& name, void *pData)
-    {
-        if(name == "DDBACKBUFFER")
-        {
-            ID3D11Texture2D** pSurf = (ID3D11Texture2D**)pData;
-            for(unsigned i = 0; i < OGRE_MAX_MULTIPLE_RENDER_TARGETS; ++i)
-                pSurf[i] = targets[i] ? targets[i]->getParentTexture()->GetTex2D() : NULL;
-        }
-        else if(name == "ID3D11RenderTargetView")
-        {
-            ID3D11RenderTargetView** pRTView = (ID3D11RenderTargetView**)pData;
-            memset(pRTView, 0, OGRE_MAX_MULTIPLE_RENDER_TARGETS * sizeof(ID3D11RenderTargetView*));
-            for(unsigned i = 0; i < OGRE_MAX_MULTIPLE_RENDER_TARGETS && mRenderTargets[i]; ++i)
-                mRenderTargets[i]->getCustomAttribute("ID3D11RenderTargetView", &pRTView[i]);
-        }
-        else if( name == "numberOfViews" )
-        {
-            *(unsigned*)pData = mNumberOfViews;
-        }
-        else if(name == "isTexture")
-        {
-            *(bool*)pData = false;
-        }
-        else
-            MultiRenderTarget::getCustomAttribute(name, pData);
-    }
-    //---------------------------------------------------------------------
     void D3D11MultiRenderTarget::checkAndUpdate()
     {
         if(mRenderTargets[0])

--- a/RenderSystems/Direct3D11/src/OgreD3D11MultiRenderTarget.cpp
+++ b/RenderSystems/Direct3D11/src/OgreD3D11MultiRenderTarget.cpp
@@ -61,13 +61,13 @@ namespace Ogre
 
         /// Find first non-null target
         int y;
-        for(y=0; y<OGRE_MAX_MULTIPLE_RENDER_TARGETS && !targets[y]; ++y) ;
+        for(y=0; y<OGRE_MAX_MULTIPLE_RENDER_TARGETS && !mRenderTargets[y]; ++y) ;
 
         if(y!=OGRE_MAX_MULTIPLE_RENDER_TARGETS)
         {
             /// If there is another target bound, compare sizes
-            if(targets[y]->getWidth() != buffer->getWidth() ||
-                targets[y]->getHeight() != buffer->getHeight())
+            if(mRenderTargets[y]->getWidth() != target->getWidth() ||
+                mRenderTargets[y]->getHeight() != target->getHeight())
             {
 				OGRE_EXCEPT(Exception::ERR_INVALIDPARAMS, 
                     "MultiRenderTarget surfaces are not of same size", 
@@ -152,10 +152,10 @@ namespace Ogre
     //---------------------------------------------------------------------
     void D3D11MultiRenderTarget::checkAndUpdate()
     {
-        if(targets[0])
+        if(mRenderTargets[0])
         {
-            mWidth = static_cast<unsigned int>(targets[0]->getWidth());
-            mHeight = static_cast<unsigned int>(targets[0]->getHeight());
+            mWidth = static_cast<unsigned int>(mRenderTargets[0]->getWidth());
+            mHeight = static_cast<unsigned int>(mRenderTargets[0]->getHeight());
         }
         else
         {

--- a/RenderSystems/Direct3D11/src/OgreD3D11MultiRenderTarget.cpp
+++ b/RenderSystems/Direct3D11/src/OgreD3D11MultiRenderTarget.cpp
@@ -107,6 +107,21 @@ namespace Ogre
 
         MultiRenderTarget::update();
     }
+
+    uint D3D11MultiRenderTarget::getNumberOfViews() const { return mNumberOfViews; }
+
+    ID3D11Texture2D* D3D11MultiRenderTarget::getSurface(uint index) const
+    {
+        D3D11RenderTarget* renderTarget = dynamic_cast<D3D11RenderTarget*>(mRenderTargets[index]);
+        return renderTarget ? renderTarget->getSurface() : NULL;
+    }
+
+    ID3D11RenderTargetView* D3D11MultiRenderTarget::getRenderTargetView(uint index) const
+    {
+        D3D11RenderTarget* renderTarget = dynamic_cast<D3D11RenderTarget*>(mRenderTargets[index]);
+        return renderTarget ? renderTarget->getRenderTargetView() : NULL;
+    }
+
     //---------------------------------------------------------------------
     void D3D11MultiRenderTarget::getCustomAttribute(const String& name, void *pData)
     {

--- a/RenderSystems/Direct3D11/src/OgreD3D11MultiRenderTarget.cpp
+++ b/RenderSystems/Direct3D11/src/OgreD3D11MultiRenderTarget.cpp
@@ -41,7 +41,6 @@ namespace Ogre
         /// Clear targets
         for(size_t x=0; x<OGRE_MAX_MULTIPLE_RENDER_TARGETS; ++x)
         {
-            targets[x] = 0;
             mRenderTargetViews[x] = 0;
             mRenderTargets[x] = 0;
         }
@@ -76,7 +75,6 @@ namespace Ogre
             }
         }
 
-        targets[attachment] = buffer;
         mRenderTargets[attachment] = target;
 
         ID3D11RenderTargetView** v;
@@ -92,7 +90,6 @@ namespace Ogre
     void D3D11MultiRenderTarget::unbindSurfaceImpl(size_t attachment)
     {
         assert(attachment<OGRE_MAX_MULTIPLE_RENDER_TARGETS);
-        targets[attachment] = 0;
         mRenderTargetViews[attachment] = 0;
 
         if(mNumberOfViews > 0)

--- a/RenderSystems/Direct3D11/src/OgreD3D11MultiRenderTarget.cpp
+++ b/RenderSystems/Direct3D11/src/OgreD3D11MultiRenderTarget.cpp
@@ -53,10 +53,8 @@ namespace Ogre
     void D3D11MultiRenderTarget::bindSurfaceImpl(size_t attachment, RenderTexture *target)
     {
         assert(attachment<OGRE_MAX_MULTIPLE_RENDER_TARGETS);
-        /// Get buffer and surface to bind to
-        D3D11HardwarePixelBuffer *buffer = 0;
-        target->getCustomAttribute("BUFFER", &buffer);
-        assert(buffer);
+
+        D3D11RenderTarget* d3d11RenderTarget = dynamic_cast<D3D11RenderTarget*>(target);
 
         /// Find first non-null target
         int y;
@@ -76,10 +74,8 @@ namespace Ogre
         }
 
         mRenderTargets[attachment] = target;
-
-        ID3D11RenderTargetView** v;
-        target->getCustomAttribute( "ID3D11RenderTargetView", &v );
-        mRenderTargetViews[attachment] = *v;
+        mRenderTargetViews[attachment] =
+            d3d11RenderTarget ? d3d11RenderTarget->getRenderTargetView() : NULL;
 
         if(mNumberOfViews < OGRE_MAX_MULTIPLE_RENDER_TARGETS)
             mNumberOfViews++;

--- a/RenderSystems/Direct3D11/src/OgreD3D11RenderWindow.cpp
+++ b/RenderSystems/Direct3D11/src/OgreD3D11RenderWindow.cpp
@@ -293,32 +293,14 @@ namespace Ogre
         // D3DDEVICE            : getD3DDevice
         // WINDOW               : getWindowHandle
 
-        if( name == "D3DDEVICE" )
+        if (name == "D3DDEVICE")
         {
-            *(ID3D11DeviceN **)pData = mDevice.get();
-        }
-        else if( name == "isTexture" )
-        {
-            *(bool*)pData = false;
-        }
-        else if( name == "ID3D11RenderTargetView" )
-        {
-            *(ID3D11RenderTargetView**)pData = mRenderTargetView.Get();
-        }
-        else if( name == "ID3D11Texture2D" )
-        {
-            *(ID3D11Texture2D**)pData = mpBackBuffer.Get();
-        }
-        else if( name == "numberOfViews" )
-        {
-            *(unsigned*)pData = 1;
-        }
-        else if( name == "DDBACKBUFFER" )
-        {
-            *(ID3D11Texture2D**)pData = NULL;
+            *(ID3D11DeviceN**)pData = mDevice.get();
         }
         else
+        {
             RenderWindow::getCustomAttribute(name, pData);
+        }
     }
     //---------------------------------------------------------------------
     void D3D11RenderWindowBase::copyContentsToMemory(const Box& src, const PixelBox &dst, FrameBuffer buffer)

--- a/RenderSystems/Direct3D11/src/OgreD3D11RenderWindow.cpp
+++ b/RenderSystems/Direct3D11/src/OgreD3D11RenderWindow.cpp
@@ -273,6 +273,19 @@ namespace Ogre
                 "D3D11RenderWindowBase::_queryDxgiDevice");
         }
     }
+
+    uint D3D11RenderWindowBase::getNumberOfViews() const { return 1; }
+
+    ID3D11Texture2D* D3D11RenderWindowBase::getSurface(uint index) const
+    {
+        return index == 0 ? mpBackBuffer.Get() : NULL;
+    }
+
+    ID3D11RenderTargetView* D3D11RenderWindowBase::getRenderTargetView(uint index) const
+    {
+        return index == 0 ? mRenderTargetView.Get() : NULL;
+    }
+
     //---------------------------------------------------------------------
     void D3D11RenderWindowBase::getCustomAttribute( const String& name, void* pData )
     {

--- a/RenderSystems/Direct3D11/src/OgreD3D11Texture.cpp
+++ b/RenderSystems/Direct3D11/src/OgreD3D11Texture.cpp
@@ -596,6 +596,20 @@ namespace Ogre
                 "D3D11RenderTexture::rebind" );
         }
     }
+
+    uint D3D11RenderTexture::getNumberOfViews() const { return 1; }
+
+    ID3D11Texture2D* D3D11RenderTexture::getSurface(uint index) const
+    {
+        return index == 0 ? static_cast<D3D11HardwarePixelBuffer*>(mBuffer)->getParentTexture()->GetTex2D()
+                          : NULL;
+    }
+
+    ID3D11RenderTargetView* D3D11RenderTexture::getRenderTargetView(uint index) const
+    {
+        return index == 0 ? mRenderTargetView.Get() : NULL;
+    }
+
     //---------------------------------------------------------------------
     void D3D11RenderTexture::getCustomAttribute( const String& name, void *pData )
     {

--- a/RenderSystems/Direct3D11/src/OgreD3D11Texture.cpp
+++ b/RenderSystems/Direct3D11/src/OgreD3D11Texture.cpp
@@ -610,41 +610,6 @@ namespace Ogre
         return index == 0 ? mRenderTargetView.Get() : NULL;
     }
 
-    //---------------------------------------------------------------------
-    void D3D11RenderTexture::getCustomAttribute( const String& name, void *pData )
-    {
-        if(name == "DDBACKBUFFER")
-        {
-            *(HardwarePixelBuffer**)pData = mBuffer;
-        }
-		else if(name == "HWND" || name == "WINDOW")
-        {
-            *(HWND*)pData = NULL;
-        }
-        else if(name == "isTexture")
-        {
-            *(bool*)pData = true;
-        }
-        else if(name == "BUFFER")
-        {
-            *(HardwarePixelBuffer**)pData = mBuffer;
-        }
-        else if( name == "ID3D11Texture2D" )
-        {
-            *(ID3D11Texture2D**)pData = static_cast<D3D11HardwarePixelBuffer*>(mBuffer)->getParentTexture()->GetTex2D();
-        }
-        else if(name == "ID3D11RenderTargetView")
-        {
-            *(ID3D11RenderTargetView**)pData = mRenderTargetView.Get();
-        }
-        else if( name == "numberOfViews" )
-        {
-            *(unsigned*)pData = 1;
-        }
-        else
-            RenderTexture::getCustomAttribute(name, pData);
-    }
-    //---------------------------------------------------------------------
     D3D11RenderTexture::D3D11RenderTexture( const String &name, D3D11HardwarePixelBuffer *buffer, uint32 zoffset, D3D11Device & device )
         : RenderTexture(buffer, zoffset)
         , mDevice(device)


### PR DESCRIPTION
I created the `D3D11RenderTarget` class/interface and inherited some classes from it.
However, I dont know if this is the best way.
Also, the related calls to the `getCustomAttribute()` methods have not been replaced yet.

Related to #1191.