### PR TITLE
Overlay: fix TextArea Font and material change

### DIFF
--- a/Components/Overlay/src/OgreTextAreaOverlayElement.cpp
+++ b/Components/Overlay/src/OgreTextAreaOverlayElement.cpp
@@ -378,7 +378,8 @@ namespace Ogre {
         if (!mFont)
             OGRE_EXCEPT( Exception::ERR_ITEM_NOT_FOUND, "Could not find font " + font,
                 "TextAreaOverlayElement::setFontName" );
-        
+        mMaterial.reset();
+
         mGeomPositionsOutOfDate = true;
         mGeomUVsOutOfDate = true;
     }


### PR DESCRIPTION
This fixes a bug where calling `TextAreaOverlayElement::setFontName` wouldn't change the font if it had already been set before. This is because `mMaterial` wasn't being updated in `getMaterial` if it had been set previously, and so it would still point to the old font's material (and textures).