### PR TITLE
XMLConverter: do not attempt to create "" named materials

### DIFF
--- a/Tools/XMLConverter/src/OgreXMLMeshSerializer.cpp
+++ b/Tools/XMLConverter/src/OgreXMLMeshSerializer.cpp
@@ -722,7 +722,7 @@ namespace Ogre {
             SubMesh* sm = mMesh->createSubMesh();
 
             const char* mat = smElem->Attribute("material");
-            if (mat)
+            if (mat && mat[0] != '\0')
             {
                 // we do not load any materials - so create a dummy here to just store the name
                 sm->setMaterial(MaterialManager::getSingleton().create(mat, RGN_DEFAULT));

--- a/Tools/XMLConverter/src/main.cpp
+++ b/Tools/XMLConverter/src/main.cpp
@@ -523,6 +523,18 @@ void skeletonToXML(XmlOptions opts)
     SkeletonManager::getSingleton().remove("conversion",
                                            ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
 }
+
+struct MaterialCreator : public MeshSerializerListener
+{
+    void processMaterialName(Mesh *mesh, String *name)
+    {
+        // create material because we do not load any .material files
+        MaterialManager::getSingleton().create(*name, mesh->getGroup());
+    }
+
+    void processSkeletonName(Mesh *mesh, String *name) {}
+    void processMeshCompleted(Mesh *mesh) {}
+};
 }
 
 int main(int numargs, char** args)
@@ -557,6 +569,8 @@ int main(int numargs, char** args)
         matMgr->initialise();
         skelMgr = new SkeletonManager();
         meshSerializer = new MeshSerializer();
+        MaterialCreator matCreator;
+        meshSerializer->setListener(&matCreator);
         xmlMeshSerializer = new XMLMeshSerializer();
         skeletonSerializer = new SkeletonSerializer();
         xmlSkeletonSerializer = new XMLSkeletonSerializer();


### PR DESCRIPTION
it is invalid and triggers an assertion, but lets be tolerant to old XML
files.