### PR TITLE
Main: remove logging from Exception constructor altogether

### DIFF
--- a/OgreMain/src/OgreException.cpp
+++ b/OgreMain/src/OgreException.cpp
@@ -48,14 +48,6 @@ namespace Ogre {
         source( src ),
         file( fil )
     {
-        // Log this error, mask it from debug though since it may be caught and ignored
-        if(LogManager::getSingletonPtr())
-        {
-            LogManager::getSingleton().logMessage(
-                this->getFullDescription(), 
-                LML_CRITICAL, true);
-        }
-
     }
 
     Exception::Exception(const Exception& rhs)


### PR DESCRIPTION
- it calls a virtual function which is UB
- Ogre uses exceptions for internal communication which must be fast
- the messages were only ever received by log-listeners