### PR TITLE
GLSupport: implement the 'currentGLContext' parameter for macOS cocoa windows 

### DIFF
--- a/RenderSystems/GLSupport/src/OSX/OgreOSXCocoaWindow.mm
+++ b/RenderSystems/GLSupport/src/OSX/OgreOSXCocoaWindow.mm
@@ -125,6 +125,9 @@ namespace Ogre {
          Default: Desktop vsync rate
 
         ***Key: "vsync" Description: Synchronize buffer swaps to vsync Values: true, false Default: 0
+
+        ***Key: "currentGLContext" Description: use an externally created OpenGL context (must be current)
+         Values: true, false Default: false
         */
 
 		BOOL hasDepthBuffer = YES;
@@ -135,6 +138,7 @@ namespace Ogre {
 		int colourDepth = 32;
         int surfaceOrder = 1;
         int contextProfile = GLNativeSupport::CONTEXT_COMPATIBILITY;
+        bool currentGLContext = false;
         NSOpenGLContext *externalGLContext = nil;
         NSObject* externalWindowHandle = nil; // NSOpenGLView, NSView or NSWindow
         NameValuePairList::const_iterator opt;
@@ -190,6 +194,10 @@ namespace Ogre {
             opt = miscParams->find("contextProfile");
             if(opt != miscParams->end())
                 contextProfile = StringConverter::parseInt(opt->second);
+
+            opt = miscParams->find("currentGLContext");
+            if (opt != miscParams->end())
+                currentGLContext = StringConverter::parseBool(opt->second);
             
             opt = miscParams->find("externalGLContext");
             if(opt != miscParams->end())
@@ -233,6 +241,11 @@ namespace Ogre {
         {
             mGLContext = [externalGLContext retain];
             mGLPixelFormat = [externalGLContext.pixelFormat retain];
+        }
+        else if(currentGLContext)
+        {
+            mGLContext = [[NSOpenGLContext currentContext] retain];
+            mGLPixelFormat = [mGLContext.pixelFormat retain];
         }
         else
         {


### PR DESCRIPTION
The `currentGLContext` parameter is defined in the [`Ogre::Root::createRenderWindow()` documentation](https://ogrecave.github.io/ogre/api/latest/class_ogre_1_1_root.html#a537b7d1d0937f799cfe4936f6b672620) but was not implemented for macOS (it works fine on Windows and Linux).

I think it would be more convenient to have this option on all platforms so here's the implementation.

I hope you'll find it useful.
Cheers.