### PR TITLE
Provide copy and assign ctors where needed.

### DIFF
--- a/Components/Overlay/include/OgreUTFString.h
+++ b/Components/Overlay/include/OgreUTFString.h
@@ -244,6 +244,9 @@ namespace Ogre {
             _fwd_iterator();
             _fwd_iterator( const _fwd_iterator& i );
 
+            //! assign
+            _fwd_iterator& operator=(const _fwd_iterator&);
+
             //! pre-increment
             _fwd_iterator& operator++();
             //! post-increment
@@ -290,6 +293,8 @@ namespace Ogre {
             _const_fwd_iterator( const _const_fwd_iterator& i );
             _const_fwd_iterator( const _fwd_iterator& i );
 
+            //! assign
+            _const_fwd_iterator& operator=(const _const_fwd_iterator&);
             //! pre-increment
             _const_fwd_iterator& operator++();
             //! post-increment
@@ -351,6 +356,8 @@ namespace Ogre {
             _rev_iterator();
             _rev_iterator( const _rev_iterator& i );
 
+            //! assign
+            _rev_iterator& operator=(const _rev_iterator&);
             //! pre-increment
             _rev_iterator& operator++();
             //! post-increment
@@ -384,6 +391,8 @@ namespace Ogre {
             _const_rev_iterator();
             _const_rev_iterator( const _const_rev_iterator& i );
             _const_rev_iterator( const _rev_iterator& i );
+            //! assign
+            _const_rev_iterator& operator=(const _const_rev_iterator&);
             //! pre-increment
             _const_rev_iterator& operator++();
             //! post-increment

--- a/Components/Overlay/src/OgreUTFString.cpp
+++ b/Components/Overlay/src/OgreUTFString.cpp
@@ -129,6 +129,12 @@ namespace Ogre {
         _become( i );
     }
     //--------------------------------------------------------------------------
+    UTFString::_fwd_iterator& UTFString::_fwd_iterator::operator=(const _fwd_iterator& rhs)
+    {
+        _become(rhs);
+        return *this;
+    }
+    //--------------------------------------------------------------------------
     UTFString::_fwd_iterator& UTFString::_fwd_iterator::operator++()
     {
         _seekFwd( 1 );
@@ -245,6 +251,12 @@ namespace Ogre {
         _become( i );
     }
     //--------------------------------------------------------------------------
+    UTFString::_const_fwd_iterator& UTFString::_const_fwd_iterator::operator=(const _const_fwd_iterator& rhs)
+    {
+        _become(rhs);
+        return *this;
+    }
+    //--------------------------------------------------------------------------
     UTFString::_const_fwd_iterator& UTFString::_const_fwd_iterator::operator++()
     {
         _seekFwd( 1 );
@@ -351,6 +363,12 @@ namespace Ogre {
         _become( i );
     }
     //--------------------------------------------------------------------------
+    UTFString::_rev_iterator& UTFString::_rev_iterator::operator=(const _rev_iterator& rhs)
+    {
+        _become(rhs);
+        return *this;
+    }
+    //--------------------------------------------------------------------------
     UTFString::_rev_iterator& UTFString::_rev_iterator::operator++()
     {
         _seekRev( 1 );
@@ -443,6 +461,12 @@ namespace Ogre {
     UTFString::_const_rev_iterator::_const_rev_iterator( const _rev_iterator& i )
     {
         _become( i );
+    }
+    //--------------------------------------------------------------------------
+    UTFString::_const_rev_iterator& UTFString::_const_rev_iterator::operator=(const _const_rev_iterator& rhs)
+    {
+        _become(rhs);
+        return *this;
     }
     //--------------------------------------------------------------------------
     UTFString::_const_rev_iterator& UTFString::_const_rev_iterator::operator++()

--- a/OgreMain/include/OgreMath.h
+++ b/OgreMain/include/OgreMath.h
@@ -61,6 +61,7 @@ namespace Ogre
     public:
         explicit Radian ( Real r=0 ) : mRad(r) {}
         Radian ( const Degree& d );
+        Radian (const Ogre::Radian& rhs) : mRad(rhs.mRad) {}
         Radian& operator = ( const Real& f ) { mRad = f; return *this; }
         Radian& operator = ( const Radian& r ) { mRad = r.mRad; return *this; }
         Radian& operator = ( const Degree& d );
@@ -112,6 +113,7 @@ namespace Ogre
     public:
         explicit Degree ( Real d=0 ) : mDeg(d) {}
         Degree ( const Radian& r ) : mDeg(r.valueDegrees()) {}
+        Degree (const Ogre::Degree& rhs) : mDeg(rhs.mDeg) {}
         Degree& operator = ( const Real& f ) { mDeg = f; return *this; }
         Degree& operator = ( const Degree& d ) { mDeg = d.mDeg; return *this; }
         Degree& operator = ( const Radian& r ) { mDeg = r.valueDegrees(); return *this; }

--- a/OgreMain/include/OgrePolygon.h
+++ b/OgreMain/include/OgrePolygon.h
@@ -133,6 +133,8 @@ namespace Ogre
         bool operator != (const Polygon& rhs) const
         { return !( *this == rhs ); }
 
+        Polygon& operator=(const Ogre::Polygon&) ;
+
         /** Prints out the polygon data.
         */
         _OgreExport friend std::ostream& operator<< ( std::ostream& strm, const Polygon& poly );

--- a/OgreMain/include/OgreQuaternion.h
+++ b/OgreMain/include/OgreQuaternion.h
@@ -61,6 +61,10 @@ namespace Ogre {
             : w(1), x(0), y(0), z(0)
         {
         }
+        /// Copy constructor
+        inline Quaternion(const Ogre::Quaternion& rhs)
+            : w(rhs.w), x(rhs.x), y(rhs.y), z(rhs.z)
+        {}
         /// Construct from an explicit list of values
         inline Quaternion (
             Real fW,

--- a/OgreMain/include/OgreSharedPtr.h
+++ b/OgreMain/include/OgreSharedPtr.h
@@ -71,7 +71,7 @@ namespace Ogre {
         template<class Y>
         SharedPtr(const shared_ptr<Y>& r) : shared_ptr<T>(r) {}
         operator const shared_ptr<T>&() { return static_cast<shared_ptr<T>&>(*this); }
-
+        SharedPtr<T>& operator=(const Ogre::SharedPtr<T>& rhs) {shared_ptr<T>::operator=(rhs); return *this;}
         // so swig recognizes it should forward the operators
         T* operator->() const { return shared_ptr<T>::operator->(); }
 

--- a/OgreMain/src/OgrePolygon.cpp
+++ b/OgreMain/src/OgrePolygon.cpp
@@ -207,6 +207,14 @@ namespace Ogre
         return true;
     }
     //-----------------------------------------------------------------------
+    Polygon& Polygon::operator=(const Ogre::Polygon& rhs)
+    {
+        mIsNormalSet = rhs.mIsNormalSet;
+        mNormal = rhs.mNormal;
+        mVertexList = rhs.mVertexList;
+        return *this;
+    }
+    //-----------------------------------------------------------------------
     std::ostream& operator<< ( std::ostream& strm, const Polygon& poly )
     {
         strm << "NUM VERTICES: " << poly.getVertexCount() << std::endl;

--- a/OgreMain/src/OgreVertexIndexData.cpp
+++ b/OgreMain/src/OgreVertexIndexData.cpp
@@ -761,6 +761,13 @@ namespace Ogre {
         {
         }
 
+        inline Triangle& operator=(const Triangle& rhs) {
+            a = rhs.a;
+            b = rhs.b;
+            c = rhs.c;
+            return *this;
+        }
+
         inline bool sharesEdge(const Triangle& t) const
         {
             return( (a == t.a && b == t.c) ||


### PR DESCRIPTION
This doesn't change anything, but it appeases gcc 9.2.1 which otherwise
absolutely spams the console with warnings about mixing implicit and
explicit copy constructors.

This implementation should work with C++98.