### PR TITLE
Install Linux docs in /usr/share/doc/OGRE

### DIFF
--- a/Docs/CMakeLists.txt
+++ b/Docs/CMakeLists.txt
@@ -16,7 +16,7 @@
 if (WIN32 OR APPLE)
   set(OGRE_DOCS_PATH "Docs")
 elseif (UNIX)
-  set(OGRE_DOCS_PATH "share/OGRE/docs")
+  set(OGRE_DOCS_PATH "share/doc/OGRE")
 endif ()
 
 # Build and install API documentation if doxygen is available


### PR DESCRIPTION
This fits with the Filesystem Hierarchy Standard. It also helps with
packaging of OGRE, since some systems require that all directories
is owned by one single package. Thus it's beneficial if the docs are
kept separate from the media.