### PR TITLE
Reverse depth buffer implementation for OpenGL3+

### DIFF
--- a/OgreMain/include/OgreMath.h
+++ b/OgreMain/include/OgreMath.h
@@ -736,7 +736,7 @@ namespace Ogre
            q = - (far + near) / (far - near)
            qn = - 2 * (far * near) / (far - near)
          */
-        static Matrix4 makePerspectiveMatrix(Real left, Real right, Real bottom, Real top, Real zNear, Real zFar);
+        static Matrix4 makePerspectiveMatrix(Real left, Real right, Real bottom, Real top, Real zNear, Real zFar, bool isReverseDepth = false);
 
         /** Get the radius of the origin-centered bounding sphere from the bounding box. */
         static Real boundingRadiusFromAABB(const AxisAlignedBox& aabb);

--- a/OgreMain/include/OgreRenderSystem.h
+++ b/OgreMain/include/OgreRenderSystem.h
@@ -434,6 +434,35 @@ namespace Ogre
         */
         void setDepthBufferFor( RenderTarget *renderTarget );
 
+        /**
+         Set reverse depth buffer enabled or disabled (default disabled).
+
+         @note You must call this function EARLY (before creating windows)!
+               You can't change this value after that.
+
+         If you have large scenes and need big far clip distance but still want
+         to draw objects closer (for example cockpit of a plane) you can enable
+         reverse depth buffer so that the depth buffer precision is greater further away.
+         This enables the OGRE_REVERSED_Z preprocessor define for shaders.
+
+         @param isReversed If true reverse Z-buffer will be enabled (false by default).
+         @see isReverseDepthBufferEnabled
+         */
+        void setReverseDepthBuffer(bool isReversed);
+
+        /**
+         Returns if reverse Z-buffer is enabled.
+
+         Usually you should not need to call this function
+         (the RenderSystem will handle everything for you).
+
+         @retval true If reverse Z-buffer is enabled.
+         @retval false If reverse Z-buffer is disabled (default).
+
+         @see setReverseDepthBuffer
+         */
+        bool isReverseDepthBufferEnabled() const;
+
         // ------------------------------------------------------------------------
         //                     Internal Rendering Access
         // All methods below here are normally only called by other OGRE classes
@@ -1175,6 +1204,7 @@ namespace Ogre
         ColourValue mManualBlendColours[OGRE_MAX_TEXTURE_LAYERS][2];
 
         bool mInvertVertexWinding;
+        bool mIsReverseDepthBufferEnabled;
 
         /// Texture units from this upwards are disabled
         size_t mDisabledTexUnitsFrom;

--- a/OgreMain/src/OgreFrustum.cpp
+++ b/OgreMain/src/OgreFrustum.cpp
@@ -372,13 +372,15 @@ namespace Ogre {
         }
 
         Real left = rect.left, right = rect.right, top = rect.top, bottom = rect.bottom;
+        RenderSystem* renderSystem = Root::getSingleton().getRenderSystem();
+        const bool isReverseDepthBuffer = renderSystem ? renderSystem->isReverseDepthBufferEnabled() : false;
 
         if (!mCustomProjMatrix)
         {
             // Recalc if frustum params changed
             if (mProjType == PT_PERSPECTIVE)
             {
-                mProjMatrix = Math::makePerspectiveMatrix(left, right, bottom, top, mNearDist, mFarDist);
+                mProjMatrix = Math::makePerspectiveMatrix(left, right, bottom, top, mNearDist, mFarDist, isReverseDepthBuffer);
 
                 if (mObliqueDepthProjection)
                 {
@@ -406,7 +408,7 @@ namespace Ogre {
                     Vector4 qVec;
                     qVec.x = (Math::Sign(plane.normal.x) + mProjMatrix[0][2]) / mProjMatrix[0][0];
                     qVec.y = (Math::Sign(plane.normal.y) + mProjMatrix[1][2]) / mProjMatrix[1][1];
-                    qVec.z = -1;
+                    qVec.z = (isReverseDepthBuffer ? 1 : -1);
                     qVec.w = (1 + mProjMatrix[2][2]) / mProjMatrix[2][3];
 
                     // Calculate the scaled plane vector
@@ -416,7 +418,7 @@ namespace Ogre {
                     // Replace the third row of the projection matrix
                     mProjMatrix[2][0] = c.x;
                     mProjMatrix[2][1] = c.y;
-                    mProjMatrix[2][2] = c.z + 1;
+                    mProjMatrix[2][2] = c.z + (isReverseDepthBuffer ? -1 : 1);
                     mProjMatrix[2][3] = c.w; 
                 }
             } // perspective
@@ -478,8 +480,6 @@ namespace Ogre {
         // Deal with orientation mode
         mProjMatrix = mProjMatrix * Quaternion(Degree(mOrientationMode * 90.f), Vector3::UNIT_Z);
 #endif
-
-        RenderSystem* renderSystem = Root::getSingleton().getRenderSystem();
 
         if(renderSystem)
         {

--- a/OgreMain/src/OgreMath.cpp
+++ b/OgreMain/src/OgreMath.cpp
@@ -807,7 +807,7 @@ namespace Ogre
 
     }
 
-    Matrix4 Math::makePerspectiveMatrix(Real left, Real right, Real bottom, Real top, Real zNear, Real zFar)
+    Matrix4 Math::makePerspectiveMatrix(Real left, Real right, Real bottom, Real top, Real zNear, Real zFar, bool isReverseDepth)
     {
         // The code below will dealing with general projection
         // parameters, similar glFrustum.
@@ -816,7 +816,16 @@ namespace Ogre
 
         Real inv_w = 1 / (right - left);
         Real inv_h = 1 / (top - bottom);
-        Real inv_d = 1 / (zFar - zNear);
+        Real inv_d;
+
+        if (isReverseDepth)
+        {
+            inv_d = 1 / (zNear - zFar);
+        }
+        else
+        {
+            inv_d = 1 / (zFar - zNear);
+        }
 
         // Calc matrix elements
         Real A = 2 * zNear * inv_w;

--- a/OgreMain/src/OgreRenderSystem.cpp
+++ b/OgreMain/src/OgreRenderSystem.cpp
@@ -60,6 +60,7 @@ namespace Ogre {
         , mFaceCount(0)
         , mVertexCount(0)
         , mInvertVertexWinding(false)
+        , mIsReverseDepthBufferEnabled(false)
         , mDisabledTexUnitsFrom(0)
         , mCurrentPassIterationCount(0)
         , mCurrentPassIterationNum(0)
@@ -634,6 +635,16 @@ namespace Ogre {
                 LogManager::getSingleton().logWarning( "Couldn't create a suited DepthBuffer"
                                                        "for RT: " + renderTarget->getName());
         }
+    }
+    //-----------------------------------------------------------------------
+    void RenderSystem::setReverseDepthBuffer(bool isReversed)
+    {
+        mIsReverseDepthBufferEnabled = isReversed;
+    }
+    //-----------------------------------------------------------------------
+    bool RenderSystem::isReverseDepthBufferEnabled() const
+    {
+        return mIsReverseDepthBufferEnabled;
     }
     //-----------------------------------------------------------------------
     void RenderSystem::shutdown(void)

--- a/RenderSystems/GL3Plus/include/OgreGL3PlusRenderSystem.h
+++ b/RenderSystems/GL3Plus/include/OgreGL3PlusRenderSystem.h
@@ -213,6 +213,10 @@ namespace Ogre {
 
         void _render(const RenderOperation& op);
 
+        void _getDepthStencilFormatFor(PixelFormat internalColourFormat,
+                                       uint32* depthFormat,
+                                       uint32* stencilFormat);
+
         void setScissorTest(bool enabled, size_t left = 0, size_t top = 0, size_t right = 800, size_t bottom = 600);
 
         void clearFrameBuffer(unsigned int buffers,
@@ -260,7 +264,7 @@ namespace Ogre {
          */
         void _setRenderTarget(RenderTarget *target);
 
-        static GLint convertCompareFunction(CompareFunction func);
+        static GLint convertCompareFunction(CompareFunction func, bool isReverse = false);
         static GLint convertStencilOp(StencilOperation op, bool invert = false);
 
         void bindGpuProgram(GpuProgram* prg);

--- a/RenderSystems/GLSupport/include/OgreGLRenderSystemCommon.h
+++ b/RenderSystems/GLSupport/include/OgreGLRenderSystemCommon.h
@@ -128,15 +128,12 @@ namespace Ogre {
             this->_initialise();
         }
 
-        void _convertProjectionMatrix(const Matrix4& matrix, Matrix4& dest, bool)
-        {
-            // no conversion request for OpenGL
-            dest = matrix;
-        }
+        void _convertProjectionMatrix(const Matrix4& matrix, Matrix4& dest, bool);
 
         /// Mimics D3D9RenderSystem::_getDepthStencilFormatFor, if no FBO RTT manager, outputs GL_NONE
-        void _getDepthStencilFormatFor(PixelFormat internalColourFormat, uint32* depthFormat,
-                                       uint32* stencilFormat);
+        virtual void _getDepthStencilFormatFor(PixelFormat internalColourFormat,
+                                               uint32* depthFormat,
+                                               uint32* stencilFormat);
 
         /** Create VAO on current context */
         virtual uint32 _createVao() { return 0; }

--- a/RenderSystems/GLSupport/src/GLSL/OgreGLSLShaderCommon.cpp
+++ b/RenderSystems/GLSupport/src/GLSL/OgreGLSLShaderCommon.cpp
@@ -62,7 +62,14 @@ namespace Ogre {
         if(getLanguage() == "glsles")
             cpp.Define("GL_ES", 5, 1);
 
+        RenderSystem* renderSystem = Root::getSingleton().getRenderSystem();
+        if (renderSystem && renderSystem->isReverseDepthBufferEnabled())
+        {
+            cpp.Define("OGRE_REVERSED_Z", 15, 1);
+        }
+
         String defines = mPreprocessorDefines;
+
         for(const auto& def : parseDefines(defines))
         {
             cpp.Define(def.first, strlen(def.first), def.second, strlen(def.second));

--- a/RenderSystems/GLSupport/src/OgreGLRenderSystemCommon.cpp
+++ b/RenderSystems/GLSupport/src/OgreGLRenderSystemCommon.cpp
@@ -209,6 +209,21 @@ namespace Ogre {
         }
     }
 
+    void GLRenderSystemCommon::_convertProjectionMatrix(const Matrix4& matrix, Matrix4& dest, bool)
+    {
+        // no conversion request for OpenGL
+        dest = matrix;
+
+        if (mIsReverseDepthBufferEnabled)
+        {
+            // Convert depth range from [+1,-1] to [1,0]
+            dest[2][0] = (dest[2][0] + dest[3][0]) * 0.5f;
+            dest[2][1] = (dest[2][1] + dest[3][1]) * 0.5f;
+            dest[2][2] = (dest[2][2] + dest[3][2]) * 0.5f;
+            dest[2][3] = (dest[2][3] + dest[3][3]) * 0.5f;
+        }
+    }
+
     void GLRenderSystemCommon::_getDepthStencilFormatFor(PixelFormat internalColourFormat,
                                                          uint32* depthFormat, uint32* stencilFormat)
     {


### PR DESCRIPTION
RenderSystem has new function setReverseDepthBuffer for controlling if this is enabled. This function must be called early to take effect.
glClipControl was not found in old gl3w so it had to be updated as well.
GLSL shaders will have REVERSE_Z_BUFFER define defined when reverse depth buffer is in use.
 * Implementations that used gl_Position.z for calculating fog for example need to change their implementation and this define can be used for that.

Normally OpenGL has it's depth range from -1 to 1 but this flag will change it to be from 1 to 0.