### PR TITLE
Reverse Z-buffer introduced invalid projection matrix

### DIFF
--- a/OgreMain/include/OgreMath.h
+++ b/OgreMain/include/OgreMath.h
@@ -736,7 +736,7 @@ namespace Ogre
            q = - (far + near) / (far - near)
            qn = - 2 * (far * near) / (far - near)
          */
-        static Matrix4 makePerspectiveMatrix(Real left, Real right, Real bottom, Real top, Real zNear, Real zFar, bool isReverseDepth = false);
+        static Matrix4 makePerspectiveMatrix(Real left, Real right, Real bottom, Real top, Real zNear, Real zFar);
 
         /** Get the radius of the origin-centered bounding sphere from the bounding box. */
         static Real boundingRadiusFromAABB(const AxisAlignedBox& aabb);

--- a/OgreMain/src/OgreFrustum.cpp
+++ b/OgreMain/src/OgreFrustum.cpp
@@ -372,15 +372,13 @@ namespace Ogre {
         }
 
         Real left = rect.left, right = rect.right, top = rect.top, bottom = rect.bottom;
-        RenderSystem* renderSystem = Root::getSingleton().getRenderSystem();
-        const bool isReverseDepthBuffer = renderSystem ? renderSystem->isReverseDepthBufferEnabled() : false;
 
         if (!mCustomProjMatrix)
         {
             // Recalc if frustum params changed
             if (mProjType == PT_PERSPECTIVE)
             {
-                mProjMatrix = Math::makePerspectiveMatrix(left, right, bottom, top, mNearDist, mFarDist, isReverseDepthBuffer);
+                mProjMatrix = Math::makePerspectiveMatrix(left, right, bottom, top, mNearDist, mFarDist);
 
                 if (mObliqueDepthProjection)
                 {
@@ -408,7 +406,7 @@ namespace Ogre {
                     Vector4 qVec;
                     qVec.x = (Math::Sign(plane.normal.x) + mProjMatrix[0][2]) / mProjMatrix[0][0];
                     qVec.y = (Math::Sign(plane.normal.y) + mProjMatrix[1][2]) / mProjMatrix[1][1];
-                    qVec.z = (isReverseDepthBuffer ? 1 : -1);
+                    qVec.z = -1;
                     qVec.w = (1 + mProjMatrix[2][2]) / mProjMatrix[2][3];
 
                     // Calculate the scaled plane vector
@@ -418,7 +416,7 @@ namespace Ogre {
                     // Replace the third row of the projection matrix
                     mProjMatrix[2][0] = c.x;
                     mProjMatrix[2][1] = c.y;
-                    mProjMatrix[2][2] = c.z + (isReverseDepthBuffer ? -1 : 1);
+                    mProjMatrix[2][2] = c.z + 1;
                     mProjMatrix[2][3] = c.w; 
                 }
             } // perspective
@@ -480,6 +478,7 @@ namespace Ogre {
         // Deal with orientation mode
         mProjMatrix = mProjMatrix * Quaternion(Degree(mOrientationMode * 90.f), Vector3::UNIT_Z);
 #endif
+        RenderSystem* renderSystem = Root::getSingleton().getRenderSystem();
 
         if(renderSystem)
         {

--- a/OgreMain/src/OgreMath.cpp
+++ b/OgreMain/src/OgreMath.cpp
@@ -807,7 +807,7 @@ namespace Ogre
 
     }
 
-    Matrix4 Math::makePerspectiveMatrix(Real left, Real right, Real bottom, Real top, Real zNear, Real zFar, bool isReverseDepth)
+    Matrix4 Math::makePerspectiveMatrix(Real left, Real right, Real bottom, Real top, Real zNear, Real zFar)
     {
         // The code below will dealing with general projection
         // parameters, similar glFrustum.
@@ -816,16 +816,7 @@ namespace Ogre
 
         Real inv_w = 1 / (right - left);
         Real inv_h = 1 / (top - bottom);
-        Real inv_d;
-
-        if (isReverseDepth)
-        {
-            inv_d = 1 / (zNear - zFar);
-        }
-        else
-        {
-            inv_d = 1 / (zFar - zNear);
-        }
+        Real inv_d = 1 / (zFar - zNear);
 
         // Calc matrix elements
         Real A = 2 * zNear * inv_w;

--- a/RenderSystems/GLSupport/src/OgreGLRenderSystemCommon.cpp
+++ b/RenderSystems/GLSupport/src/OgreGLRenderSystemCommon.cpp
@@ -211,16 +211,16 @@ namespace Ogre {
 
     void GLRenderSystemCommon::_convertProjectionMatrix(const Matrix4& matrix, Matrix4& dest, bool)
     {
-        // no conversion request for OpenGL
+        // no conversion required for OpenGL
         dest = matrix;
 
         if (mIsReverseDepthBufferEnabled)
         {
-            // Convert depth range from [+1,-1] to [1,0]
-            dest[2][0] = (dest[2][0] + dest[3][0]) * 0.5f;
-            dest[2][1] = (dest[2][1] + dest[3][1]) * 0.5f;
-            dest[2][2] = (dest[2][2] + dest[3][2]) * 0.5f;
-            dest[2][3] = (dest[2][3] + dest[3][3]) * 0.5f;
+            // Convert depth range from [-1,+1] to [1,0]
+            dest[2][0] = (dest[2][0] - dest[3][0]) * -0.5f;
+            dest[2][1] = (dest[2][1] - dest[3][1]) * -0.5f;
+            dest[2][2] = (dest[2][2] - dest[3][2]) * -0.5f;
+            dest[2][3] = (dest[2][3] - dest[3][3]) * -0.5f;
         }
     }
 


### PR DESCRIPTION
The problem was when using custom near clip plane. I have undone the frustum changes and made correct projection matrix change in the `GLRenderSystemCommon::_convertProjectionMatrix` function. This makes even the custom near clip plane work correctly with the reversed z buffer.