### PR TITLE
Main: make reverse-Z a ConfigOption and check compatibility in GL3Plus

### DIFF
--- a/OgreMain/include/OgreRenderSystem.h
+++ b/OgreMain/include/OgreRenderSystem.h
@@ -435,26 +435,12 @@ namespace Ogre
         void setDepthBufferFor( RenderTarget *renderTarget );
 
         /**
-         Set reverse depth buffer enabled or disabled (default disabled).
-
-         @note You must call this function EARLY (before creating windows)!
-               You can't change this value after that.
+         Returns if reverse Z-buffer is enabled.
 
          If you have large scenes and need big far clip distance but still want
          to draw objects closer (for example cockpit of a plane) you can enable
          reverse depth buffer so that the depth buffer precision is greater further away.
          This enables the OGRE_REVERSED_Z preprocessor define for shaders.
-
-         @param isReversed If true reverse Z-buffer will be enabled (false by default).
-         @see isReverseDepthBufferEnabled
-         */
-        void setReverseDepthBuffer(bool isReversed);
-
-        /**
-         Returns if reverse Z-buffer is enabled.
-
-         Usually you should not need to call this function
-         (the RenderSystem will handle everything for you).
 
          @retval true If reverse Z-buffer is enabled.
          @retval false If reverse Z-buffer is disabled (default).

--- a/OgreMain/src/OgreRenderSystem.cpp
+++ b/OgreMain/src/OgreRenderSystem.cpp
@@ -637,11 +637,6 @@ namespace Ogre {
         }
     }
     //-----------------------------------------------------------------------
-    void RenderSystem::setReverseDepthBuffer(bool isReversed)
-    {
-        mIsReverseDepthBufferEnabled = isReversed;
-    }
-    //-----------------------------------------------------------------------
     bool RenderSystem::isReverseDepthBufferEnabled() const
     {
         return mIsReverseDepthBufferEnabled;

--- a/RenderSystems/GL3Plus/include/OgreGL3PlusRenderSystem.h
+++ b/RenderSystems/GL3Plus/include/OgreGL3PlusRenderSystem.h
@@ -139,6 +139,8 @@ namespace Ogre {
 
         void _initialise() override;
 
+        void initConfigOptions();
+
         virtual RenderSystemCapabilities* createRenderSystemCapabilities() const;
 
         void initialiseFromRenderSystemCapabilities(RenderSystemCapabilities* caps, RenderTarget* primary);

--- a/RenderSystems/GL3Plus/src/OgreGL3PlusRenderSystem.cpp
+++ b/RenderSystems/GL3Plus/src/OgreGL3PlusRenderSystem.cpp
@@ -190,6 +190,19 @@ namespace Ogre {
         mGLSupport->start();
     }
 
+    void GL3PlusRenderSystem::initConfigOptions()
+    {
+        GLRenderSystemCommon::initConfigOptions();
+
+        ConfigOption opt;
+        opt.name = "Reversed Z-Buffer";
+        opt.possibleValues = {"No", "Yes"};
+        opt.currentValue = opt.possibleValues[0];
+        opt.immutable = false;
+
+        mOptions[opt.name] = opt;
+    }
+
     RenderSystemCapabilities* GL3PlusRenderSystem::createRenderSystemCapabilities() const
     {
         RenderSystemCapabilities* rsc = OGRE_NEW RenderSystemCapabilities();
@@ -650,6 +663,15 @@ namespace Ogre {
             const char* shadingLangVersion = (const char*)glGetString(GL_SHADING_LANGUAGE_VERSION);
             StringVector tokens = StringUtil::split(shadingLangVersion, ". ");
             mNativeShadingLanguageVersion = (StringConverter::parseUnsignedInt(tokens[0]) * 100) + StringConverter::parseUnsignedInt(tokens[1]);
+
+            auto it = mOptions.find("Reversed Z-Buffer");
+            if (it != mOptions.end())
+            {
+                mIsReverseDepthBufferEnabled = StringConverter::parseBool(it->second.currentValue);
+                OgreAssert(!mIsReverseDepthBufferEnabled || hasMinGLVersion(4, 5) ||
+                               checkExtension("GL_ARB_clip_control"),
+                           "Reversed Z-Buffer not supported");
+            }
 
             // Initialise GL after the first window has been created
             // TODO: fire this from emulation options, and don't duplicate Real and Current capabilities


### PR DESCRIPTION
this ensures it is enabled early on and that it cannot be enabled on
RenderSystems not explicitly supporting it.