### PR TITLE
fix ssao demo for directx11

### DIFF
--- a/Samples/Media/materials/scripts/SSAO/SSAOPost.hlsl
+++ b/Samples/Media/materials/scripts/SSAO/SSAOPost.hlsl
@@ -76,6 +76,10 @@ float4 smartBoxFilter_fp
 //    oColor0 = float4(tex2D(sOcclusion, screenTC).www, 1);
 }
 
+struct noFilterIn
+{
+    float2 uv : TEXCOORD0;
+};
 
 // cross bilateral filter
 // gaussian blur with photometric weighting

--- a/Samples/SSAO/include/SSAO.h
+++ b/Samples/SSAO/include/SSAO.h
@@ -176,9 +176,9 @@ public:
             OGRE_EXCEPT(Exception::ERR_NOT_IMPLEMENTED, "Your graphics card does not support vertex and fragment"
                         " programs, so you cannot run this sample. Sorry!", "Sample_SSAO::testCapabilities");
         }
-		if (StringUtil::startsWith(caps->getRenderSystemName(), "OpenGL ES"))
+        if (!StringUtil::startsWith(caps->getRenderSystemName(), "OpenGL 3+") && !StringUtil::startsWith (caps->getRenderSystemName (), "Direct3D11"))
         {
-            OGRE_EXCEPT(Exception::ERR_INVALID_STATE, "This demo currently only supports OpenGL and DirectX9. Sorry!",
+            OGRE_EXCEPT (Exception::ERR_INVALID_STATE, "This demo currently only supports OpenGL 3+ and DirectX 11. Sorry!",
                 "Sample_SSAO:testCapabilities");
         }
     }


### PR DESCRIPTION
ssao crashes because the hlsl shader is missing a struct definition.  also updated the sample to check for the required render systems which are directx 11 and opengl 3+.