### PR TITLE
Compile Remotery.c as cpp-file

### DIFF
--- a/OgreMain/CMakeLists.txt
+++ b/OgreMain/CMakeLists.txt
@@ -181,6 +181,7 @@ endif()
 
 if(OGRE_PROFILING_REMOTERY_PATH)
   list(APPEND SOURCE_FILES ${OGRE_PROFILING_REMOTERY_PATH}/Remotery.c)
+  set_source_files_properties(${OGRE_PROFILING_REMOTERY_PATH}/Remotery.c PROPERTIES LANGUAGE CXX)
   set_source_files_properties(src/OgreProfiler.cpp PROPERTIES COMPILE_DEFINITIONS USE_REMOTERY)
 endif()
 


### PR DESCRIPTION
Otherwise Visual Studio will complain "precompiled header file is from a previous version of the compiler, or the precompiled header is C++ and you are using it from C (or vice versa)".