### PR TITLE
GLSupport: add the 'externalGLControl' option to Cocoa render windows

### DIFF
--- a/RenderSystems/GLSupport/include/OSX/OgreOSXCocoaWindow.h
+++ b/RenderSystems/GLSupport/include/OSX/OgreOSXCocoaWindow.h
@@ -60,6 +60,7 @@ namespace Ogre {
         bool mVSync;
         bool mHasResized;
         bool mIsExternal;
+        bool mExternalGLControl;
         String mWindowTitle;
         bool mUseOgreGLView;
         float mContentScalingFactor;


### PR DESCRIPTION
The option was missing for macOS but described in the [`Ogre::Root::createRenderWindow`](https://ogrecave.github.io/ogre/api/latest/class_ogre_1_1_root.html#a537b7d1d0937f799cfe4936f6b672620) documentation.