### PR TITLE
Main: make HighLevelGpuProgramPtr an alias for GpuProgramPtr

### DIFF
--- a/Components/RTShaderSystem/src/OgreShaderProgramManager.cpp
+++ b/Components/RTShaderSystem/src/OgreShaderProgramManager.cpp
@@ -331,7 +331,7 @@ GpuProgramPtr ProgramManager::createGpuProgram(Program* shaderProgram,
     }
 
     pGpuProgram->setSource(source);
-    pGpuProgram->setPreprocessorDefines(shaderProgram->getPreprocessorDefines());
+    pGpuProgram->setParameter("preprocessor_defines", shaderProgram->getPreprocessorDefines());
     pGpuProgram->setParameter("entry_point", shaderProgram->getEntryPointFunction()->getName());
 
     if (language == "hlsl")

--- a/Components/Terrain/src/OgreTerrainMaterialShaderHelperGLSL.cpp
+++ b/Components/Terrain/src/OgreTerrainMaterialShaderHelperGLSL.cpp
@@ -66,7 +66,7 @@ namespace Ogre
 
         if (prof->getParent()->getDebugLevel())
         {
-            ret->setPreprocessorDefines(
+            ret->setParameter("preprocessor_defines",
                 StringUtil::format("TERRAIN_DEBUG,NUM_LODS=%d", terrain->getNumLodLevels()));
         }
 
@@ -98,7 +98,7 @@ namespace Ogre
         if (prof->getReceiveDynamicShadowsPSSM())
         {
             uint numShadowTextures = prof->getReceiveDynamicShadowsPSSM()->getSplitCount();
-            ret->setPreprocessorDefines(StringUtil::format("PSSM_NUM_SPLITS=%d", numShadowTextures));
+            ret->setParameter("preprocessor_defines", StringUtil::format("PSSM_NUM_SPLITS=%d", numShadowTextures));
         }
 
         if(!mIsGLSL)

--- a/OgreMain/include/OgrePrerequisites.h
+++ b/OgreMain/include/OgrePrerequisites.h
@@ -296,7 +296,7 @@ namespace Ogre {
     typedef SharedPtr<HardwareUniformBuffer> HardwareUniformBufferSharedPtr;
     typedef HardwareUniformBufferSharedPtr HardwareCounterBufferSharedPtr;
     typedef SharedPtr<HardwareVertexBuffer> HardwareVertexBufferSharedPtr;
-    typedef SharedPtr<HighLevelGpuProgram> HighLevelGpuProgramPtr;
+    typedef GpuProgramPtr HighLevelGpuProgramPtr; //!< @deprecated
     typedef SharedPtr<Material> MaterialPtr;
     typedef SharedPtr<MemoryDataStream> MemoryDataStreamPtr;
     typedef SharedPtr<Mesh> MeshPtr;

--- a/OgreMain/include/OgreScriptCompiler.h
+++ b/OgreMain/include/OgreScriptCompiler.h
@@ -524,21 +524,7 @@ namespace Ogre
     };
 
     /// @deprecated use CreateGpuProgramScriptCompilerEvent
-    class OGRE_DEPRECATED _OgreExport CreateHighLevelGpuProgramScriptCompilerEvent : public CreateGpuProgramScriptCompilerEvent
-    {
-    public:
-        String mLanguage;
-        static String eventType;
-
-        CreateHighLevelGpuProgramScriptCompilerEvent(const String& file, const String& name,
-                                                     const String& resourceGroup, const String& source,
-                                                     const String& language, GpuProgramType programType)
-            : CreateGpuProgramScriptCompilerEvent(file, name, resourceGroup, source, language, programType),
-              mLanguage(language)
-        {
-            mType = eventType; // override
-        }
-    };
+    typedef OGRE_DEPRECATED CreateGpuProgramScriptCompilerEvent CreateHighLevelGpuProgramScriptCompilerEvent;
 
     class _OgreExport CreateGpuSharedParametersScriptCompilerEvent : public ScriptCompilerEvent
     {

--- a/OgreMain/include/OgreUnifiedHighLevelGpuProgram.h
+++ b/OgreMain/include/OgreUnifiedHighLevelGpuProgram.h
@@ -58,7 +58,7 @@ namespace Ogre {
         at another program name. The first one which has a supported syntax 
         will be used.
     */
-    class _OgreExport UnifiedHighLevelGpuProgram : public HighLevelGpuProgram
+    class _OgreExport UnifiedHighLevelGpuProgram : public GpuProgram
     {
     private:
         static std::map<String,int> mLanguagePriorities;
@@ -91,6 +91,7 @@ namespace Ogre {
         void buildConstantDefinitions() const;
         void loadFromSource(void);
 
+        void unloadImpl() { resetCompileError(); }
     public:
         /** Constructor, should be used only by factory classes. */
         UnifiedHighLevelGpuProgram(ResourceManager* creator, const String& name, ResourceHandle handle,

--- a/OgreMain/src/OgreHighLevelGpuProgramManager.cpp
+++ b/OgreMain/src/OgreHighLevelGpuProgramManager.cpp
@@ -32,34 +32,19 @@ THE SOFTWARE.
 namespace Ogre {
 
     String sNullLang = "null";
-    class NullProgram : public HighLevelGpuProgram
+    class NullProgram : public GpuProgram
     {
     protected:
         /** Internal load implementation, must be implemented by subclasses.
         */
         void loadFromSource(void) {}
-        /** Internal method for creating an appropriate low-level program from this
-        high-level program, must be implemented by subclasses. */
-        void createLowLevelImpl(void) {}
-        /// Internal unload implementation, must be implemented by subclasses
-        void unloadHighLevelImpl(void) {}
-        /// Populate the passed parameters with name->index map, must be overridden
-        void populateParameterNames(GpuProgramParametersSharedPtr params)
-        {
-            // Skip the normal implementation
-            // Ensure we don't complain about missing parameter names
-            params->setIgnoreMissingParams(true);
+        void unloadImpl() {}
 
-        }
-        void buildConstantDefinitions() const
-        {
-            // do nothing
-        }
     public:
         NullProgram(ResourceManager* creator, 
             const String& name, ResourceHandle handle, const String& group, 
             bool isManual, ManualResourceLoader* loader)
-            : HighLevelGpuProgram(creator, name, handle, group, isManual, loader){}
+            : GpuProgram(creator, name, handle, group, isManual, loader){}
         ~NullProgram() {}
         /// Overridden from GpuProgram - never supported
         bool isSupported(void) const { return false; }

--- a/OgreMain/src/OgreScriptCompiler.cpp
+++ b/OgreMain/src/OgreScriptCompiler.cpp
@@ -1688,8 +1688,6 @@ namespace Ogre
     //----------------------------------------------------------------------------
     String CreateGpuProgramScriptCompilerEvent::eventType = "createGpuProgram";
     //-------------------------------------------------------------------------
-    String CreateHighLevelGpuProgramScriptCompilerEvent::eventType = "createHighLevelGpuProgram";
-    //-------------------------------------------------------------------------
     String CreateGpuSharedParametersScriptCompilerEvent::eventType = "createGpuSharedParameters";
     //-------------------------------------------------------------------------
     String CreateParticleSystemScriptCompilerEvent::eventType = "createParticleSystem";

--- a/OgreMain/src/OgreScriptTranslator.cpp
+++ b/OgreMain/src/OgreScriptTranslator.cpp
@@ -3642,13 +3642,9 @@ namespace Ogre{
         GpuProgram *prog = 0;
 
         bool isHighLevel = language != "asm";
-        CreateGpuProgramScriptCompilerEvent evt(obj->file, obj->name, compiler->getResourceGroup(), source, syntax,
-                                                gpt);
-        OGRE_IGNORE_DEPRECATED_BEGIN
-        CreateHighLevelGpuProgramScriptCompilerEvent evtHL(obj->file, obj->name, compiler->getResourceGroup(), source,
-                                                         language, gpt);
-        OGRE_IGNORE_DEPRECATED_END
-        bool processed = compiler->_fireEvent(isHighLevel ? &evt : &evtHL, &prog);
+        CreateGpuProgramScriptCompilerEvent evt(obj->file, obj->name, compiler->getResourceGroup(), source,
+                                                isHighLevel ? language : syntax, gpt);
+        bool processed = compiler->_fireEvent(&evt, &prog);
         if(!processed)
         {
             if(isHighLevel)

--- a/OgreMain/src/OgreUnifiedHighLevelGpuProgram.cpp
+++ b/OgreMain/src/OgreUnifiedHighLevelGpuProgram.cpp
@@ -54,7 +54,7 @@ namespace Ogre
     UnifiedHighLevelGpuProgram::UnifiedHighLevelGpuProgram(
         ResourceManager* creator, const String& name, ResourceHandle handle,
         const String& group, bool isManual, ManualResourceLoader* loader)
-        :HighLevelGpuProgram(creator, name, handle, group, isManual, loader)
+        :GpuProgram(creator, name, handle, group, isManual, loader)
     {
         if (createParamDictionary("UnifiedHighLevelGpuProgram"))
         {
@@ -147,7 +147,7 @@ namespace Ogre
     {
         size_t memSize = 0;
 
-        memSize += HighLevelGpuProgram::calculateSize();
+        memSize += GpuProgram::calculateSize();
 
         // Delegate Names
         for (StringVector::const_iterator i = mDelegateNames.begin(); i != mDelegateNames.end(); ++i)
@@ -253,7 +253,7 @@ namespace Ogre
         if (_getDelegate())
             return _getDelegate()->getPassSurfaceAndLightStates();
         else
-            return HighLevelGpuProgram::getPassSurfaceAndLightStates();
+            return GpuProgram::getPassSurfaceAndLightStates();
     }
     //---------------------------------------------------------------------
     bool UnifiedHighLevelGpuProgram::getPassFogStates(void) const
@@ -261,7 +261,7 @@ namespace Ogre
         if (_getDelegate())
             return _getDelegate()->getPassFogStates();
         else
-            return HighLevelGpuProgram::getPassFogStates();
+            return GpuProgram::getPassFogStates();
     }
     //---------------------------------------------------------------------
     bool UnifiedHighLevelGpuProgram::getPassTransformStates(void) const
@@ -269,7 +269,7 @@ namespace Ogre
         if (_getDelegate())
             return _getDelegate()->getPassTransformStates();
         else
-            return HighLevelGpuProgram::getPassTransformStates();
+            return GpuProgram::getPassTransformStates();
 
     }
     //-----------------------------------------------------------------------


### PR DESCRIPTION
and derive UnifiedHighLevelGpuProgram and NullProgram from GpuProgramPtr

fixes #1368 

we cannot unify any further as:
- HighLevelProgramManager has its own resource namespace right now, merging with low level would cause conflicts in user code
- The factory classes do not consider syntax, which requires special hacks