### PR TITLE
Switched ClearState and Flush

### DIFF
--- a/RenderSystems/Direct3D11/src/OgreD3D11Device.cpp
+++ b/RenderSystems/Direct3D11/src/OgreD3D11Device.cpp
@@ -48,8 +48,8 @@ namespace Ogre
         // Clear state
         if (mImmediateContext)
         {
-            mImmediateContext->Flush();
             mImmediateContext->ClearState();
+            mImmediateContext->Flush();
         }
 #if OGRE_D3D11_PROFILING
         mPerf.Reset();


### PR DESCRIPTION
The Microsoft documentation recommends that Flush should be called after ClearState.

https://docs.microsoft.com/en-us/windows/win32/api/d3d11/nf-d3d11-id3d11devicecontext-flush