### PR TITLE
XMLConverter: validate bone ids and use logError for colored output

### DIFF
--- a/Tools/XMLConverter/src/OgreXMLSkeletonSerializer.cpp
+++ b/Tools/XMLConverter/src/OgreXMLSkeletonSerializer.cpp
@@ -114,12 +114,18 @@ namespace Ogre {
         
         Quaternion quat ;
 
+        int max_id = -1;
+
         for (pugi::xml_node& bonElem : mBonesNode.children())
         {
             String name = bonElem.attribute("name").value();
             int id = StringConverter::parseInt(bonElem.attribute("id").value());
             skel->createBone(name,id) ;
+
+            max_id = std::max(id, max_id);
         }
+
+        OgreAssert(size_t(max_id + 1) == skel->getBones().size(), "Bone ids must be consecutive in range [0; N)");
     }
     // ---------------------------------------------------------
     // set positions and orientations.

--- a/Tools/XMLConverter/src/main.cpp
+++ b/Tools/XMLConverter/src/main.cpp
@@ -592,8 +592,7 @@ int main(int numargs, char** args)
     }
     catch(Exception& e)
     {
-        cerr << "FATAL ERROR: " << e.getDescription() << std::endl;
-        cerr << "ABORTING!" << std::endl;
+        LogManager::getSingleton().logError(e.getDescription());
         retCode = 1;
     }
 


### PR DESCRIPTION
fixes #11 