### PR TITLE
RTSS - add hardware instancing support

### DIFF
--- a/Components/RTShaderSystem/include/OgreShaderFFPTransform.h
+++ b/Components/RTShaderSystem/include/OgreShaderFFPTransform.h
@@ -30,6 +30,7 @@ THE SOFTWARE.
 #include "OgreShaderPrerequisites.h"
 #ifdef RTSHADER_SYSTEM_BUILD_CORE_SHADERS
 #include "OgreShaderSubRenderState.h"
+#include "OgreShaderParameter.h"
 
 namespace Ogre {
 namespace RTShader {
@@ -73,9 +74,18 @@ public:
 
     bool preAddToRenderState(const RenderState* renderState, Pass* srcPass, Pass* dstPass);
 
+    void setInstancingParams(bool enabled, int texCoordIndex)
+    {
+        mInstanced = enabled;
+        mTexCoordIndex = Parameter::Content(Parameter::SPC_TEXTURE_COORDINATE0 + texCoordIndex);
+    }
+
     static String Type;
 protected:
+    Parameter::Content mTexCoordIndex = Parameter::SPC_TEXTURE_COORDINATE0;
     bool mSetPointSize;
+    bool mInstanced = false;
+    bool mDoLightCalculations;
 };
 
 

--- a/Components/RTShaderSystem/include/OgreShaderParameter.h
+++ b/Components/RTShaderSystem/include/OgreShaderParameter.h
@@ -678,7 +678,9 @@ public:
 
     static ParameterPtr createInTexcoord(GpuConstantType type, int index, Parameter::Content content);
     static ParameterPtr createOutTexcoord(GpuConstantType type, int index, Parameter::Content content);
+    /// @deprecated use createInTexcoord
     static ParameterPtr createInTexcoord1(int index, Parameter::Content content);
+    /// @deprecated use createOutTexcoord
     static ParameterPtr createOutTexcoord1(int index, Parameter::Content content);
     static ParameterPtr createInTexcoord2(int index, Parameter::Content content);
     static ParameterPtr createOutTexcoord2(int index, Parameter::Content content);

--- a/Components/RTShaderSystem/src/OgreShaderGLSLProgramWriter.cpp
+++ b/Components/RTShaderSystem/src/OgreShaderGLSLProgramWriter.cpp
@@ -326,15 +326,16 @@ void GLSLProgramWriter::writeInputParameters(std::ostream& os, Function* functio
                 os << "attribute\t";
             }
 
-            // all uv texcoords passed by ogre are vec4
-            if (paramContent == Parameter::SPC_TEXTURE_COORDINATE0 ||
-                paramContent == Parameter::SPC_TEXTURE_COORDINATE1 ||
-                paramContent == Parameter::SPC_TEXTURE_COORDINATE2 ||
-                paramContent == Parameter::SPC_TEXTURE_COORDINATE3 ||
-                paramContent == Parameter::SPC_TEXTURE_COORDINATE4 ||
-                paramContent == Parameter::SPC_TEXTURE_COORDINATE5 ||
-                paramContent == Parameter::SPC_TEXTURE_COORDINATE6 ||
-                paramContent == Parameter::SPC_TEXTURE_COORDINATE7 )
+            // all uv texcoords passed by ogre are at least vec4
+            if ((paramContent == Parameter::SPC_TEXTURE_COORDINATE0 ||
+                 paramContent == Parameter::SPC_TEXTURE_COORDINATE1 ||
+                 paramContent == Parameter::SPC_TEXTURE_COORDINATE2 ||
+                 paramContent == Parameter::SPC_TEXTURE_COORDINATE3 ||
+                 paramContent == Parameter::SPC_TEXTURE_COORDINATE4 ||
+                 paramContent == Parameter::SPC_TEXTURE_COORDINATE5 ||
+                 paramContent == Parameter::SPC_TEXTURE_COORDINATE6 ||
+                 paramContent == Parameter::SPC_TEXTURE_COORDINATE7) &&
+                (pParam->getType() < GCT_FLOAT4))
             {
                 os << "vec4";
             }

--- a/Components/RTShaderSystem/src/OgreShaderParameter.cpp
+++ b/Components/RTShaderSystem/src/OgreShaderParameter.cpp
@@ -487,24 +487,9 @@ ParameterPtr ParameterFactory::createInTexcoord(GpuConstantType type, int index,
     switch (type)
     {
     case GCT_FLOAT1:
-        return createInTexcoord1(index, content);
-        
     case GCT_FLOAT2:
-        return createInTexcoord2(index, content);
-        
     case GCT_FLOAT3:
-        return createInTexcoord3(index, content);
-        
     case GCT_FLOAT4:
-        return createInTexcoord4(index, content);       
-    default:
-    case GCT_SAMPLER1D:
-    case GCT_SAMPLER2D:
-    case GCT_SAMPLER2DARRAY:
-    case GCT_SAMPLER3D:
-    case GCT_SAMPLERCUBE:
-    case GCT_SAMPLER1DSHADOW:
-    case GCT_SAMPLER2DSHADOW:
     case GCT_MATRIX_2X2:
     case GCT_MATRIX_2X3:
     case GCT_MATRIX_2X4:
@@ -522,6 +507,16 @@ ParameterPtr ParameterFactory::createInTexcoord(GpuConstantType type, int index,
     case GCT_UINT2:
     case GCT_UINT3:
     case GCT_UINT4:
+        return std::make_shared<Parameter>(type, StringUtil::format("iTexcoord_%d", index),
+                                           Parameter::SPS_TEXTURE_COORDINATES, index, content);
+    default:
+    case GCT_SAMPLER1D:
+    case GCT_SAMPLER2D:
+    case GCT_SAMPLER2DARRAY:
+    case GCT_SAMPLER3D:
+    case GCT_SAMPLERCUBE:
+    case GCT_SAMPLER1DSHADOW:
+    case GCT_SAMPLER2DSHADOW:
     case GCT_UNKNOWN:
         break;
     }
@@ -535,17 +530,11 @@ ParameterPtr ParameterFactory::createOutTexcoord(GpuConstantType type, int index
     switch (type)
     {
     case GCT_FLOAT1:
-        return createOutTexcoord1(index, content);
-
     case GCT_FLOAT2:
-        return createOutTexcoord2(index, content);
-
     case GCT_FLOAT3:
-        return createOutTexcoord3(index, content);
-
     case GCT_FLOAT4:
-        return createOutTexcoord4(index, content);      
-    
+        return std::make_shared<Parameter>(type, StringUtil::format("oTexcoord_%d", index),
+                                           Parameter::SPS_TEXTURE_COORDINATES, index, content);
     default:
     case GCT_SAMPLER1D:
     case GCT_SAMPLER2D:

--- a/Docs/src/rtss.md
+++ b/Docs/src/rtss.md
@@ -17,6 +17,7 @@ To modify the default lighting stage [see below](@ref rtss_custom_api). For more
 
 Here are the attributes you can use in a `rtshader_system` block of a .material script:
 
+- [transform_stage](#transform_stage)
 - [lighting_stage](#lighting_stage)
 - [fog_stage](#fog_stage)
 - [light_count](#light_count)
@@ -25,6 +26,21 @@ Here are the attributes you can use in a `rtshader_system` block of a .material 
 - [hardware_skinning](#hardware_skinning)
 - [layered_blend](#layered_blend)
 - [source_modifier](#source_modifier)
+
+<a name="transform_stage"></a>
+
+## transform_stage
+
+Force a specific transform calculation
+@par
+Format: `transform_stage <type> [attrIndex]`
+@par
+Example: `transform_stage instanced 1`
+
+@param type either `ffp` or `instanced`
+@param coordinateIndex the start texcoord attribute index to read the instanced world matrix from
+
+@note `instanced` is supposed to be used with Ogre::InstanceManager::HWInstancingBasic
 
 <a name="lighting_stage"></a>
 

--- a/RenderSystems/Direct3D11/src/OgreD3D11VertexDeclaration.cpp
+++ b/RenderSystems/Direct3D11/src/OgreD3D11VertexDeclaration.cpp
@@ -96,8 +96,9 @@ namespace Ogre {
                 if (!found)
                 {
                     OGRE_EXCEPT(Exception::ERR_RENDERINGAPI_ERROR,
-                                StringUtil::format("No VertexElement for semantic %s in shader %s found",
-                                                   inputDesc.SemanticName, boundVertexProgram->getName().c_str()));
+                                StringUtil::format("No VertexElement for semantic %s%d in shader %s found",
+                                                   inputDesc.SemanticName, inputDesc.SemanticIndex,
+                                                   boundVertexProgram->getName().c_str()));
                 }
 
                 D3D11_INPUT_ELEMENT_DESC elem = {};

--- a/RenderSystems/GL/src/GLSL/src/OgreGLSLLinkProgram.cpp
+++ b/RenderSystems/GL/src/GLSL/src/OgreGLSLLinkProgram.cpp
@@ -180,6 +180,14 @@ namespace Ogre {
             if (attrib != -1)
             {
                 mValidAttributes.insert(a.attrib);
+
+                if(a.semantic != VES_TEXTURE_COORDINATES) continue;
+
+                // also enable next 4 attributes to allow matrix types in texcoord semantic
+                // might cause problems with mixing builtin and custom names,
+                // but then again you should not
+                for(int j = 0; j < 4; j++)
+                    mValidAttributes.insert(msCustomAttributes[i + j].attrib);
             }
         }
     }

--- a/Samples/Media/materials/programs/GLSL120/HWBasicInstancing.vert
+++ b/Samples/Media/materials/programs/GLSL120/HWBasicInstancing.vert
@@ -6,57 +6,19 @@
 
 //Vertex input
 attribute vec4 vertex;
-attribute vec3 normal;
-attribute vec4 uv0;
-attribute vec4 uv1;
-attribute vec4 uv2;
-attribute vec4 uv3;
-attribute vec3 tangent;
+attribute mat3x4 uv1;
 
 //Parameters
 uniform mat4 viewProjMatrix;
-
-#if (DEPTH_SHADOWCASTER || DEPTH_SHADOWRECEIVER)
-uniform vec4 depthRange;
-#endif
-
-#if DEPTH_SHADOWRECEIVER
-uniform mat4 texViewProjMatrix;
-#endif
-
-//Output
-#if DEPTH_SHADOWCASTER
-	varying vec2 depth;
-#else
-	varying vec2 _uv0;
-	varying vec3 oNormal;
-	varying vec3 oVPos;
-	#if DEPTH_SHADOWRECEIVER
-		varying vec4 oLightSpacePos;
-	#endif
-#endif
 
 //---------------------------------------------
 //Main Vertex Shader
 //---------------------------------------------
 void main(void)
 {
-	mat3x4 worldMatrix = mat3x4(uv1, uv2, uv3);
+	mat3x4 worldMatrix = uv1;
 	vec4 worldPos		= vec4(vertex * worldMatrix, 1);
-	vec3 worldNorm		= normal * mat3(worldMatrix);
 
 	//Transform the position
 	gl_Position			= viewProjMatrix * worldPos;
-	
-#if DEPTH_SHADOWCASTER
-	depth				= gl_Position.zw;
-#else
-	_uv0		= uv0.xy;
-	oNormal		= worldNorm;
-	oVPos		= worldPos.xyz;
-
-	#if DEPTH_SHADOWRECEIVER
-		oLightSpacePos		= texViewProjMatrix * worldPos;
-	#endif
-#endif
 }

--- a/Samples/Media/materials/programs/GLSLES/HWBasicInstancing.vert
+++ b/Samples/Media/materials/programs/GLSLES/HWBasicInstancing.vert
@@ -8,64 +8,19 @@ precision mediump float;
 
 //Vertex input
 in vec4 vertex;
-in vec3 normal;
-in vec4 uv0;
-in vec4 uv1;
-in vec4 uv2;
-in vec4 uv3;
-in vec3 tangent;
+in mat3x4 uv1;
 
 //Parameters
 uniform mat4 viewProjMatrix;
-
-#if (DEPTH_SHADOWCASTER || DEPTH_SHADOWRECEIVER)
-uniform vec4 depthRange;
-#endif
-
-#if DEPTH_SHADOWRECEIVER
-uniform mat4 texViewProjMatrix;
-#endif
-
-//Output
-#if DEPTH_SHADOWCASTER
-	out vec2 depth;
-#else
-	out vec2 _uv0;
-	out vec3 oNormal;
-	out vec3 oVPos;
-	#if DEPTH_SHADOWRECEIVER
-		out vec4 oLightSpacePos;
-	#endif
-#endif
 
 //---------------------------------------------
 //Main Vertex Shader
 //---------------------------------------------
 void main(void)
 {
-	mat4 worldMatrix;
-	worldMatrix[0] = uv1;
-	worldMatrix[1] = uv2;
-	worldMatrix[2] = uv3;
-	worldMatrix[3] = vec4( 0, 0, 0, 1 );
-
-	vec4 worldPos		= vertex * worldMatrix;
-	vec3 worldNorm		= normal * mat3(worldMatrix);
+	mat3x4 worldMatrix = uv1;
+	vec3 worldPos		= vertex * worldMatrix;
 
 	//Transform the position
-	gl_Position			= viewProjMatrix * worldPos;
-	
-#if DEPTH_SHADOWCASTER
-	depth.x				= (gl_Position.z - depthRange.x) * depthRange.w;
-	depth.y				= depthRange.w;
-#else
-	_uv0		= uv0.xy;
-	oNormal		= worldNorm;
-	oVPos		= worldPos.xyz;
-
-	#if DEPTH_SHADOWRECEIVER
-		oLightSpacePos		= texViewProjMatrix * worldPos;
-		oLightSpacePos.z	= (oLightSpacePos.z - depthRange.x) * depthRange.w;
-	#endif
-#endif
+	gl_Position			= viewProjMatrix * vec4(worldPos, 1);
 }

--- a/Samples/Media/materials/programs/HLSL_Cg/HWBasicInstancing.cg
+++ b/Samples/Media/materials/programs/HLSL_Cg/HWBasicInstancing.cg
@@ -9,12 +9,7 @@
 struct VS_INPUT
 {
 	float4 Position	:	POSITION;
-	float3 Normal	:	NORMAL;
-	float2 uv0		:	TEXCOORD0;
-
-	float4 mat14	:	TEXCOORD1;
-	float4 mat24	:	TEXCOORD2;
-	float4 mat34	:	TEXCOORD3;
+	float3x4 mat	:	TEXCOORD1;
 };
 
 #include "InstancingVertexInterpolators.cg"
@@ -24,45 +19,18 @@ struct VS_INPUT
 //---------------------------------------------
 VS_OUTPUT main_vs( in VS_INPUT input,
 				   uniform float4x4 viewProjMatrix
-
-#if defined( DEPTH_SHADOWCASTER ) || defined( DEPTH_SHADOWRECEIVER )
-				,  uniform float4 depthRange
-#endif
-#ifdef DEPTH_SHADOWRECEIVER
-				,  uniform float4x4 texViewProjMatrix
-#endif
 				)
 {
 	VS_OUTPUT output;
 
-	float3x4 worldMatrix;
-	worldMatrix[0] = input.mat14;
-	worldMatrix[1] = input.mat24;
-	worldMatrix[2] = input.mat34;
+	float3x4 worldMatrix = input.mat;
 
 	float4 worldPos = float4( mul( worldMatrix, input.Position ).xyz, 1.0f );
-	float3 worldNorm= mul( (float3x3)(worldMatrix), input.Normal );
-
 	//Transform the position
 	output.Position		= mul( viewProjMatrix, worldPos );
 
-#ifdef DEPTH_SHADOWCASTER
-	output.ps.unused	= float3( 0, 0, 0 );
-	output.ps.depth		= (output.Position.z - depthRange.x + SHADOW_BIAS) * depthRange.w;
-#else
-	output.ps.uv0		= input.uv0;
-
-	//Pass Normal and position for Blinn Phong lighting
-	output.ps.Normal	= normalize(worldNorm);
-	output.ps.vPos		= worldPos.xyz;
-	
-	#ifdef DEPTH_SHADOWRECEIVER
-		// Calculate the position of vertex in light space to do shadows
-		output.ps.lightSpacePos = mul( texViewProjMatrix, worldPos );
-		// make linear
-		output.ps.lightSpacePos.z = (output.ps.lightSpacePos.z - depthRange.x) * depthRange.w;
-	#endif
-#endif
+	output.ps.unused	= float3( output.Position.zw, 0 );
+	output.ps.depth		= output.Position.z;
 
 	return output;
 }

--- a/Samples/Media/materials/scripts/HWInstancing.material
+++ b/Samples/Media/materials/scripts/HWInstancing.material
@@ -6,13 +6,6 @@
 //--------------------------------------------------------------
 // GLSL Programs
 //--------------------------------------------------------------
-vertex_program Ogre/Instancing/HWBasic_glsl_vs glsl
-{
-	source HWBasicInstancing.vert
-
-	preprocessor_defines DEPTH_SHADOWRECEIVER=1
-}
-
 vertex_program Ogre/Instancing/HWBasic/shadow_caster_glsl_vs glsl
 {
 	source HWBasicInstancing.vert
@@ -23,15 +16,6 @@ vertex_program Ogre/Instancing/HWBasic/shadow_caster_glsl_vs glsl
 //--------------------------------------------------------------
 // hlsl Programs
 //--------------------------------------------------------------
-vertex_program Ogre/Instancing/HWBasic_hlsl_vs hlsl
-{
-	source HWBasicInstancing.cg
-	entry_point main_vs
-	target vs_3_0
-	
-	preprocessor_defines DEPTH_SHADOWRECEIVER
-}
-
 vertex_program Ogre/Instancing/HWBasic/shadow_caster_hlsl_vs hlsl
 {
 	source HWBasicInstancing.cg
@@ -39,18 +23,12 @@ vertex_program Ogre/Instancing/HWBasic/shadow_caster_hlsl_vs hlsl
 	target vs_3_0
 	
 	preprocessor_defines DEPTH_SHADOWCASTER
+	column_major_matrices false
 }
 
 //--------------------------------------------------------------
 // GLSL ES Programs
 //--------------------------------------------------------------
-vertex_program Ogre/Instancing/HWBasic_glsles_vs glsles
-{
-	source HWBasicInstancing.vert
-
-	preprocessor_defines DEPTH_SHADOWRECEIVER=1
-}
-
 vertex_program Ogre/Instancing/HWBasic/shadow_caster_glsles_vs glsles
 {
 	source HWBasicInstancing.vert
@@ -61,15 +39,6 @@ vertex_program Ogre/Instancing/HWBasic/shadow_caster_glsles_vs glsles
 //--------------------------------------------------------------
 // CG Programs
 //--------------------------------------------------------------
-vertex_program Ogre/Instancing/HWBasic_cg_vs cg
-{
-	source HWBasicInstancing.cg
-	entry_point main_vs
-	profiles  vs_3_0 vp40
-	
-	compile_arguments -DDEPTH_SHADOWRECEIVER
-}
-
 vertex_program Ogre/Instancing/HWBasic/shadow_caster_cg_vs cg
 {
 	source HWBasicInstancing.cg
@@ -82,22 +51,6 @@ vertex_program Ogre/Instancing/HWBasic/shadow_caster_cg_vs cg
 //--------------------------------------------------------------
 // Unified CG/GLSL Programs
 //--------------------------------------------------------------
-vertex_program Ogre/Instancing/HWBasic_vs unified
-{
-	delegate Ogre/Instancing/HWBasic_glsl_vs
-	delegate Ogre/Instancing/HWBasic_glsles_vs
-	delegate Ogre/Instancing/HWBasic_hlsl_vs
-	delegate Ogre/Instancing/HWBasic_cg_vs
-
-	default_params
-	{
-		param_named_auto	viewProjMatrix				viewproj_matrix
-
-		param_named_auto	depthRange					shadow_scene_depth_range 0
-		param_named_auto	texViewProjMatrix			texture_viewproj_matrix 0
-	}
-}
-
 vertex_program Ogre/Instancing/HWBasic/shadow_caster_vs unified
 {
 	delegate Ogre/Instancing/HWBasic/shadow_caster_glsl_vs
@@ -108,7 +61,6 @@ vertex_program Ogre/Instancing/HWBasic/shadow_caster_vs unified
 	default_params
 	{
 		param_named_auto	viewProjMatrix				viewproj_matrix
-		param_named_auto	depthRange					scene_depth_range
 	}
 }
 
@@ -128,7 +80,30 @@ material Examples/Instancing/HWBasic/shadow_caster
 	}
 }
 
-abstract material Examples/Instancing/HWBasic
+material Examples/Instancing/HWBasic/Robot
+{
+	technique
+	{
+		shadow_caster_material Examples/Instancing/HWBasic/shadow_caster
+
+		pass
+		{
+			specular	1 1 1 1 12.5
+
+			texture_unit Diffuse
+			{
+				texture		r2skin.jpg
+			}
+
+			rtshader_system
+            {
+				transform_stage instanced
+			}
+		}
+	}
+}
+
+material Examples/Instancing/HWBasic/spine
 {
 	technique
 	{
@@ -138,36 +113,17 @@ abstract material Examples/Instancing/HWBasic
 		{
 			diffuse		0.3 0.3 0.3
 			specular	0.1 0.1 0.1 0.1 12.5
-			vertex_program_ref Ogre/Instancing/HWBasic_vs
-			{
-			}
-
-			fragment_program_ref Ogre/Instancing_ps
-			{
-			}
 
 			texture_unit Diffuse
 			{
-				texture		$DiffuseMap
+				texture		circuit.dds
 				tex_address_mode	clamp
 			}
 
-			texture_unit shadow0
-			{
-				content_type shadow
-				tex_address_mode border
-				tex_border_colour 1 1 1 1
+			rtshader_system
+            {
+				transform_stage instanced
 			}
 		}
 	}
-}
-
-material Examples/Instancing/HWBasic/Robot : Examples/Instancing/HWBasic
-{
-	set	$DiffuseMap	r2skin.jpg
-}
-
-material Examples/Instancing/HWBasic/spine : Examples/Instancing/HWBasic
-{
-	set	$DiffuseMap	circuit.dds
 }


### PR DESCRIPTION
- [x] ~inspect renderable for correct uv attribute slot~ (let user manually specify)
- [ ] ~auto handle shadow programs like hardware skinning~ (postponed)
- [x] forward the right normal & viewpos to lighting
   - custom instancing shaders are broken (fix them first?)

fixes #1024