### PR TITLE
Void Pointer and casting of MovableObject

### DIFF
--- a/OgreMain/include/Ogre.i
+++ b/OgreMain/include/Ogre.i
@@ -87,6 +87,18 @@ JNIEnv* OgreJNIGetEnv() {
 }
 #endif
 
+#ifdef SWIGCSHARP
+  %apply void *VOID_INT_PTR {void *}
+
+  %typemap(csvarout) void * %{
+    get {
+	  global::System.IntPtr cPtr = $imcall;
+	  if (OgrePINVOKE.SWIGPendingException.Pending) throw OgrePINVOKE.SWIGPendingException.Retrieve();
+	  return cPtr;
+	}
+  %}
+#endif
+
 // convert c++ exceptions to language native exceptions
 %exception {
     try {
@@ -497,7 +509,7 @@ SHARED_PTR(Material);
 %include "OgreMaterialManager.h"
 %include "OgreRenderable.h"
 %include "OgreShadowCaster.h"
-//#ifdef SWIGCSHARP
+#ifdef SWIGCSHARP
 %typemap(cscode) Ogre::MovableObject %{
   public bool tryCastEntity(out Entity entity)
   {
@@ -505,14 +517,14 @@ SHARED_PTR(Material);
   	if (this.getMovableType() != "Entity")
 	  return false;
 
-    global::System.IntPtr cPtr = OgrePINVOKE.SWIG_CastMovableObjectToEntity(MovableObject.getCPtr(this));
+    global::System.IntPtr cPtr = OgrePINVOKE.SWIG_CastMovableObjectToEntity(MovableObject.getCPtr(this).Handle);
     entity = (cPtr == global::System.IntPtr.Zero) ? null : new Entity(cPtr, false);
     if (OgrePINVOKE.SWIGPendingException.Pending) throw OgrePINVOKE.SWIGPendingException.Retrieve();
 
 	return entity != null;
   }
 %}
-//#endif
+#endif
 %include "OgreMovableObject.h"
     %include "OgreBillboardChain.h"
         %include "OgreRibbonTrail.h"

--- a/OgreMain/include/Ogre.i
+++ b/OgreMain/include/Ogre.i
@@ -514,12 +514,9 @@ SHARED_PTR(Material);
   public bool tryCastEntity(out Entity entity)
   {
 	entity = null;
-  	if (this.getMovableType() != "Entity")
-	  return false;
 
     global::System.IntPtr cPtr = OgrePINVOKE.SWIG_CastMovableObjectToEntity(MovableObject.getCPtr(this).Handle);
     entity = (cPtr == global::System.IntPtr.Zero) ? null : new Entity(cPtr, false);
-    if (OgrePINVOKE.SWIGPendingException.Pending) throw OgrePINVOKE.SWIGPendingException.Retrieve();
 
 	return entity != null;
   }
@@ -583,17 +580,9 @@ SHARED_PTR(Material);
           Ogre::Entity *result = 0 ;
 
           arg1 = (Ogre::MovableObject *)jarg1;
-          {
-            try {
-              result = (Ogre::Entity *)arg1;
-            }
 
-            catch (const std::exception& e) {
-              {
-                SWIG_CSharpException(SWIG_RuntimeError, e.what()); return 0;
-              };
-            }
-          }
+          result = dynamic_cast<Ogre::Entity *>(arg1);
+
           jresult = (void *)result;
           return jresult;
 		}

--- a/OgreMain/include/Ogre.i
+++ b/OgreMain/include/Ogre.i
@@ -512,7 +512,7 @@ SHARED_PTR(Material);
 %extend Ogre::MovableObject {
   Entity* castEntity()
   {
-    return dynamic_cast<Entity*>(this);	
+    return dynamic_cast<Ogre::Entity*>($self);
   }
 }
 %include "OgreMovableObject.h"

--- a/OgreMain/include/Ogre.i
+++ b/OgreMain/include/Ogre.i
@@ -509,12 +509,12 @@ SHARED_PTR(Material);
 %include "OgreMaterialManager.h"
 %include "OgreRenderable.h"
 %include "OgreShadowCaster.h"
-%extend Ogre::MovableObject %{
+%extend Ogre::MovableObject {
   Entity* castEntity()
   {
     return dynamic_cast<Entity*>(this);	
   }
-%}
+}
 %include "OgreMovableObject.h"
     %include "OgreBillboardChain.h"
         %include "OgreRibbonTrail.h"

--- a/OgreMain/include/Ogre.i
+++ b/OgreMain/include/Ogre.i
@@ -509,19 +509,12 @@ SHARED_PTR(Material);
 %include "OgreMaterialManager.h"
 %include "OgreRenderable.h"
 %include "OgreShadowCaster.h"
-#ifdef SWIGCSHARP
-%typemap(cscode) Ogre::MovableObject %{
-  public bool tryCastEntity(out Entity entity)
+%extend Ogre::MovableObject %{
+  Entity* castEntity()
   {
-	entity = null;
-
-    global::System.IntPtr cPtr = OgrePINVOKE.SWIG_CastMovableObjectToEntity(MovableObject.getCPtr(this).Handle);
-    entity = (cPtr == global::System.IntPtr.Zero) ? null : new Entity(cPtr, false);
-
-	return entity != null;
+    return dynamic_cast<Entity*>(this);	
   }
 %}
-#endif
 %include "OgreMovableObject.h"
     %include "OgreBillboardChain.h"
         %include "OgreRibbonTrail.h"
@@ -572,21 +565,6 @@ SHARED_PTR(Material);
     %template(SubEntityList) std::vector<Ogre::SubEntity*>;
     %ignore Ogre::Entity::getAttachedObjectIterator;
     %include "OgreEntity.h"
-	%inline %{
-		static void* SWIG_CastMovableObjectToEntity(void * jarg1)
-		{
-          void * jresult ;
-          Ogre::MovableObject *arg1 = (Ogre::MovableObject *) 0 ;
-          Ogre::Entity *result = 0 ;
-
-          arg1 = (Ogre::MovableObject *)jarg1;
-
-          result = dynamic_cast<Ogre::Entity *>(arg1);
-
-          jresult = (void *)result;
-          return jresult;
-		}
-	%}
     %include "OgreSubEntity.h"
     SHARED_PTR(ParticleSystem);
     %include "OgreParticleSystem.h"

--- a/OgreMain/include/Ogre.i
+++ b/OgreMain/include/Ogre.i
@@ -497,6 +497,22 @@ SHARED_PTR(Material);
 %include "OgreMaterialManager.h"
 %include "OgreRenderable.h"
 %include "OgreShadowCaster.h"
+//#ifdef SWIGCSHARP
+%typemap(cscode) Ogre::MovableObject %{
+  public bool tryCastEntity(out Entity entity)
+  {
+	entity = null;
+  	if (this.getMovableType() != "Entity")
+	  return false;
+
+    global::System.IntPtr cPtr = OgrePINVOKE.SWIG_CastMovableObjectToEntity(MovableObject.getCPtr(this));
+    entity = (cPtr == global::System.IntPtr.Zero) ? null : new Entity(cPtr, false);
+    if (OgrePINVOKE.SWIGPendingException.Pending) throw OgrePINVOKE.SWIGPendingException.Retrieve();
+
+	return entity != null;
+  }
+%}
+//#endif
 %include "OgreMovableObject.h"
     %include "OgreBillboardChain.h"
         %include "OgreRibbonTrail.h"
@@ -547,6 +563,29 @@ SHARED_PTR(Material);
     %template(SubEntityList) std::vector<Ogre::SubEntity*>;
     %ignore Ogre::Entity::getAttachedObjectIterator;
     %include "OgreEntity.h"
+	%inline %{
+		static void* SWIG_CastMovableObjectToEntity(void * jarg1)
+		{
+          void * jresult ;
+          Ogre::MovableObject *arg1 = (Ogre::MovableObject *) 0 ;
+          Ogre::Entity *result = 0 ;
+
+          arg1 = (Ogre::MovableObject *)jarg1;
+          {
+            try {
+              result = (Ogre::Entity *)arg1;
+            }
+
+            catch (const std::exception& e) {
+              {
+                SWIG_CSharpException(SWIG_RuntimeError, e.what()); return 0;
+              };
+            }
+          }
+          jresult = (void *)result;
+          return jresult;
+		}
+	%}
     %include "OgreSubEntity.h"
     SHARED_PTR(ParticleSystem);
     %include "OgreParticleSystem.h"


### PR DESCRIPTION
The changes are for the C# wrapper.
They allow the use of System.IntPtr instead of void* marshalling of Swig and it is possible to create Vertex Buffers with Code like that:
```
var vertexBuffer = HardwareBufferManager.getSingleton().createVertexBuffer(offset, vertexCount, HardwareBuffer.Usage.HBU_STATIC_WRITE_ONLY);
vertexBuffer.writeData(0, vertexBuffer.getSizeInBytes(), new IntPtr(verticesPtr), true);
```
The second change makes the implementation of this tutorial possible, there I needed to cast MovableObject to Entity
http://wiki.ogre3d.org/Raycasting+to+the+polygon+level