### PR TITLE
Fixed possible crash in the addImpl() method of the ResourceManager class

### DIFF
--- a/OgreMain/src/OgreResourceManager.cpp
+++ b/OgreMain/src/OgreResourceManager.cpp
@@ -138,8 +138,8 @@ namespace Ogre {
             }
             else
             {
-                ResourceWithGroupMap::iterator itGroup = mResourcesWithGroup.find(res->getGroup());
-                result = itGroup->second.emplace(res->getName(), res);
+                auto resgroup = mResourcesWithGroup.emplace(res->getGroup(), ResourceMap()).first;
+                result = resgroup->second.emplace(res->getName(), res);
             }
         }
 


### PR DESCRIPTION
The iterator of a map returned by the find() method was used without checking it for validity.
This caused a crash.