### PR TITLE
SWIG: allow building Overlay bindings without imgui

### DIFF
--- a/Components/Overlay/include/OgreOverlay.i
+++ b/Components/Overlay/include/OgreOverlay.i
@@ -20,9 +20,13 @@
 #include "OgrePanelOverlayElement.h"
 #include "OgreTextAreaOverlayElement.h"
 
+%}
+#ifdef HAVE_IMGUI
+%{
 #include "imgui.h"
 #include "OgreImGuiOverlay.h"
 %}
+#endif
 
 %include std_string.i
 %include exception.i 


### PR DESCRIPTION
fixes #1392