### PR TITLE
CMake/Utils/PrecompiledHeader.cmake: Add -c argument to build precompiled headers

### DIFF
--- a/CMake/Utils/PrecompiledHeader.cmake
+++ b/CMake/Utils/PrecompiledHeader.cmake
@@ -133,11 +133,11 @@ MACRO(_PCH_GET_COMPILE_COMMAND out_command _input _output)
             STRING(REGEX REPLACE "^ +" "" pchsupport_compiler_cxx_arg1 ${CMAKE_CXX_COMPILER_ARG1})
 
             SET(${out_command}
-              ${CMAKE_CXX_COMPILER} ${pchsupport_compiler_cxx_arg1} ${_compile_FLAGS} -x c++-header -o ${_output} ${_input}
+              ${CMAKE_CXX_COMPILER} ${pchsupport_compiler_cxx_arg1} ${_compile_FLAGS} -x c++-header -c -o ${_output} ${_input}
               )
         ELSE(CMAKE_CXX_COMPILER_ARG1)
             SET(${out_command}
-              ${CMAKE_CXX_COMPILER}  ${_compile_FLAGS} -x c++-header -o ${_output} ${_input}
+              ${CMAKE_CXX_COMPILER}  ${_compile_FLAGS} -x c++-header -c -o ${_output} ${_input}
               )
         ENDIF(CMAKE_CXX_COMPILER_ARG1)
     ELSE(CMAKE_COMPILER_IS_GNUCXX)
@@ -291,7 +291,7 @@ MACRO(ADD_PRECOMPILED_HEADER _targetName _input)
     set_target_properties(${_targetName}_pch_dephelp PROPERTIES INCLUDE_DIRECTORIES "${DIRINC}")
 
     #MESSAGE("_compile_FLAGS: ${_compile_FLAGS}")
-    #message("COMMAND ${CMAKE_CXX_COMPILER}	${_compile_FLAGS} -x c++-header -o ${_output} ${_input}")
+    #message("COMMAND ${CMAKE_CXX_COMPILER}	${_compile_FLAGS} -x c++-header -c -o ${_output} ${_input}")
 
     ADD_CUSTOM_COMMAND(
       OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${_name}"


### PR DESCRIPTION
Add "-c" argument when building precompiled headers to fix build with
RELRO.

More information on a similar issue with domoticz can be found here:
https://patchwork.ozlabs.org/patch/1187328:

"The problem AFAICS is that if no -c or similar option is given, GCC
decides what needs to be done based on the rest of the arguments. If the
rest of the arguments include a -Wl,... option, it decides that linking
needs to be done. If the rest of the arguments are just header files, it
decides to create a precompiled header."

Fixes:
 - http://autobuild.buildroot.org/results/8fabf8d270b9257c3a9db6a2f17f1c08ec9428d3

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>