### PR TITLE
GL: add ConfigOption to disable FFP

### DIFF
--- a/RenderSystems/GL/include/OgreGLRenderSystem.h
+++ b/RenderSystems/GL/include/OgreGLRenderSystem.h
@@ -127,6 +127,9 @@ namespace Ogre {
         std::vector<GLuint> mRenderAttribsBound;
         std::vector<GLuint> mRenderInstanceAttribsBound;
 
+        /// is fixed pipeline enabled
+        bool mEnableFixedPipeline;
+
 #if OGRE_NO_QUAD_BUFFER_STEREO == 0
 		/// @copydoc RenderSystem::setDrawBuffer
 		virtual bool setDrawBuffer(ColourBufferType colourBuffer);
@@ -158,6 +161,8 @@ namespace Ogre {
         const String& getName(void) const;
 
         void _initialise() override;
+
+        void initConfigOptions() override;
 
         virtual RenderSystemCapabilities* createRenderSystemCapabilities() const;
 

--- a/RenderSystems/GL/src/GLSL/include/OgreGLSLProgram.h
+++ b/RenderSystems/GL/src/GLSL/include/OgreGLSLProgram.h
@@ -50,13 +50,13 @@ namespace Ogre {
         const String& getLanguage(void) const;
 
         bool getPassTransformStates(void) const {
-            return true;
+            return mPassFFPStates;
         }
         bool getPassSurfaceAndLightStates(void) const {
-            return true;
+            return mPassFFPStates;
         }
         bool getPassFogStates(void) const {
-            return true;
+            return mPassFFPStates;
         }
 
         /** Returns the operation type that this geometry program expects to
@@ -119,6 +119,7 @@ namespace Ogre {
         RenderOperation::OperationType mInputOperationType;
         RenderOperation::OperationType mOutputOperationType;
         int mMaxOutputVertices;
+        bool mPassFFPStates;
     };
     }
 }

--- a/RenderSystems/GL/src/GLSL/src/OgreGLSLProgram.cpp
+++ b/RenderSystems/GL/src/GLSL/src/OgreGLSLProgram.cpp
@@ -321,6 +321,7 @@ namespace Ogre {
         }
         // Manually assign language now since we use it immediately
         mSyntaxCode = "glsl";
+        mPassFFPStates = Root::getSingleton().getRenderSystem()->getCapabilities()->hasCapability(RSC_FIXED_FUNCTION);
     }
 
     //-----------------------------------------------------------------------

--- a/Tests/VisualTests/Context/src/TestContext.cpp
+++ b/Tests/VisualTests/Context/src/TestContext.cpp
@@ -506,9 +506,6 @@ bool TestContext::oneTimeConfig()
             rs->setConfigOption("FSAA", "2");
 
             try {
-                rs->setConfigOption("Fixed Pipeline Enabled", "No");
-            } catch(...) {}
-            try {
                 rs->setConfigOption("VSync", "No");
             } catch(...) {}
         }


### PR DESCRIPTION
useful for porting to GL3+ or to improve performance if only shaders are
used

fixes #1467