### PR TITLE
Main: deinline non performance-critical methods to improve compile speed

### DIFF
--- a/OgreMain/include/OgreAnimable.h
+++ b/OgreMain/include/OgreAnimable.h
@@ -246,35 +246,10 @@ namespace Ogre {
         /** Internal method for creating a dictionary of animable value names 
             for the class, if it does not already exist.
         */
-        void createAnimableDictionary(void) const
-        {
-            if (msAnimableDictionary.find(getAnimableDictionaryName()) 
-                == msAnimableDictionary.end())
-            {
-                StringVector vec;
-                initialiseAnimableDictionary(vec);
-                msAnimableDictionary[getAnimableDictionaryName()] = vec;
-            }
-
-        }
+        void createAnimableDictionary(void) const;
     
         /// Get an updateable reference to animable value list
-        StringVector& _getAnimableValueNames(void)
-        {
-            AnimableDictionaryMap::iterator i = 
-                msAnimableDictionary.find(getAnimableDictionaryName());
-            if (i != msAnimableDictionary.end())
-            {
-                return i->second;
-            }
-            else
-            {
-                OGRE_EXCEPT(Exception::ERR_ITEM_NOT_FOUND, 
-                    "Animable value list not found for " + getAnimableDictionaryName(), 
-                    "AnimableObject::getAnimableValueNames");
-            }
-
-        }
+        StringVector& _getAnimableValueNames(void);
 
         /** Internal method for initialising dictionary; should be implemented by 
             subclasses wanting to expose animable parameters.
@@ -287,24 +262,7 @@ namespace Ogre {
         virtual ~AnimableObject() {}
 
         /** Gets a list of animable value names for this object. */
-        const StringVector& getAnimableValueNames(void) const
-        {
-            createAnimableDictionary();
-
-            AnimableDictionaryMap::iterator i = 
-                msAnimableDictionary.find(getAnimableDictionaryName());
-            if (i != msAnimableDictionary.end())
-            {
-                return i->second;
-            }
-            else
-            {
-                OGRE_EXCEPT(Exception::ERR_ITEM_NOT_FOUND, 
-                    "Animable value list not found for " + getAnimableDictionaryName(), 
-                    "AnimableObject::getAnimableValueNames");
-            }
-
-        }
+        const StringVector& getAnimableValueNames(void) const;
 
         /** Create a reference-counted AnimableValuePtr for the named value.
         @remarks

--- a/OgreMain/include/OgreAnimationState.h
+++ b/OgreMain/include/OgreAnimationState.h
@@ -298,10 +298,7 @@ namespace Ogre {
          * @param targetAnimationState
          * @param addTime if true, increment time instead of setting to an absolute position
          */
-        static ControllerValueRealPtr create(AnimationState* targetAnimationState, bool addTime = false)
-        {
-            return std::make_shared<AnimationStateControllerValue>(targetAnimationState, addTime);
-        }
+        static ControllerValueRealPtr create(AnimationState* targetAnimationState, bool addTime = false);
 
         /** ControllerValue implementation. */
         Real getValue(void) const

--- a/OgreMain/include/OgreGpuProgramParams.h
+++ b/OgreMain/include/OgreGpuProgramParams.h
@@ -318,7 +318,8 @@ namespace Ogre {
         /// Map of parameter names to GpuConstantDefinition
         GpuConstantDefinitionMap map;
 
-        GpuNamedConstants() : floatBufferSize(0), doubleBufferSize(0), intBufferSize(0) {}
+        GpuNamedConstants();
+        ~GpuNamedConstants();
 
         /// @deprecated obsolete
         OGRE_DEPRECATED void generateConstantDefinitionArrayEntries(const String& paramName,
@@ -385,7 +386,8 @@ namespace Ogre {
         GpuLogicalIndexUseMap map;
         /// Shortcut to know the buffer size needs
         size_t bufferSize;
-    GpuLogicalBufferStruct() : bufferSize(0) {}
+        GpuLogicalBufferStruct();
+        ~GpuLogicalBufferStruct();
     };
 
     /** Definition of container that holds the current float constants.
@@ -1365,7 +1367,7 @@ namespace Ogre {
 
     public:
         GpuProgramParameters();
-        ~GpuProgramParameters() {}
+        ~GpuProgramParameters();
 
         /// Copy constructor
         GpuProgramParameters(const GpuProgramParameters& oth);

--- a/OgreMain/include/OgreInstanceManager.h
+++ b/OgreMain/include/OgreInstanceManager.h
@@ -279,8 +279,7 @@ namespace Ogre
         /** Returns true if settings were already created for the given material name.
             If false is returned, it means getSetting will return default settings.
         */
-        bool hasSettings( const String &materialName ) const
-        { return mBatchSettings.find( materialName ) != mBatchSettings.end(); }
+        bool hasSettings( const String &materialName ) const;
 
         /** @copydoc InstanceBatch::setStaticAndUpdate */
         void setBatchesAsStaticAndUpdate( bool bStatic );
@@ -306,15 +305,7 @@ namespace Ogre
             setCustomParameter), but there's no synchronization mechanism when
             multithreading or creating more instances, that's up to the user.
         */
-        InstanceBatchIterator getInstanceBatchIterator( const String &materialName ) const
-        {
-            InstanceBatchMap::const_iterator it = mInstanceBatches.find( materialName );
-            if(it != mInstanceBatches.end())
-                return InstanceBatchIterator( it->second.begin(), it->second.end() );
-            else
-                OGRE_EXCEPT(Exception::ERR_INVALID_STATE, "Cannot create instance batch iterator. "
-                            "Material " + materialName + " cannot be found.", "InstanceManager::getInstanceBatchIterator");
-        }
+        InstanceBatchIterator getInstanceBatchIterator( const String &materialName ) const;
     };
 } // namespace Ogre
 

--- a/OgreMain/include/OgreRenderSystemCapabilities.h
+++ b/OgreMain/include/OgreRenderSystemCapabilities.h
@@ -231,28 +231,8 @@ namespace Ogre
             major = minor = release = build = 0;
         }
 
-        String toString() const 
-        {
-            StringStream str;
-            str << major << "." << minor << "." << release << "." << build;
-            return str.str();
-        }
-
-        void fromString(const String& versionString)
-        {
-            StringVector tokens = StringUtil::split(versionString, ".");
-            if(!tokens.empty())
-            {
-                major = StringConverter::parseInt(tokens[0]);
-                if (tokens.size() > 1)
-                    minor = StringConverter::parseInt(tokens[1]);
-                if (tokens.size() > 2)
-                    release = StringConverter::parseInt(tokens[2]);
-                if (tokens.size() > 3)
-                    build = StringConverter::parseInt(tokens[3]);
-            }
-
-        }
+        String toString() const;
+        void fromString(const String& versionString);
     };
 
     /** Enumeration of GPU vendors. */
@@ -550,26 +530,15 @@ namespace Ogre
 
         /** Adds the profile to the list of supported profiles
         */
-        void addShaderProfile(const String& profile)
-        {
-            mSupportedShaderProfiles.insert(profile);
-
-        }
+        void addShaderProfile(const String& profile);
 
         /** Remove a given shader profile, if present.
         */
-        void removeShaderProfile(const String& profile)
-        {
-            mSupportedShaderProfiles.erase(profile);
-        }
+        void removeShaderProfile(const String& profile);
 
         /** Returns true if profile is in the list of supported profiles
         */
-        bool isShaderProfileSupported(const String& profile) const
-        {
-            return (mSupportedShaderProfiles.end() != mSupportedShaderProfiles.find(profile));
-        }
-
+        bool isShaderProfileSupported(const String& profile) const;
 
         /** Returns a set of all supported shader profiles
         * */

--- a/OgreMain/include/OgreRenderable.h
+++ b/OgreMain/include/OgreRenderable.h
@@ -229,47 +229,25 @@ namespace Ogre {
             two is performed by the ACT_CUSTOM entry, if that is used.
         @param value The value to associate.
         */
-        void setCustomParameter(size_t index, const Vector4& value) 
-        {
-            mCustomParameters[index] = value;
-        }
+        void setCustomParameter(size_t index, const Vector4& value);
 
         /** Removes a custom value which is associated with this Renderable at the given index.
         @param index Index of the parameter to remove.
             @see setCustomParameter for full details.
         */
-        void removeCustomParameter(size_t index)
-        {
-            mCustomParameters.erase(index);
-        }
+        void removeCustomParameter(size_t index);
 
         /** Checks whether a custom value is associated with this Renderable at the given index.
         @param index Index of the parameter to check for existence.
             @see setCustomParameter for full details.
         */
-        bool hasCustomParameter(size_t index) const
-        {
-            return mCustomParameters.find(index) != mCustomParameters.end();
-        }
+        bool hasCustomParameter(size_t index) const;
 
         /** Gets the custom value associated with this Renderable at the given index.
         @param index Index of the parameter to retrieve.
             @see setCustomParameter for full details.
         */
-        const Vector4& getCustomParameter(size_t index) const
-        {
-            CustomParameterMap::const_iterator i = mCustomParameters.find(index);
-            if (i != mCustomParameters.end())
-            {
-                return i->second;
-            }
-            else
-            {
-                OGRE_EXCEPT(Exception::ERR_ITEM_NOT_FOUND, 
-                    "Parameter at the given index was not found.",
-                    "Renderable::getCustomParameter");
-            }
-        }
+        const Vector4& getCustomParameter(size_t index) const;
 
         /** Update a custom GpuProgramParameters constant which is derived from 
             information only this Renderable knows.
@@ -295,17 +273,8 @@ namespace Ogre {
         @param params The parameters object which this method should call to 
             set the updated parameters.
         */
-        virtual void _updateCustomGpuParameter(
-            const GpuProgramParameters::AutoConstantEntry& constantEntry,
-            GpuProgramParameters* params) const
-        {
-            CustomParameterMap::const_iterator i = mCustomParameters.find(constantEntry.data);
-            if (i != mCustomParameters.end())
-            {
-                params->_writeRawConstant(constantEntry.physicalIndex, i->second, 
-                    constantEntry.elementCount);
-            }
-        }
+        virtual void _updateCustomGpuParameter(const GpuProgramParameters::AutoConstantEntry& constantEntry,
+                                               GpuProgramParameters* params) const;
 
         /** Sets whether this renderable's chosen detail level can be
             overridden (downgraded) by the camera setting. 

--- a/OgreMain/include/OgreStringInterface.h
+++ b/OgreMain/include/OgreStringInterface.h
@@ -31,7 +31,6 @@ THE SOFTWARE.
 
 #include "OgrePrerequisites.h"
 #include "OgreCommon.h"
-#include "Threading/OgreThreadHeaders.h"
 #include "OgreHeaderPrefix.h"
 
 namespace Ogre {
@@ -96,44 +95,18 @@ namespace Ogre {
         ParamCommandMap mParamCommands;
 
         /** Retrieves the parameter command object for a named parameter. */
-        ParamCommand* getParamCommand(const String& name)
-        {
-            ParamCommandMap::iterator i = mParamCommands.find(name);
-            if (i != mParamCommands.end())
-            {
-                return i->second;
-            }
-            else
-            {
-                return 0;
-            }
-        }
-
-        const ParamCommand* getParamCommand(const String& name) const
-        {
-            ParamCommandMap::const_iterator i = mParamCommands.find(name);
-            if (i != mParamCommands.end())
-            {
-                return i->second;
-            }
-            else
-            {
-                return 0;
-            }
-        }
+        ParamCommand* getParamCommand(const String& name);
+        const ParamCommand* getParamCommand(const String& name) const;
     public:
-        ParamDictionary()  {}
+        ParamDictionary();
+        ~ParamDictionary();
         /** Method for adding a parameter definition for this class. 
         @param paramDef A ParameterDef object defining the parameter
         @param paramCmd Pointer to a ParamCommand subclass to handle the getting / setting of this parameter.
             NB this class will not destroy this on shutdown, please ensure you do
 
         */
-        void addParameter(const ParameterDef& paramDef, ParamCommand* paramCmd)
-        {
-            mParamDefs.push_back(paramDef);
-            mParamCommands[paramDef.name] = paramCmd;
-        }
+        void addParameter(const ParameterDef& paramDef, ParamCommand* paramCmd);
         /** Retrieves a list of parameters valid for this object. 
         @return
             A reference to a static list of ParameterDef objects.
@@ -143,9 +116,6 @@ namespace Ogre {
         {
             return mParamDefs;
         }
-
-
-
     };
     typedef std::map<String, ParamDictionary> ParamDictionaryMap;
     
@@ -161,11 +131,6 @@ namespace Ogre {
     class _OgreExport StringInterface 
     {
     private:
-        OGRE_STATIC_MUTEX( msDictionaryMutex );
-
-        /// Dictionary of parameters
-        static ParamDictionaryMap msDictionary;
-
         /// Class name for this instance to be used as a lookup (must be initialised by subclasses)
         String mParamDictName;
         ParamDictionary* mParamDict;
@@ -181,25 +146,7 @@ namespace Ogre {
         @return
             true if a new dictionary was created, false if it was already there
         */
-        bool createParamDictionary(const String& className)
-        {
-            OGRE_LOCK_MUTEX( msDictionaryMutex );
-
-            ParamDictionaryMap::iterator it = msDictionary.find(className);
-
-            if ( it == msDictionary.end() )
-            {
-                mParamDict = &msDictionary.insert( std::make_pair( className, ParamDictionary() ) ).first->second;
-                mParamDictName = className;
-                return true;
-            }
-            else
-            {
-                mParamDict = &it->second;
-                mParamDictName = className;
-                return false;
-            }
-        }
+        bool createParamDictionary(const String& className);
 
     public:
         StringInterface() : mParamDict(NULL) { }
@@ -267,25 +214,7 @@ namespace Ogre {
         @return
             String value of parameter, blank if not found
         */
-        String getParameter(const String& name) const
-        {
-            // Get dictionary
-            const ParamDictionary* dict = getParamDictionary();
-
-            if (dict)
-            {
-                // Look up command object
-                const ParamCommand* cmd = dict->getParamCommand(name);
-
-                if (cmd)
-                {
-                    return cmd->doGet(this);
-                }
-            }
-
-            // Fallback
-            return "";
-        }
+        String getParameter(const String& name) const;
         /** Method for copying this object's parameters to another object.
         @remarks
             This method takes the values of all the object's parameters and tries to set the
@@ -298,26 +227,7 @@ namespace Ogre {
         @param dest Pointer to object to have it's parameters set the same as this object.
 
         */
-        void copyParametersTo(StringInterface* dest) const
-        {
-            // Get dictionary
-            const ParamDictionary* dict = getParamDictionary();
-
-            if (dict)
-            {
-                // Iterate through own parameters
-                ParameterList::const_iterator i;
-            
-                for (i = dict->mParamDefs.begin(); 
-                i != dict->mParamDefs.end(); ++i)
-                {
-                    dest->setParameter(i->name, getParameter(i->name));
-                }
-            }
-
-
-        }
-
+        void copyParametersTo(StringInterface* dest) const;
         /** Cleans up the static 'msDictionary' required to reset Ogre,
         otherwise the containers are left with invalid pointers, which will lead to a crash
         as soon as one of the ResourceManager implementers (e.g. MaterialManager) initializes.*/

--- a/OgreMain/include/OgreTextureManager.h
+++ b/OgreMain/include/OgreTextureManager.h
@@ -65,27 +65,10 @@ namespace Ogre {
         virtual ~TextureManager();
 
         /// create a new sampler
-        SamplerPtr createSampler(const String& name = BLANKSTRING)
-        {
-            SamplerPtr ret = _createSamplerImpl();
-            if(!name.empty())
-            {
-                OgreAssert(mNamedSamplers.find(name) == mNamedSamplers.end(),
-                           ("Sampler '" + name + "' already exists").c_str());
-                mNamedSamplers[name] = ret;
-            }
-            return ret;
-        }
+        SamplerPtr createSampler(const String& name = BLANKSTRING);
 
         /// retrieve an named sampler
-        const SamplerPtr& getSampler(const String& name) const
-        {
-            static SamplerPtr nullPtr;
-            auto it = mNamedSamplers.find(name);
-            if(it == mNamedSamplers.end())
-                return nullPtr;
-            return it->second;
-        }
+        const SamplerPtr& getSampler(const String& name) const;
 
         /// Create a new texture
         /// @copydetails ResourceManager::createResource

--- a/OgreMain/include/OgreTextureUnitState.h
+++ b/OgreMain/include/OgreTextureUnitState.h
@@ -381,11 +381,7 @@ namespace Ogre {
         /**
         @deprecated use setLayerArrayNames()
          */
-        OGRE_DEPRECATED void setCubicTextureName( const String* const names, bool forUVW = false )
-        {
-            setLayerArrayNames(TEX_TYPE_CUBE_MAP,
-                               std::vector<String>(names, names + 6));
-        }
+        OGRE_DEPRECATED void setCubicTextureName( const String* const names, bool forUVW = false );
 
         /**
         @deprecated use setTexture()

--- a/OgreMain/include/OgreUserObjectBindings.h
+++ b/OgreMain/include/OgreUserObjectBindings.h
@@ -94,17 +94,9 @@ namespace Ogre {
         /** Copy constructor. Performs a copy of all stored UserAny. */
         UserObjectBindings(const UserObjectBindings& other);
 
-        UserObjectBindings& swap(UserObjectBindings& rhs)
-        {
-            std::swap(mAttributes, rhs.mAttributes);
-            return *this;
-        }
+        UserObjectBindings& swap(UserObjectBindings& rhs);
 
-        UserObjectBindings& operator=(const UserObjectBindings& rhs)
-        {
-            UserObjectBindings(rhs).swap(*this);
-            return *this;
-        }
+        UserObjectBindings& operator=(const UserObjectBindings& rhs);
 
     // Types.
     protected:

--- a/OgreMain/src/OgreAnimable.cpp
+++ b/OgreMain/src/OgreAnimable.cpp
@@ -32,6 +32,41 @@ namespace Ogre {
     //--------------------------------------------------------------------------
     AnimableObject::AnimableDictionaryMap AnimableObject::msAnimableDictionary;
     //--------------------------------------------------------------------------
+    void AnimableObject::createAnimableDictionary(void) const
+    {
+        if (msAnimableDictionary.find(getAnimableDictionaryName()) == msAnimableDictionary.end())
+        {
+            StringVector vec;
+            initialiseAnimableDictionary(vec);
+            msAnimableDictionary[getAnimableDictionaryName()] = vec;
+        }
+    }
+
+    /// Get an updateable reference to animable value list
+    StringVector& AnimableObject::_getAnimableValueNames(void)
+    {
+        AnimableDictionaryMap::iterator i = msAnimableDictionary.find(getAnimableDictionaryName());
+        if (i != msAnimableDictionary.end())
+        {
+            return i->second;
+        }
+
+        OGRE_EXCEPT(Exception::ERR_ITEM_NOT_FOUND, "Animable value list not found for " + getAnimableDictionaryName());
+    }
+
+    const StringVector& AnimableObject::getAnimableValueNames(void) const
+    {
+        createAnimableDictionary();
+
+        AnimableDictionaryMap::iterator i = msAnimableDictionary.find(getAnimableDictionaryName());
+        if (i != msAnimableDictionary.end())
+        {
+            return i->second;
+        }
+
+        OGRE_EXCEPT(Exception::ERR_ITEM_NOT_FOUND, "Animable value list not found for " + getAnimableDictionaryName());
+    }
+
     void AnimableValue::resetToBaseValue(void)
     {
         switch(mType)

--- a/OgreMain/src/OgreAnimationState.cpp
+++ b/OgreMain/src/OgreAnimationState.cpp
@@ -409,5 +409,10 @@ namespace Ogre
         return ConstEnabledAnimationStateIterator(
             mEnabledAnimationStates.begin(), mEnabledAnimationStates.end());
     }
+
+    ControllerValueRealPtr AnimationStateControllerValue::create(AnimationState* targetAnimationState, bool addTime)
+    {
+        return std::make_shared<AnimationStateControllerValue>(targetAnimationState, addTime);
+    }
 }
 

--- a/OgreMain/src/OgreGpuProgramParams.cpp
+++ b/OgreMain/src/OgreGpuProgramParams.cpp
@@ -188,6 +188,12 @@ namespace Ogre
 
     bool GpuNamedConstants::msGenerateAllConstantDefinitionArrayEntries = false;
 
+    GpuNamedConstants::GpuNamedConstants() : floatBufferSize(0), doubleBufferSize(0), intBufferSize(0) {}
+    GpuNamedConstants::~GpuNamedConstants() {}
+
+    GpuLogicalBufferStruct::GpuLogicalBufferStruct() : bufferSize(0) {}
+    GpuLogicalBufferStruct::~GpuLogicalBufferStruct() {}
+
     //---------------------------------------------------------------------
     void GpuNamedConstants::generateConstantDefinitionArrayEntries(
         const String& paramName, const GpuConstantDefinition& baseDef)
@@ -919,6 +925,8 @@ namespace Ogre
         , mActivePassIterationIndex(std::numeric_limits<size_t>::max())
     {
     }
+    GpuProgramParameters::~GpuProgramParameters() {}
+
     //-----------------------------------------------------------------------------
 
     GpuProgramParameters::GpuProgramParameters(const GpuProgramParameters& oth)

--- a/OgreMain/src/OgreInstanceManager.cpp
+++ b/OgreMain/src/OgreInstanceManager.cpp
@@ -439,6 +439,10 @@ namespace Ogre
         //Return default
         return BatchSettings().setting[id];
     }
+    bool InstanceManager::hasSettings(const String& materialName) const
+    {
+        return mBatchSettings.find(materialName) != mBatchSettings.end();
+    }
     //-----------------------------------------------------------------------
     void InstanceManager::applySettingToBatches( BatchSettingId id, bool value,
                                                  const InstanceBatchVec &container )
@@ -629,4 +633,13 @@ namespace Ogre
         mesh->clearBoneAssignments();
     }
     //-----------------------------------------------------------------------
+    InstanceManager::InstanceBatchIterator InstanceManager::getInstanceBatchIterator( const String &materialName ) const
+    {
+        InstanceBatchMap::const_iterator it = mInstanceBatches.find( materialName );
+        if(it != mInstanceBatches.end())
+            return InstanceBatchIterator( it->second.begin(), it->second.end() );
+
+        OGRE_EXCEPT(Exception::ERR_INVALID_STATE, "Cannot create instance batch iterator. "
+                    "Material " + materialName + " cannot be found");
+    }
 }

--- a/OgreMain/src/OgreRenderSystemCapabilities.cpp
+++ b/OgreMain/src/OgreRenderSystemCapabilities.cpp
@@ -31,6 +31,28 @@ THE SOFTWARE.
 
 namespace Ogre {
 
+    String DriverVersion::toString() const
+    {
+        StringStream str;
+        str << major << "." << minor << "." << release << "." << build;
+        return str.str();
+    }
+
+    void  DriverVersion::fromString(const String& versionString)
+    {
+        StringVector tokens = StringUtil::split(versionString, ".");
+        if(!tokens.empty())
+        {
+            major = StringConverter::parseInt(tokens[0]);
+            if (tokens.size() > 1)
+                minor = StringConverter::parseInt(tokens[1]);
+            if (tokens.size() > 2)
+                release = StringConverter::parseInt(tokens[2]);
+            if (tokens.size() > 3)
+                build = StringConverter::parseInt(tokens[3]);
+        }
+    }
+
     //-----------------------------------------------------------------------
     RenderSystemCapabilities::RenderSystemCapabilities()
         : mVendor(GPU_UNKNOWN)
@@ -53,6 +75,18 @@ namespace Ogre {
         // each rendersystem should enable these
         mCategoryRelevant[CAPS_CATEGORY_D3D9] = false;
         mCategoryRelevant[CAPS_CATEGORY_GL] = false;
+    }
+
+    void RenderSystemCapabilities::addShaderProfile(const String& profile) { mSupportedShaderProfiles.insert(profile); }
+
+    void RenderSystemCapabilities::removeShaderProfile(const String& profile)
+    {
+        mSupportedShaderProfiles.erase(profile);
+    }
+
+    bool RenderSystemCapabilities::isShaderProfileSupported(const String& profile) const
+    {
+        return (mSupportedShaderProfiles.end() != mSupportedShaderProfiles.find(profile));
     }
 
     //-----------------------------------------------------------------------

--- a/OgreMain/src/OgreRenderable.cpp
+++ b/OgreMain/src/OgreRenderable.cpp
@@ -1,0 +1,40 @@
+// This file is part of the OGRE project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at https://www.ogre3d.org/licensing.
+
+#include "OgreStableHeaders.h"
+
+namespace Ogre
+{
+void Renderable::setCustomParameter(size_t index, const Vector4& value) { mCustomParameters[index] = value; }
+
+void Renderable::removeCustomParameter(size_t index) { mCustomParameters.erase(index); }
+
+bool Renderable::hasCustomParameter(size_t index) const
+{
+    return mCustomParameters.find(index) != mCustomParameters.end();
+}
+
+const Vector4& Renderable::getCustomParameter(size_t index) const
+{
+    CustomParameterMap::const_iterator i = mCustomParameters.find(index);
+    if (i != mCustomParameters.end())
+    {
+        return i->second;
+    }
+    else
+    {
+        OGRE_EXCEPT(Exception::ERR_ITEM_NOT_FOUND, "Parameter at the given index was not found.");
+    }
+}
+
+void Renderable::_updateCustomGpuParameter(const GpuProgramParameters::AutoConstantEntry& constantEntry,
+                                           GpuProgramParameters* params) const
+{
+    CustomParameterMap::const_iterator i = mCustomParameters.find(constantEntry.data);
+    if (i != mCustomParameters.end())
+    {
+        params->_writeRawConstant(constantEntry.physicalIndex, i->second, constantEntry.elementCount);
+    }
+}
+} // namespace Ogre

--- a/OgreMain/src/OgreStringInterface.cpp
+++ b/OgreMain/src/OgreStringInterface.cpp
@@ -26,11 +26,67 @@ THE SOFTWARE.
 -----------------------------------------------------------------------------
 */
 #include "OgreStableHeaders.h"
+#include "Threading/OgreThreadHeaders.h"
 
 namespace Ogre {
-    OGRE_STATIC_MUTEX_INSTANCE( StringInterface::msDictionaryMutex );
-    ParamDictionaryMap StringInterface::msDictionary;
+    OGRE_STATIC_MUTEX( msDictionaryMutex );
+    /// Dictionary of parameters
+    static ParamDictionaryMap msDictionary;
 
+    ParamDictionary::ParamDictionary() {}
+    ParamDictionary::~ParamDictionary() {}
+
+    ParamCommand* ParamDictionary::getParamCommand(const String& name)
+    {
+        ParamCommandMap::iterator i = mParamCommands.find(name);
+        if (i != mParamCommands.end())
+        {
+            return i->second;
+        }
+        else
+        {
+            return 0;
+        }
+    }
+
+    const ParamCommand* ParamDictionary::getParamCommand(const String& name) const
+    {
+        ParamCommandMap::const_iterator i = mParamCommands.find(name);
+        if (i != mParamCommands.end())
+        {
+            return i->second;
+        }
+        else
+        {
+            return 0;
+        }
+    }
+
+    void ParamDictionary::addParameter(const ParameterDef& paramDef, ParamCommand* paramCmd)
+    {
+        mParamDefs.push_back(paramDef);
+        mParamCommands[paramDef.name] = paramCmd;
+    }
+
+    bool StringInterface::createParamDictionary(const String& className)
+    {
+        OGRE_LOCK_MUTEX( msDictionaryMutex );
+
+        ParamDictionaryMap::iterator it = msDictionary.find(className);
+
+        if ( it == msDictionary.end() )
+        {
+            mParamDict = &msDictionary.insert( std::make_pair( className, ParamDictionary() ) ).first->second;
+            mParamDictName = className;
+            return true;
+        }
+        else
+        {
+            mParamDict = &it->second;
+            mParamDictName = className;
+            return false;
+        }
+    }
 
     const ParameterList& StringInterface::getParameters(void) const
     {
@@ -42,6 +98,26 @@ namespace Ogre {
         else
             return emptyList;
 
+    }
+
+    String StringInterface::getParameter(const String& name) const
+    {
+        // Get dictionary
+        const ParamDictionary* dict = getParamDictionary();
+
+        if (dict)
+        {
+            // Look up command object
+            const ParamCommand* cmd = dict->getParamCommand(name);
+
+            if (cmd)
+            {
+                return cmd->doGet(this);
+            }
+        }
+
+        // Fallback
+        return "";
     }
 
     bool StringInterface::setParameter(const String& name, const String& value)
@@ -72,6 +148,25 @@ namespace Ogre {
             setParameter(i->first, i->second);
         }
     }
+
+    void StringInterface::copyParametersTo(StringInterface* dest) const
+    {
+        // Get dictionary
+        const ParamDictionary* dict = getParamDictionary();
+
+        if (dict)
+        {
+            // Iterate through own parameters
+            ParameterList::const_iterator i;
+
+            for (i = dict->mParamDefs.begin();
+            i != dict->mParamDefs.end(); ++i)
+            {
+                dest->setParameter(i->name, getParameter(i->name));
+            }
+        }
+    }
+
     //-----------------------------------------------------------------------
     void StringInterface::cleanupDictionary ()
     {

--- a/OgreMain/src/OgreTextureManager.cpp
+++ b/OgreMain/src/OgreTextureManager.cpp
@@ -56,6 +56,27 @@ namespace Ogre {
         // subclasses should unregister with resource group manager
 
     }
+    SamplerPtr TextureManager::createSampler(const String& name)
+    {
+        SamplerPtr ret = _createSamplerImpl();
+        if(!name.empty())
+        {
+            OgreAssert(mNamedSamplers.find(name) == mNamedSamplers.end(),
+                       ("Sampler '" + name + "' already exists").c_str());
+            mNamedSamplers[name] = ret;
+        }
+        return ret;
+    }
+
+    /// retrieve an named sampler
+    const SamplerPtr& TextureManager::getSampler(const String& name) const
+    {
+        static SamplerPtr nullPtr;
+        auto it = mNamedSamplers.find(name);
+        if(it == mNamedSamplers.end())
+            return nullPtr;
+        return it->second;
+    }
     //-----------------------------------------------------------------------
     TexturePtr TextureManager::getByName(const String& name, const String& groupName)
     {

--- a/OgreMain/src/OgreTextureUnitState.cpp
+++ b/OgreMain/src/OgreTextureUnitState.cpp
@@ -410,6 +410,11 @@ namespace Ogre {
         }
     }
 
+    void TextureUnitState::setCubicTextureName(const String* const names, bool forUVW)
+    {
+        setLayerArrayNames(TEX_TYPE_CUBE_MAP, std::vector<String>(names, names + 6));
+    }
+
     //-----------------------------------------------------------------------
     void TextureUnitState::setAnimatedTextureName( const String& name, size_t numFrames, Real duration)
     {

--- a/OgreMain/src/OgreUserObjectBindings.cpp
+++ b/OgreMain/src/OgreUserObjectBindings.cpp
@@ -37,6 +37,18 @@ namespace Ogre {
             mAttributes.reset(new Attributes(*other.mAttributes));
     }
 
+    UserObjectBindings& UserObjectBindings::swap(UserObjectBindings& rhs)
+    {
+        std::swap(mAttributes, rhs.mAttributes);
+        return *this;
+    }
+
+    UserObjectBindings& UserObjectBindings::operator=(const UserObjectBindings& rhs)
+    {
+        UserObjectBindings(rhs).swap(*this);
+        return *this;
+    }
+
     //-----------------------------------------------------------------------
     void UserObjectBindings::setUserAny( const Any& anything )
     {


### PR DESCRIPTION
notably StringInterface and map related methods.

# before
Compilation (524 times):
  Parsing (frontend):          931.2 s
  Codegen & opts (backend):    474.7 s

# after
Compilation (525 times):
  Parsing (frontend):          786.6 s
  Codegen & opts (backend):    450.5 s

# real-world
no significant compile time reduction on CI.