### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/BuildingOgre.md
+++ b/BuildingOgre.md
@@ -223,6 +223,17 @@ for OGRE_DEPENDENCIES_DIR, "Configure", should be no more errors, then press
 
 Select SampleBrowser as the start up project and run.
 
+Installing and building via vcpkg
+You can download and install ogre using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+```
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh
+./vcpkg integrate install
+vcpkg install ogre
+```
+The ogre port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ### Notes
 
 1. The code and generated CMake solution should be on local NTFS drive,


### PR DESCRIPTION
`Ogre `is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for ogre and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build ogre, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/ogre/portfile.cmake). We try to keep the library maintained as close as possible to the original library.