### PR TITLE
Main: RenderSystem - fix FunctionInvocation leak

### DIFF
--- a/Components/RTShaderSystem/src/OgreShaderGLSLESProgramWriter.cpp
+++ b/Components/RTShaderSystem/src/OgreShaderGLSLESProgramWriter.cpp
@@ -605,6 +605,9 @@ namespace Ogre {
                                 functionBody += "\n";
                                 line = stream->getLine();
                             }
+                            if (functionInvoc != NULL) {
+                                delete functionInvoc;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
```cpp
functionInvoc = createInvocationFromString(functionSig);

// Ok, now if we have found the signature, iterate through the file until we find the end
// of the function.
bool foundEndOfBody = false;
size_t braceCount = 0;
while(!foundEndOfBody)
{
    functionBody += line;

    String::size_type brace_pos = line.find('{', 0);
    if(brace_pos != String::npos)
    {
        braceCount++;
    }

    brace_pos = line.find('}', 0);
    if(brace_pos != String::npos)
        braceCount--;

    if(braceCount == 0)
    {
        foundEndOfBody = true;

        // Remove first and last braces
        size_t pos = functionBody.find('{');
        functionBody.erase(pos, 1);
        pos = functionBody.rfind('}');
        functionBody.erase(pos, 1);
        mFunctionCacheMap.emplace(*functionInvoc, functionBody);
    }
    functionBody += "\n";
    line = stream->getLine();
}
```

The **emplace** method is value copy, so **functionInvoc** is not released.

My running environment is MacOS 10.15.2 (19C57), Xcode 11.3.1 (11C504), iOS 12. 
I found the problem of memory leak through "debug memory graph" of xcode
