### PR TITLE
Fixed badly calculated matrices alignement

### DIFF
--- a/OgreMain/include/OgreGpuProgramParams.h
+++ b/OgreMain/include/OgreGpuProgramParams.h
@@ -454,7 +454,7 @@ namespace Ogre {
         unsigned long mVersion;
 
 		/// Accumulated offset used to calculate uniform location.
-		unsigned int mOffset;
+		size_t mOffset;
 
         bool mDirty;
 

--- a/OgreMain/src/OgreGpuProgramParams.cpp
+++ b/OgreMain/src/OgreGpuProgramParams.cpp
@@ -398,14 +398,24 @@ namespace Ogre
 
 		// we try to adhere to GLSL std140 packing rules
 		// handle alignment requirements
-		auto align_size = std::min<int>(def.elementSize == 3 ? 4 : def.elementSize, 4); // vec3 is 16 byte aligned, which is max
-		align_size *= 4; // bytes
+        auto align_size = std::min<int>(def.elementSize == 3 ? 4 : def.elementSize, 4); // vec3 is 16 byte aligned, which is max
+        align_size *= 4; // bytes
 
-		// abuse logical index to store offset
-		def.logicalIndex = ((mOffset + align_size - 1) / align_size) * align_size; //integer call
-        def.variability = (uint16)GPV_GLOBAL;
+        int nextAlignedOffset = ((mOffset + align_size - 1) / align_size) * align_size;
 
-		mOffset = def.logicalIndex + align_size;
+        // abuse logical index to store offset
+        if (mOffset + align_size > nextAlignedOffset)
+        {
+            def.logicalIndex = nextAlignedOffset;
+        }
+        else
+        {
+            def.logicalIndex = mOffset;
+        }
+
+        mOffset = def.logicalIndex + (def.constType == GCT_MATRIX_4X3 ? 16 : def.elementSize) * 4; // mat4x3 have a size of 64 bytes
+
+        def.variability = (uint16)GPV_GLOBAL;        
 
         if (def.isFloat())
         {

--- a/OgreMain/src/OgreGpuProgramParams.cpp
+++ b/OgreMain/src/OgreGpuProgramParams.cpp
@@ -398,10 +398,10 @@ namespace Ogre
 
 		// we try to adhere to GLSL std140 packing rules
 		// handle alignment requirements
-        auto align_size = std::min<int>(def.elementSize == 3 ? 4 : def.elementSize, 4); // vec3 is 16 byte aligned, which is max
+        size_t align_size = std::min<size_t>(def.elementSize == 3 ? 4 : def.elementSize, 4); // vec3 is 16 byte aligned, which is max
         align_size *= 4; // bytes
 
-        int nextAlignedOffset = ((mOffset + align_size - 1) / align_size) * align_size;
+        size_t nextAlignedOffset = ((mOffset + align_size - 1) / align_size) * align_size;
 
         // abuse logical index to store offset
         if (mOffset + align_size > nextAlignedOffset)

--- a/OgreMain/src/OgreGpuProgramParams.cpp
+++ b/OgreMain/src/OgreGpuProgramParams.cpp
@@ -415,7 +415,7 @@ namespace Ogre
 
         mOffset = def.logicalIndex + (def.constType == GCT_MATRIX_4X3 ? 16 : def.elementSize) * 4; // mat4x3 have a size of 64 bytes
 
-        def.variability = (uint16)GPV_GLOBAL;        
+        def.variability = (uint16)GPV_GLOBAL;
 
         if (def.isFloat())
         {


### PR DESCRIPTION
Related to issue https://github.com/OGRECave/ogre/issues/1476

Matrices params size was not properly handled when calculating the aligned offset.
This new fix should handle every case.

Tested it against this Uniform block:
```

layout(std140) uniform TestAlignment
{
	mat3 _mat33 ; 	//0
	mat4x3 _mat43 ; //48
	float _float ; 	//112
	mat3x4 _mat34 ; //128
	vec3 _vec3;	//176
	vec2 _vec2; 	//192
	mat4 _mat44; 	//208
	float _float1; 	//272
	float _float2; 	//276
	mat3 _mat33_2; 	//288
	mat2 _mat22 ;	//336
};
```

