### PR TITLE
D3D11: port to Sampler object. Enables caching of ID3D11SamplerState

### DIFF
--- a/OgreMain/include/OgreCamera.h
+++ b/OgreMain/include/OgreCamera.h
@@ -304,11 +304,11 @@ namespace Ogre {
         /** Rotate the camera around an arbitrary axis.
         @deprecated attach to SceneNode and use SceneNode::rotate
         */
-        void rotate(const Vector3& axis, const Radian& angle);
+        OGRE_DEPRECATED void rotate(const Vector3& axis, const Radian& angle);
 
         /// @overload
         /// @deprecated attach to SceneNode and use SceneNode::rotate
-        void rotate(const Quaternion& q);
+        OGRE_DEPRECATED void rotate(const Quaternion& q);
 
         /** Tells the camera whether to yaw around it's own local Y axis or a 
             fixed axis of choice.

--- a/OgreMain/include/OgreCompositionTechnique.h
+++ b/OgreMain/include/OgreCompositionTechnique.h
@@ -98,7 +98,7 @@ namespace Ogre {
         /** Get a local texture definition.
         @deprecated use getTextureDefinitions()
         */
-        TextureDefinition *getTextureDefinition(size_t idx);
+        OGRE_DEPRECATED TextureDefinition *getTextureDefinition(size_t idx);
         
         /** Get a local texture definition with a specific name.
         */

--- a/OgreMain/include/OgreGpuProgram.h
+++ b/OgreMain/include/OgreGpuProgram.h
@@ -330,9 +330,9 @@ namespace Ogre {
     */
     virtual bool isVertexTextureFetchRequired(void) const { return mVertexTextureFetch; }
 
-    /// @deprecated
-    virtual void setAdjacencyInfoRequired(bool r) { mNeedsAdjacencyInfo = r; }
-    /// @deprecated
+    /// @deprecated use OT_DETAIL_ADJACENCY_BIT
+    OGRE_DEPRECATED virtual void setAdjacencyInfoRequired(bool r) { mNeedsAdjacencyInfo = r; }
+    /// @deprecated use OT_DETAIL_ADJACENCY_BIT
     virtual bool isAdjacencyInfoRequired(void) const { return mNeedsAdjacencyInfo; }
     /** Sets the number of process groups dispatched by this compute
         program.

--- a/OgreMain/include/OgreMaterial.h
+++ b/OgreMain/include/OgreMaterial.h
@@ -647,7 +647,7 @@ namespace Ogre {
         }
         
         /// @deprecated do not use
-        bool applyTextureAliases(const AliasTextureNamePairList& aliasList, const bool apply = true) const;
+        OGRE_DEPRECATED bool applyTextureAliases(const AliasTextureNamePairList& aliasList, const bool apply = true) const;
 
         /** Gets the compilation status of the material.
         @return True if the material needs recompilation.

--- a/OgreMain/include/OgreRenderSystem.h
+++ b/OgreMain/include/OgreRenderSystem.h
@@ -609,14 +609,14 @@ namespace Ogre
         virtual void _setTextureBlendMode(size_t unit, const LayerBlendModeEx& bm) {}
 
         /// @deprecated use _setSampler
-        virtual void _setTextureUnitFiltering(size_t unit, FilterType ftype, FilterOptions filter) = 0;
+        OGRE_DEPRECATED virtual void _setTextureUnitFiltering(size_t unit, FilterType ftype, FilterOptions filter) {}
 
         /// @deprecated use _setSampler
         OGRE_DEPRECATED virtual void _setTextureUnitFiltering(size_t unit, FilterOptions minFilter,
             FilterOptions magFilter, FilterOptions mipFilter);
 
         /// @deprecated use _setSampler
-        OGRE_DEPRECATED virtual void _setTextureAddressingMode(size_t unit, const Sampler::UVWAddressingMode& uvw) = 0;
+        OGRE_DEPRECATED virtual void _setTextureAddressingMode(size_t unit, const Sampler::UVWAddressingMode& uvw) {}
 
         /** Sets the texture coordinate transformation matrix for a texture unit.
         @param unit Texture unit to affect

--- a/OgreMain/include/OgreSceneManagerEnumerator.h
+++ b/OgreMain/include/OgreSceneManagerEnumerator.h
@@ -142,7 +142,7 @@ namespace Ogre {
             providing some information about each one.
             @deprecated use getMetaData()
         */
-        MetaDataIterator getMetaDataIterator(void) const;
+        OGRE_DEPRECATED MetaDataIterator getMetaDataIterator(void) const;
 
         /** Create a SceneManager instance of a given type.
         @remarks
@@ -182,7 +182,7 @@ namespace Ogre {
         typedef MapIterator<Instances> SceneManagerIterator;
         /** Get an iterator over all the existing SceneManager instances.
         @deprecated use getSceneManagers() instead */
-        SceneManagerIterator getSceneManagerIterator(void);
+        OGRE_DEPRECATED SceneManagerIterator getSceneManagerIterator(void);
 
         /// Get all the existing SceneManager instances.
         const Instances& getSceneManagers() const;

--- a/OgreMain/include/OgreScriptCompiler.h
+++ b/OgreMain/include/OgreScriptCompiler.h
@@ -459,7 +459,7 @@ namespace Ogre
     };
 
     /// @deprecated do not use
-    class _OgreExport PreApplyTextureAliasesScriptCompilerEvent : public ScriptCompilerEvent
+    class OGRE_DEPRECATED _OgreExport PreApplyTextureAliasesScriptCompilerEvent : public ScriptCompilerEvent
     {
     public:
         Material *mMaterial;
@@ -524,7 +524,7 @@ namespace Ogre
     };
 
     /// @deprecated use CreateGpuProgramScriptCompilerEvent
-    class _OgreExport CreateHighLevelGpuProgramScriptCompilerEvent : public CreateGpuProgramScriptCompilerEvent
+    class OGRE_DEPRECATED _OgreExport CreateHighLevelGpuProgramScriptCompilerEvent : public CreateGpuProgramScriptCompilerEvent
     {
     public:
         String mLanguage;

--- a/OgreMain/include/OgreTechnique.h
+++ b/OgreMain/include/OgreTechnique.h
@@ -614,7 +614,7 @@ namespace Ogre {
         const String& getName(void) const { return mName; }
 
         /// @deprecated do not use
-        bool applyTextureAliases(const AliasTextureNamePairList& aliasList, const bool apply = true) const;
+        OGRE_DEPRECATED bool applyTextureAliases(const AliasTextureNamePairList& aliasList, const bool apply = true) const;
 
 
         /** Add a rule which manually influences the support for this technique based

--- a/OgreMain/include/OgreTexture.h
+++ b/OgreMain/include/OgreTexture.h
@@ -377,10 +377,10 @@ namespace Ogre {
         void setDesiredBitDepths(ushort integerBits, ushort floatBits);
 
         /// @deprecated use setFormat(PF_A8)
-        void setTreatLuminanceAsAlpha(bool asAlpha);
+        OGRE_DEPRECATED void setTreatLuminanceAsAlpha(bool asAlpha);
 
         /// @deprecated do not use
-        bool getTreatLuminanceAsAlpha(void) const;
+        OGRE_DEPRECATED bool getTreatLuminanceAsAlpha(void) const;
 
         /** Return the number of faces this texture has. This will be 6 for a cubemap
             texture and 1 for a 1D, 2D or 3D one.

--- a/OgreMain/include/OgreTextureUnitState.h
+++ b/OgreMain/include/OgreTextureUnitState.h
@@ -1068,7 +1068,7 @@ namespace Ogre {
         const String& getTextureNameAlias(void) const { return mTextureNameAlias;}
 
         /// @deprecated do not use
-        bool applyTextureAliases(const AliasTextureNamePairList& aliasList, const bool apply = true);
+        OGRE_DEPRECATED bool applyTextureAliases(const AliasTextureNamePairList& aliasList, const bool apply = true);
 
         /** Notify this object that its parent has changed. */
         void _notifyParent(Pass* parent);

--- a/OgreMain/src/OgreCamera.cpp
+++ b/OgreMain/src/OgreCamera.cpp
@@ -255,7 +255,9 @@ namespace Ogre {
     {
         // Rotate around local Z axis
         Vector3 zAxis = mOrientation * Vector3::UNIT_Z;
+        OGRE_IGNORE_DEPRECATED_BEGIN
         rotate(zAxis, angle);
+        OGRE_IGNORE_DEPRECATED_END
 
         invalidateView();
     }
@@ -276,7 +278,9 @@ namespace Ogre {
             yAxis = mOrientation * Vector3::UNIT_Y;
         }
 
+        OGRE_IGNORE_DEPRECATED_BEGIN
         rotate(yAxis, angle);
+        OGRE_IGNORE_DEPRECATED_END
 
         invalidateView();
     }
@@ -286,7 +290,9 @@ namespace Ogre {
     {
         // Rotate around local X axis
         Vector3 xAxis = mOrientation * Vector3::UNIT_X;
+        OGRE_IGNORE_DEPRECATED_BEGIN
         rotate(xAxis, angle);
+        OGRE_IGNORE_DEPRECATED_END
 
         invalidateView();
 
@@ -297,7 +303,9 @@ namespace Ogre {
     {
         Quaternion q;
         q.FromAngleAxis(angle,axis);
+        OGRE_IGNORE_DEPRECATED_BEGIN
         rotate(q);
+        OGRE_IGNORE_DEPRECATED_END
     }
 
     //-----------------------------------------------------------------------

--- a/OgreMain/src/OgreMaterial.cpp
+++ b/OgreMain/src/OgreMaterial.cpp
@@ -797,8 +797,10 @@ namespace Ogre {
 
         for (i = mTechniques.begin(); i != iend; ++i)
         {
+            OGRE_IGNORE_DEPRECATED_BEGIN
             if ((*i)->applyTextureAliases(aliasList, apply))
                 testResult = true;
+            OGRE_IGNORE_DEPRECATED_END
         }
 
         return testResult;

--- a/OgreMain/src/OgreMeshSerializerImpl.cpp
+++ b/OgreMain/src/OgreMeshSerializerImpl.cpp
@@ -1099,7 +1099,9 @@ namespace Ogre {
     {
         String aliasName = readString(stream);
         String textureName = readString(stream);
+        OGRE_IGNORE_DEPRECATED_BEGIN
         sub->addTextureAlias(aliasName, textureName);
+        OGRE_IGNORE_DEPRECATED_END
     }
     //---------------------------------------------------------------------
     void MeshSerializerImpl::writeSkeletonLink(const String& skelName)

--- a/OgreMain/src/OgrePass.cpp
+++ b/OgreMain/src/OgrePass.cpp
@@ -1787,8 +1787,10 @@ namespace Ogre {
 
         for (i = mTextureUnitStates.begin(); i != iend; ++i)
         {
+            OGRE_IGNORE_DEPRECATED_BEGIN
             if ((*i)->applyTextureAliases(aliasList, apply))
                 testResult = true;
+            OGRE_IGNORE_DEPRECATED_END
         }
 
         return testResult;

--- a/OgreMain/src/OgreRenderQueue.cpp
+++ b/OgreMain/src/OgreRenderQueue.cpp
@@ -102,17 +102,12 @@ namespace Ogre {
     //-----------------------------------------------------------------------
     void RenderQueue::clear(bool destroyPassMaps)
     {
-        // Clear the queues
-        SceneManagerEnumerator::SceneManagerIterator scnIt =
-            SceneManagerEnumerator::getSingleton().getSceneManagerIterator();
-
         // Note: We clear dirty passes from all RenderQueues in all 
         // SceneManagers, because the following recalculation of pass hashes
         // also considers all RenderQueues and could become inconsistent, otherwise.
-        while (scnIt.hasMoreElements())
+        for (auto p : SceneManagerEnumerator::getSingleton().getSceneManagers())
         {
-            SceneManager* sceneMgr = scnIt.getNext();
-            RenderQueue* queue = sceneMgr->getRenderQueue();
+            RenderQueue* queue = p.second->getRenderQueue();
 
             for (size_t i = 0; i < RENDER_QUEUE_MAX; ++i)
             {

--- a/OgreMain/src/OgreRenderSystem.cpp
+++ b/OgreMain/src/OgreRenderSystem.cpp
@@ -567,9 +567,11 @@ namespace Ogre {
     void RenderSystem::_setTextureUnitFiltering(size_t unit, FilterOptions minFilter,
             FilterOptions magFilter, FilterOptions mipFilter)
     {
+        OGRE_IGNORE_DEPRECATED_BEGIN
         _setTextureUnitFiltering(unit, FT_MIN, minFilter);
         _setTextureUnitFiltering(unit, FT_MAG, magFilter);
         _setTextureUnitFiltering(unit, FT_MIP, mipFilter);
+        OGRE_IGNORE_DEPRECATED_END
     }
     //---------------------------------------------------------------------
     void RenderSystem::_cleanupDepthBuffers( bool bCleanManualBuffers )

--- a/OgreMain/src/OgreRoot.cpp
+++ b/OgreMain/src/OgreRoot.cpp
@@ -636,7 +636,9 @@ namespace Ogre {
     SceneManagerEnumerator::MetaDataIterator
     Root::getSceneManagerMetaDataIterator(void) const
     {
+        OGRE_IGNORE_DEPRECATED_BEGIN
         return mSceneManagerEnum->getMetaDataIterator();
+        OGRE_IGNORE_DEPRECATED_END
     }
     //-----------------------------------------------------------------------
     const SceneManagerEnumerator::MetaDataList&
@@ -668,7 +670,9 @@ namespace Ogre {
     //-----------------------------------------------------------------------
     SceneManagerEnumerator::SceneManagerIterator Root::getSceneManagerIterator(void)
     {
+        OGRE_IGNORE_DEPRECATED_BEGIN
         return mSceneManagerEnum->getSceneManagerIterator();
+        OGRE_IGNORE_DEPRECATED_END
     }
     //-----------------------------------------------------------------------
     const SceneManagerEnumerator::Instances& Root::getSceneManagers(void) const

--- a/OgreMain/src/OgreScriptTranslator.cpp
+++ b/OgreMain/src/OgreScriptTranslator.cpp
@@ -1218,6 +1218,7 @@ namespace Ogre{
             }
         }
 
+        OGRE_IGNORE_DEPRECATED_BEGIN
         // Apply the texture aliases
         if(compiler->getListener())
         {
@@ -1226,6 +1227,7 @@ namespace Ogre{
         }
         mMaterial->applyTextureAliases(mTextureAliases);
         mTextureAliases.clear();
+        OGRE_IGNORE_DEPRECATED_END
     }
 
     /**************************************************************************
@@ -3628,8 +3630,10 @@ namespace Ogre{
         bool isHighLevel = language != "asm";
         CreateGpuProgramScriptCompilerEvent evt(obj->file, obj->name, compiler->getResourceGroup(), source, syntax,
                                                 gpt);
+        OGRE_IGNORE_DEPRECATED_BEGIN
         CreateHighLevelGpuProgramScriptCompilerEvent evtHL(obj->file, obj->name, compiler->getResourceGroup(), source,
                                                          language, gpt);
+        OGRE_IGNORE_DEPRECATED_END
         bool processed = compiler->_fireEvent(isHighLevel ? &evt : &evtHL, &prog);
         if(!processed)
         {

--- a/OgreMain/src/OgreStableHeaders.h
+++ b/OgreMain/src/OgreStableHeaders.h
@@ -107,4 +107,14 @@ THE SOFTWARE.
 #   include "OgreZip.h"
 #endif
 
+#if OGRE_COMPILER == OGRE_COMPILER_MSVC
+#define OGRE_IGNORE_DEPRECATED_BEGIN __pragma(warning(push)) \
+    __pragma(warning(disable:4996))
+#define OGRE_IGNORE_DEPRECATED_END __pragma(warning(pop))
+#else
+#define OGRE_IGNORE_DEPRECATED_BEGIN _Pragma("GCC diagnostic push") \
+    _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+#define OGRE_IGNORE_DEPRECATED_END _Pragma("GCC diagnostic pop")
+#endif
+
 #endif 

--- a/OgreMain/src/OgreSubMesh.cpp
+++ b/OgreMain/src/OgreSubMesh.cpp
@@ -141,6 +141,7 @@ namespace Ogre {
         bool newMaterialCreated = false;
         // if submesh has texture aliases
         // ask the material manager if the current submesh material exists
+        OGRE_IGNORE_DEPRECATED_BEGIN
         if (hasTextureAliases() && mMaterial)
         {
             // get the current submesh material
@@ -186,6 +187,7 @@ namespace Ogre {
                 newMaterialCreated = true;
             }
         }
+        OGRE_IGNORE_DEPRECATED_END
 
         return newMaterialCreated;
     }

--- a/OgreMain/src/OgreTextureManager.cpp
+++ b/OgreMain/src/OgreTextureManager.cpp
@@ -105,7 +105,9 @@ namespace Ogre {
             tex->setNumMipmaps((numMipmaps == MIP_DEFAULT)? mDefaultNumMipmaps :
                 static_cast<uint32>(numMipmaps));
             tex->setGamma(gamma);
+            OGRE_IGNORE_DEPRECATED_BEGIN
             tex->setTreatLuminanceAsAlpha(isAlpha);
+            OGRE_IGNORE_DEPRECATED_END
             tex->setFormat(desiredFormat);
             tex->setHardwareGammaEnabled(hwGamma);
         }
@@ -153,7 +155,9 @@ namespace Ogre {
         tex->setNumMipmaps((numMipmaps == MIP_DEFAULT)? mDefaultNumMipmaps :
             static_cast<uint32>(numMipmaps));
         tex->setGamma(gamma);
+        OGRE_IGNORE_DEPRECATED_BEGIN
         tex->setTreatLuminanceAsAlpha(isAlpha);
+        OGRE_IGNORE_DEPRECATED_END
         tex->setFormat(desiredFormat);
         tex->setHardwareGammaEnabled(hwGamma);
         tex->loadImage(img);

--- a/OgreMain/src/OgreTextureUnitState.cpp
+++ b/OgreMain/src/OgreTextureUnitState.cpp
@@ -570,13 +570,17 @@ namespace Ogre {
     void TextureUnitState::setIsAlpha(bool isAlpha)
     {
         OgreAssert(mFramePtrs[0], "frame must not be blank");
+        OGRE_IGNORE_DEPRECATED_BEGIN
         for(auto& frame : mFramePtrs)
             frame->setTreatLuminanceAsAlpha(isAlpha);
+        OGRE_IGNORE_DEPRECATED_END
     }
     //-----------------------------------------------------------------------
     bool TextureUnitState::getIsAlpha(void) const
     {
+        OGRE_IGNORE_DEPRECATED_BEGIN
         return mFramePtrs[0] && mFramePtrs[0]->getTreatLuminanceAsAlpha();
+        OGRE_IGNORE_DEPRECATED_END
     }
     float TextureUnitState::getGamma() const
     {

--- a/PlugIns/CgProgramManager/src/OgreCgProgram.cpp
+++ b/PlugIns/CgProgramManager/src/OgreCgProgram.cpp
@@ -192,7 +192,7 @@ namespace Ogre {
 		if (mDelegate)
 		{
 			mDelegate->setSource(mProgramString);
-			mDelegate->setAdjacencyInfoRequired(isAdjacencyInfoRequired());
+
 			if (mSelectedCgProfile == CG_PROFILE_GLSLG)
 			{
 				// need to set input and output operations
@@ -486,8 +486,6 @@ namespace Ogre {
 					mType,
 					mSelectedProfile);
 			}
-			// Shader params need to be forwarded to low level implementation
-			mAssemblerProgram->setAdjacencyInfoRequired(isAdjacencyInfoRequired());
 		}
 	}
 	//-----------------------------------------------------------------------

--- a/RenderSystems/Direct3D11/include/OgreD3D11RenderSystem.h
+++ b/RenderSystems/Direct3D11/include/OgreD3D11RenderSystem.h
@@ -60,6 +60,7 @@ namespace Ogre
         , protected D3D11DeviceResourceManager
     {
     private:
+	    friend class D3D11Sampler;
         Ogre::String mDriverName;    // it`s hint rather than hard requirement, could be ignored if empty or device removed
         D3D_DRIVER_TYPE mDriverType; // should be XXX_HARDWARE, XXX_SOFTWARE or XXX_WARP, never XXX_UNKNOWN or XXX_NULL
         D3D_FEATURE_LEVEL mFeatureLevel;
@@ -86,9 +87,6 @@ namespace Ogre
 
         void freeDevice(void);
         void createDevice();
-
-        /// return anisotropy level
-        DWORD _getCurrentAnisotropy(size_t unit);
         
         D3D11HardwareBufferManager* mHardwareBufferManager;
         GpuProgramManager* mGpuProgramManager;
@@ -126,11 +124,6 @@ namespace Ogre
         bool                        mDepthStencilDescChanged;
 
         PolygonMode mPolygonMode;
-
-        FilterOptions FilterMinification[OGRE_MAX_TEXTURE_LAYERS];
-        FilterOptions FilterMagnification[OGRE_MAX_TEXTURE_LAYERS];
-        FilterOptions FilterMips[OGRE_MAX_TEXTURE_LAYERS];
-        bool          CompareEnabled;
 
         D3D11_RECT mScissorRect;
         
@@ -172,7 +165,7 @@ namespace Ogre
 
             /// texture 
             ID3D11ShaderResourceView  *pTex;
-            D3D11_SAMPLER_DESC  samplerDesc;
+            ID3D11SamplerState    *pSampler;
             bool used;
         } mTexStageDesc[OGRE_MAX_TEXTURE_LAYERS];
 
@@ -279,7 +272,6 @@ namespace Ogre
         D3D11HLSLProgram* _getBoundComputeProgram() const;
         void _setTexture(size_t unit, bool enabled, const TexturePtr &texPtr);
         void _setSampler(size_t unit, Sampler& sampler);
-        void _setTextureAddressingMode(size_t stage, const Sampler::UVWAddressingMode& uvw);
         void _setAlphaRejectSettings( CompareFunction func, unsigned char value, bool alphaToCoverage );
         void _setViewport( Viewport *vp );
         void _endFrame(void);
@@ -293,7 +285,6 @@ namespace Ogre
         void _setDepthBias(float constantBias, float slopeScaleBias);
 		void _convertProjectionMatrix(const Matrix4& matrix, Matrix4& dest, bool forGpuProgram = false);
         void _setPolygonMode(PolygonMode level);
-        void _setTextureUnitFiltering(size_t unit, FilterType ftype, FilterOptions filter);
         void setVertexDeclaration(VertexDeclaration* decl);
         void setVertexDeclaration(VertexDeclaration* decl, VertexBufferBinding* binding);
         void setVertexBufferBinding(VertexBufferBinding* binding);

--- a/RenderSystems/Direct3D11/include/OgreD3D11TextureManager.h
+++ b/RenderSystems/Direct3D11/include/OgreD3D11TextureManager.h
@@ -33,6 +33,16 @@ THE SOFTWARE.
 
 namespace Ogre 
 {
+    class _OgreD3D11Export D3D11Sampler : public Sampler
+    {
+    public:
+        D3D11Sampler(D3D11Device & device) : mDevice(device) {}
+        ID3D11SamplerState* getState();
+    private:
+        ComPtr<ID3D11SamplerState> mState;
+        D3D11Device & mDevice;
+    };
+
     class _OgreD3D11Export D3D11TextureManager : public TextureManager
     {
     protected:
@@ -41,6 +51,8 @@ namespace Ogre
         Resource* createImpl(const String& name, ResourceHandle handle, 
             const String& group, bool isManual, ManualResourceLoader* loader, 
             const NameValuePairList* createParams);
+
+        SamplerPtr _createSamplerImpl();
 
     public:
         D3D11TextureManager( D3D11Device & device );

--- a/RenderSystems/Direct3D11/src/OgreD3D11TextureManager.cpp
+++ b/RenderSystems/Direct3D11/src/OgreD3D11TextureManager.cpp
@@ -35,6 +35,49 @@ THE SOFTWARE.
 
 namespace Ogre 
 {
+    ID3D11SamplerState* D3D11Sampler::getState()
+    {
+        if(!mDirty)
+            return mState.Get();
+
+        D3D11_SAMPLER_DESC  desc;
+
+        desc.Filter = D3D11Mappings::get(mMinFilter, mMagFilter, mMipFilter, mCompareEnabled);
+        desc.MaxAnisotropy = mMaxAniso;
+        desc.MipLODBias = static_cast<float>(Math::Clamp(mMipmapBias - 0.5, -16.00, 15.99));
+        desc.MinLOD = -D3D11_FLOAT32_MAX;
+        desc.MaxLOD = D3D11_FLOAT32_MAX;
+
+        bool reversedZ = Root::getSingleton().getRenderSystem()->isReverseDepthBufferEnabled();
+        auto cmpFunc = mCompareFunc;
+        if(reversedZ)
+            cmpFunc = D3D11RenderSystem::reverseCompareFunction(cmpFunc);
+        desc.ComparisonFunc = D3D11Mappings::get(cmpFunc);
+
+        desc.AddressU = D3D11Mappings::get(mAddressMode.u);
+        desc.AddressV = D3D11Mappings::get(mAddressMode.v);
+        desc.AddressW = D3D11Mappings::get(mAddressMode.w);
+
+        if (mAddressMode.u == TAM_BORDER || mAddressMode.v == TAM_BORDER || mAddressMode.w == TAM_BORDER)
+        {
+            auto borderColour =
+                (reversedZ && mCompareEnabled) ? ColourValue::White - mBorderColour : mBorderColour;
+            D3D11Mappings::get(borderColour, desc.BorderColor);
+        }
+
+        HRESULT hr = mDevice->CreateSamplerState(&desc, mState.ReleaseAndGetAddressOf());
+        if (FAILED(hr))
+        {
+            String errorDescription = mDevice.getErrorDescription(hr);
+            OGRE_EXCEPT_EX(Exception::ERR_RENDERINGAPI_ERROR, hr,
+                "Failed to create sampler state\nError Description:" + errorDescription,
+                "D3D11Sampler::getState" );
+        }
+
+        mDirty = false;
+
+        return mState.Get();
+    }
     //---------------------------------------------------------------------
     D3D11TextureManager::D3D11TextureManager( D3D11Device & device ) : TextureManager(), mDevice (device)
     {
@@ -56,6 +99,10 @@ namespace Ogre
         ManualResourceLoader* loader, const NameValuePairList* createParams)
     {
         return new D3D11Texture(this, name, handle, group, isManual, loader, mDevice); 
+    }
+    SamplerPtr D3D11TextureManager::_createSamplerImpl()
+    {
+        return std::make_shared<D3D11Sampler>(mDevice);
     }
     //---------------------------------------------------------------------
     PixelFormat D3D11TextureManager::getNativeFormat(TextureType ttype, PixelFormat format, int usage)


### PR DESCRIPTION
also likely fixes some bugs as sampler settings were all over the place