### PR TITLE
Fix OSX platform libs

### DIFF
--- a/OgreMain/CMakeLists.txt
+++ b/OgreMain/CMakeLists.txt
@@ -54,8 +54,8 @@ elseif (APPLE)
   else ()
     include_directories("${CMAKE_CURRENT_SOURCE_DIR}/src/OSX")
     file(GLOB PLATFORM_SOURCE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/src/OSX/*.cpp"
-      "${CMAKE_CURRENT_SOURCE_DIR}/src/OSX/*.mm"
-    )
+      "${CMAKE_CURRENT_SOURCE_DIR}/src/OSX/*.mm")
+    set(PLATFORM_LIBS "-framework CoreFoundation -framework Foundation")
   endif ()
 elseif(ANDROID)
   # required by OgrePlatformInformation.cpp


### PR DESCRIPTION
We failed to build ogre in https://github.com/conda-forge/ogre-feedstock/pull/24 after https://github.com/OGRECave/ogre/commit/397e24cfc4ec96f35cab41c99a05d0458af7e1a0 was merged (see https://github.com/conda-forge/ogre-feedstock/pull/24).

This patch fixes the build (see https://github.com/conda-forge/ogre-feedstock/pull/25). It would be great if it could be merged.


Many thanks,
Tobias