### PR TITLE
Overlay: make OverlaySystem a Singleton

### DIFF
--- a/Components/Overlay/include/OgreOverlaySystem.h
+++ b/Components/Overlay/include/OgreOverlaySystem.h
@@ -54,7 +54,7 @@ namespace Ogre {
         instance as a RenderQueueListener in your scenemanager(s).
     */
     class _OgreOverlayExport OverlaySystem
-        : public OverlayAlloc
+        : public Singleton<OverlaySystem>
         , public Ogre::RenderQueueListener
         , public Ogre::RenderSystem::Listener
     {
@@ -69,6 +69,8 @@ namespace Ogre {
         /// @see RenderSystem::Listener
         virtual void eventOccurred(const String& eventName, const NameValuePairList* parameters);
 
+        static OverlaySystem& getSingleton();
+        static OverlaySystem* getSingletonPtr();
     private:
         OverlayManager* mOverlayManager;
         FontManager* mFontManager;

--- a/Components/Overlay/src/OgreOverlaySystem.cpp
+++ b/Components/Overlay/src/OgreOverlaySystem.cpp
@@ -36,6 +36,16 @@ THE SOFTWARE.
 
 namespace Ogre {
     //---------------------------------------------------------------------
+    template<> OverlaySystem *Singleton<OverlaySystem>::msSingleton = 0;
+    OverlaySystem* OverlaySystem::getSingletonPtr()
+    {
+        return msSingleton;
+    }
+    OverlaySystem& OverlaySystem::getSingleton()
+    {
+        assert( msSingleton );  return ( *msSingleton );
+    }
+    //---------------------------------------------------------------------
     OverlaySystem::OverlaySystem()
     {
         RenderSystem::setSharedListener(this);


### PR DESCRIPTION
rationale: it internally manages singletons and functionality was previously in Root, which is also a singleton.

fixes #112