### PR TITLE
Main: split SkyRenderer into Plane, Box and Dome classes

### DIFF
--- a/OgreMain/src/OgreSceneManager.cpp
+++ b/OgreMain/src/OgreSceneManager.cpp
@@ -58,7 +58,9 @@ mName(name),
 mLastRenderQueueInvocationCustom(false),
 mCameraInProgress(0),
 mCurrentViewport(0),
-mSkyRenderer(this),
+mSkyPlane(this),
+mSkyBox(this),
+mSkyDome(this),
 mFogMode(FOG_NONE),
 mFogColour(),
 mFogStart(0),
@@ -100,8 +102,6 @@ mGpuParamsDirty((uint16)GPV_ALL)
 
     // create the auto param data source instance
     mAutoParamDataSource.reset(createAutoParamDataSource());
-
-    addListener(&mSkyRenderer);
 }
 //-----------------------------------------------------------------------
 SceneManager::~SceneManager()
@@ -708,8 +708,6 @@ void SceneManager::clearScene(void)
     
     // Clear animations
     destroyAllAnimations();
-
-    mSkyRenderer.clear();
 
     // Clear render queue, empty completely
     if (mRenderQueue)
@@ -1533,17 +1531,16 @@ void SceneManager::setSkyPlane(
                                int xsegments, int ysegments,
                                const String& groupName)
 {
-    mSkyRenderer.setSkyPlane(
-        enable, plane, materialName, gscale, tiling,
-        static_cast<uint8>(drawFirst ? RENDER_QUEUE_SKIES_EARLY : RENDER_QUEUE_SKIES_LATE), bow,
-        xsegments, ysegments, groupName);
+    _setSkyPlane(enable, plane, materialName, gscale, tiling,
+                 drawFirst ? RENDER_QUEUE_SKIES_EARLY : RENDER_QUEUE_SKIES_LATE, bow, xsegments, ysegments,
+                 groupName);
 }
 
 void SceneManager::_setSkyPlane(bool enable, const Plane& plane, const String& materialName,
                                 Real gscale, Real tiling, uint8 renderQueue, Real bow,
                                 int xsegments, int ysegments, const String& groupName)
 {
-    mSkyRenderer.setSkyPlane(enable, plane, materialName, gscale, tiling, renderQueue, bow,
+    mSkyPlane.setSkyPlane(enable, plane, materialName, gscale, tiling, renderQueue, bow,
                              xsegments, ysegments, groupName);
 }
 
@@ -1556,16 +1553,15 @@ void SceneManager::setSkyBox(
                              const Quaternion& orientation,
                              const String& groupName)
 {
-    mSkyRenderer.setSkyBox(enable, materialName, distance,
-        static_cast<uint8>(drawFirst?RENDER_QUEUE_SKIES_EARLY: RENDER_QUEUE_SKIES_LATE), 
-        orientation, groupName);
+    _setSkyBox(enable, materialName, distance,
+               drawFirst ? RENDER_QUEUE_SKIES_EARLY : RENDER_QUEUE_SKIES_LATE, orientation, groupName);
 }
 
 void SceneManager::_setSkyBox(bool enable, const String& materialName, Real distance,
                               uint8 renderQueue, const Quaternion& orientation,
                               const String& groupName)
 {
-    mSkyRenderer.setSkyBox(enable, materialName, distance, renderQueue, orientation, groupName);
+    mSkyBox.setSkyBox(enable, materialName, distance, renderQueue, orientation, groupName);
 }
 
 //-----------------------------------------------------------------------
@@ -1580,9 +1576,9 @@ void SceneManager::setSkyDome(
                               int xsegments, int ysegments, int ySegmentsToKeep,
                               const String& groupName)
 {
-    mSkyRenderer.setSkyDome(enable, materialName, curvature, tiling, distance,
-        static_cast<uint8>(drawFirst?RENDER_QUEUE_SKIES_EARLY: RENDER_QUEUE_SKIES_LATE), 
-        orientation, xsegments, ysegments, ySegmentsToKeep, groupName);
+    _setSkyDome(enable, materialName, curvature, tiling, distance,
+                drawFirst ? RENDER_QUEUE_SKIES_EARLY : RENDER_QUEUE_SKIES_LATE, orientation, xsegments,
+                ysegments, ySegmentsToKeep, groupName);
 }
 
 void SceneManager::_setSkyDome(bool enable, const String& materialName, Real curvature, Real tiling,
@@ -1590,7 +1586,7 @@ void SceneManager::_setSkyDome(bool enable, const String& materialName, Real cur
                                int xsegments, int ysegments, int ysegments_keep,
                                const String& groupName)
 {
-    mSkyRenderer.setSkyDome(enable, materialName, curvature, tiling, distance, renderQueue,
+    mSkyDome.setSkyDome(enable, materialName, curvature, tiling, distance, renderQueue,
                             orientation, xsegments, ysegments, ysegments_keep, groupName);
 }
 

--- a/OgreMain/src/OgreSkyRenderer.cpp
+++ b/OgreMain/src/OgreSkyRenderer.cpp
@@ -33,31 +33,26 @@ THE SOFTWARE.
 #include "OgreViewport.h"
 
 namespace Ogre {
-SceneManager::SkyRenderer::SkyRenderer(SceneManager* owner) :
-        mSceneManager(owner),
-        mSkyPlaneEntity(0),
-        mSkyPlaneNode(0),
-        mSkyDomeNode(0),
-        mSkyBoxNode(0),
-        mSkyPlaneEnabled(false),
-        mSkyBoxEnabled(false),
-        mSkyDomeEnabled(false)
+SceneManager::SkyRenderer::SkyRenderer(SceneManager* owner)
+    : mSceneManager(owner), mSceneNode(0), mEnabled(false)
 {
-    // init sky
-    for (size_t i = 0; i < 5; ++i)
-    {
-        mSkyDomeEntity[i] = 0;
-    }
 }
 
-void SceneManager::SkyRenderer::clear()
+void SceneManager::SkyRenderer::nodeDestroyed(const Node*)
 {
     // Remove sky nodes since they've been deleted
-    mSkyBoxNode = mSkyPlaneNode = mSkyDomeNode = 0;
-    mSkyBoxEnabled = mSkyPlaneEnabled = mSkyDomeEnabled = false;
+    mSceneNode = 0;
+    mEnabled = false;
 }
 
-void SceneManager::SkyRenderer::setSkyPlane(
+void SceneManager::SkyRenderer::setEnabled(bool enable)
+{
+    if(enable == mEnabled) return;
+    mEnabled = enable;
+    enable ? mSceneManager->addListener(this) : mSceneManager->removeListener(this);
+}
+
+void SceneManager::SkyPlaneRenderer::setSkyPlane(
                                bool enable,
                                const Plane& plane,
                                const String& materialName,
@@ -84,8 +79,6 @@ void SceneManager::SkyRenderer::setSkyPlane(
         m->setDepthWriteEnabled(false);
         // Ensure loaded
         m->load();
-
-        mSkyPlaneRenderQueue = renderQueue;
 
         // Set up the plane
         MeshPtr planeMesh = MeshManager::getSingleton().getByName(meshName, groupName);
@@ -131,23 +124,25 @@ void SceneManager::SkyRenderer::setSkyPlane(
         mSkyPlaneEntity = static_cast<Entity*>(factory->createInstance(meshName, mSceneManager, &params));
         mSkyPlaneEntity->setMaterialName(materialName, groupName);
         mSkyPlaneEntity->setCastShadows(false);
+        mSkyPlaneEntity->setRenderQueueGroup(renderQueue);
 
         MovableObjectCollection* objectMap = mSceneManager->getMovableObjectCollection(EntityFactory::FACTORY_TYPE_NAME);
         objectMap->map[meshName] = mSkyPlaneEntity;
 
         // Create node and attach
-        if (!mSkyPlaneNode)
+        if (!mSceneNode)
         {
-            mSkyPlaneNode = mSceneManager->createSceneNode(meshName + "Node");
+            mSceneNode = mSceneManager->createSceneNode(meshName + "Node");
+            mSceneNode->setListener(this);
         }
         else
         {
-            mSkyPlaneNode->detachAllObjects();
+            mSceneNode->detachAllObjects();
         }
-        mSkyPlaneNode->attachObject(mSkyPlaneEntity);
+        mSceneNode->attachObject(mSkyPlaneEntity);
 
     }
-    mSkyPlaneEnabled = enable;
+    setEnabled(enable);
     mSkyPlaneGenParameters.skyPlaneBow = bow;
     mSkyPlaneGenParameters.skyPlaneScale = gscale;
     mSkyPlaneGenParameters.skyPlaneTiling = tiling;
@@ -155,7 +150,7 @@ void SceneManager::SkyRenderer::setSkyPlane(
     mSkyPlaneGenParameters.skyPlaneYSegments = ysegments;
 }
 
-void SceneManager::SkyRenderer::setSkyBox(
+void SceneManager::SkyBoxRenderer::setSkyBox(
                              bool enable,
                              const String& materialName,
                              Real distance,
@@ -190,12 +185,11 @@ void SceneManager::SkyRenderer::setSkyBox(
             m = MaterialManager::getSingleton().getDefaultSettings();
         }
 
-        mSkyBoxRenderQueue = renderQueue;
-
         // Create node
-        if (!mSkyBoxNode)
+        if (!mSceneNode)
         {
-            mSkyBoxNode = mSceneManager->createSceneNode("SkyBoxNode");
+            mSceneNode = mSceneManager->createSceneNode("SkyBoxNode");
+            mSceneNode->setListener(this);
         }
 
         // Create object
@@ -203,18 +197,18 @@ void SceneManager::SkyRenderer::setSkyBox(
         {
             mSkyBoxObj.reset(new ManualObject("SkyBox"));
             mSkyBoxObj->setCastShadows(false);
-            mSkyBoxNode->attachObject(mSkyBoxObj.get());
+            mSceneNode->attachObject(mSkyBoxObj.get());
         }
         else
         {
             if (!mSkyBoxObj->isAttached())
             {
-                mSkyBoxNode->attachObject(mSkyBoxObj.get());
+                mSceneNode->attachObject(mSkyBoxObj.get());
             }
             mSkyBoxObj->clear();
         }
 
-        mSkyBoxObj->setRenderQueueGroup(mSkyBoxRenderQueue);
+        mSkyBoxObj->setRenderQueueGroup(renderQueue);
         mSkyBoxObj->begin(materialName, RenderOperation::OT_TRIANGLE_LIST, groupName);
 
         // Set up the box (6 planes)
@@ -285,11 +279,11 @@ void SceneManager::SkyRenderer::setSkyBox(
 
         mSkyBoxObj->end();
     }
-    mSkyBoxEnabled = enable;
+    setEnabled(enable);
     mSkyBoxGenParameters.skyBoxDistance = distance;
 }
 
-void SceneManager::SkyRenderer::setSkyDome(
+void SceneManager::SkyDomeRenderer::setSkyDome(
                               bool enable,
                               const String& materialName,
                               Real curvature,
@@ -314,17 +308,15 @@ void SceneManager::SkyRenderer::setSkyDome(
         // Ensure loaded
         m->load();
 
-        //mSkyDomeDrawFirst = drawFirst;
-        mSkyDomeRenderQueue = renderQueue;
-
         // Create node
-        if (!mSkyDomeNode)
+        if (!mSceneNode)
         {
-            mSkyDomeNode = mSceneManager->createSceneNode("SkyDomeNode");
+            mSceneNode = mSceneManager->createSceneNode("SkyDomeNode");
+            mSceneNode->setListener(this);
         }
         else
         {
-            mSkyDomeNode->detachAllObjects();
+            mSceneNode->detachAllObjects();
         }
 
         // Set up the dome (5 planes)
@@ -352,16 +344,18 @@ void SceneManager::SkyRenderer::setSkyDome(
             mSkyDomeEntity[i] = static_cast<Entity*>(factory->createInstance(entName, mSceneManager, &params));
             mSkyDomeEntity[i]->setMaterialName(m->getName(), groupName);
             mSkyDomeEntity[i]->setCastShadows(false);
+            mSkyDomeEntity[i]->setRenderQueueGroup(renderQueue);
+
 
             MovableObjectCollection* objectMap = mSceneManager->getMovableObjectCollection(EntityFactory::FACTORY_TYPE_NAME);
             objectMap->map[entName] = mSkyDomeEntity[i];
 
             // Attach to node
-            mSkyDomeNode->attachObject(mSkyDomeEntity[i]);
+            mSceneNode->attachObject(mSkyDomeEntity[i]);
         } // for each plane
 
     }
-    mSkyDomeEnabled = enable;
+    setEnabled(enable);
     mSkyDomeGenParameters.skyDomeCurvature = curvature;
     mSkyDomeGenParameters.skyDomeDistance = distance;
     mSkyDomeGenParameters.skyDomeTiling = tiling;
@@ -370,7 +364,7 @@ void SceneManager::SkyRenderer::setSkyDome(
     mSkyDomeGenParameters.skyDomeYSegments_keep = ySegmentsToKeep;
 }
 
-MeshPtr SceneManager::SkyRenderer::createSkydomePlane(
+MeshPtr SceneManager::SkyDomeRenderer::createSkydomePlane(
                                        BoxPlane bp,
                                        Real curvature,
                                        Real tiling,
@@ -444,6 +438,32 @@ MeshPtr SceneManager::SkyRenderer::createSkydomePlane(
 
 }
 
+void SceneManager::SkyPlaneRenderer::_updateRenderQueue(RenderQueue* queue)
+{
+    if (mSkyPlaneEntity->isVisible())
+    {
+        mSkyPlaneEntity->_updateRenderQueue(queue);
+    }
+}
+
+void SceneManager::SkyBoxRenderer::_updateRenderQueue(RenderQueue* queue)
+{
+    if (mSkyBoxObj->isVisible())
+    {
+        mSkyBoxObj->_updateRenderQueue(queue);
+    }
+}
+
+void SceneManager::SkyDomeRenderer::_updateRenderQueue(RenderQueue* queue)
+{
+    for (uint plane = 0; plane < 5; ++plane)
+    {
+        if (!mSkyDomeEntity[plane]->isVisible()) continue;
+
+        mSkyDomeEntity[plane]->_updateRenderQueue(queue);
+    }
+}
+
 void SceneManager::SkyRenderer::postFindVisibleObjects(SceneManager* source, IlluminationRenderStage irs,
                                                        Viewport* vp)
 {
@@ -451,51 +471,12 @@ void SceneManager::SkyRenderer::postFindVisibleObjects(SceneManager* source, Ill
     if (!vp->getSkiesEnabled() || irs == IRS_RENDER_TO_TEXTURE)
         return;
 
-    Camera* cam = vp->getCamera();
-    RenderQueue* queue = source->getRenderQueue();
+    if(!mEnabled || !mSceneNode)
+        return;
 
     // Update nodes
     // Translate the box by the camera position (constant distance)
-    if (mSkyPlaneNode)
-    {
-        // The plane position relative to the camera has already been set up
-        mSkyPlaneNode->setPosition(cam->getDerivedPosition());
-    }
-
-    if (mSkyBoxNode)
-    {
-        mSkyBoxNode->setPosition(cam->getDerivedPosition());
-    }
-
-    if (mSkyDomeNode)
-    {
-        mSkyDomeNode->setPosition(cam->getDerivedPosition());
-    }
-
-    if (mSkyPlaneEnabled
-        && mSkyPlaneEntity && mSkyPlaneEntity->isVisible()
-        && mSkyPlaneEntity->getSubEntity(0) && mSkyPlaneEntity->getSubEntity(0)->isVisible())
-    {
-        queue->addRenderable(mSkyPlaneEntity->getSubEntity(0), mSkyPlaneRenderQueue, Renderable::DEFAULT_PRIORITY);
-    }
-
-    if (mSkyBoxEnabled
-        && mSkyBoxObj && mSkyBoxObj->isVisible())
-    {
-        mSkyBoxObj->_updateRenderQueue(queue);
-    }
-
-    if (mSkyDomeEnabled)
-    {
-        for (uint plane = 0; plane < 5; ++plane)
-        {
-            if (mSkyDomeEntity[plane] && mSkyDomeEntity[plane]->isVisible()
-                && mSkyDomeEntity[plane]->getSubEntity(0) && mSkyDomeEntity[plane]->getSubEntity(0)->isVisible())
-            {
-                queue->addRenderable(
-                    mSkyDomeEntity[plane]->getSubEntity(0), mSkyDomeRenderQueue, Renderable::DEFAULT_PRIORITY);
-            }
-        }
-    }
+    mSceneNode->setPosition(vp->getCamera()->getDerivedPosition());
+    _updateRenderQueue(source->getRenderQueue());
 }
 }

--- a/PlugIns/PCZSceneManager/src/OgrePCZSceneManager.cpp
+++ b/PlugIns/PCZSceneManager/src/OgrePCZSceneManager.cpp
@@ -445,8 +445,6 @@ namespace Ogre
         // Clear animations
         destroyAllAnimations();
 
-        mSkyRenderer.clear();
-
         // Clear render queue, empty completely
         if (mRenderQueue)
             mRenderQueue->clear(true);
@@ -489,17 +487,17 @@ namespace Ogre
     /* enable/disable sky rendering */
     void PCZSceneManager::enableSky(bool onoff)
     {
-        if (mSkyRenderer.mSkyBoxNode)
+        if (mSkyBox.mSceneNode)
         {
-            mSkyRenderer.mSkyBoxEnabled = onoff;
+            mSkyBox.setEnabled(onoff);
         }
-        else if (mSkyRenderer.mSkyDomeNode)
+        else if (mSkyDome.mSceneNode)
         {
-            mSkyRenderer.mSkyDomeEnabled = onoff;
+            mSkyDome.setEnabled(onoff);
         }
-        else if (mSkyRenderer.mSkyPlaneNode)
+        else if (mSkyPlane.mSceneNode)
         {
-            mSkyRenderer.mSkyPlaneEnabled = onoff;
+            mSkyPlane.setEnabled(onoff);
         }
     }
 
@@ -511,22 +509,22 @@ namespace Ogre
             // if no zone specified, use default zone
             zone = mDefaultZone;
         }
-        if (mSkyRenderer.mSkyBoxNode)
+        if (auto node = (PCZSceneNode*)mSkyBox.mSceneNode)
         {
-            ((PCZSceneNode*)mSkyRenderer.mSkyBoxNode)->setHomeZone(zone);
-            ((PCZSceneNode*)mSkyRenderer.mSkyBoxNode)->anchorToHomeZone(zone);
+            node->setHomeZone(zone);
+            node->anchorToHomeZone(zone);
             zone->setHasSky(true);
         }
-        if (mSkyRenderer.mSkyDomeNode)
+        if (auto node = (PCZSceneNode*)mSkyDome.mSceneNode)
         {
-            ((PCZSceneNode*)mSkyRenderer.mSkyDomeNode)->setHomeZone(zone);
-            ((PCZSceneNode*)mSkyRenderer.mSkyDomeNode)->anchorToHomeZone(zone);
+            node->setHomeZone(zone);
+            node->anchorToHomeZone(zone);
             zone->setHasSky(true);
         }
-        if (mSkyRenderer.mSkyPlaneNode)
+        if (auto node = (PCZSceneNode*)mSkyPlane.mSceneNode)
         {
-            ((PCZSceneNode*)mSkyRenderer.mSkyPlaneNode)->setHomeZone(zone);
-            ((PCZSceneNode*)mSkyRenderer.mSkyPlaneNode)->anchorToHomeZone(zone);
+            node->setHomeZone(zone);
+            node->anchorToHomeZone(zone);
             zone->setHasSky(true);
         }
         


### PR DESCRIPTION
dropped remaining Sky special casing, except in PCZSceneManager