### PR TITLE
Only include <sys/sysctl.h> for iOS

### DIFF
--- a/OgreMain/src/OgrePlatformInformation.cpp
+++ b/OgreMain/src/OgrePlatformInformation.cpp
@@ -36,7 +36,7 @@ THE SOFTWARE.
 
     #if OGRE_PLATFORM == OGRE_PLATFORM_ANDROID
         #include <cpu-features.h>
-    #elif OGRE_CPU == OGRE_CPU_ARM 
+    #elif OGRE_CPU == OGRE_CPU_ARM && OGRE_PLATFORM == OGRE_PLATFORM_APPLE_IOS
         #include <sys/sysctl.h>
         #if __MACH__
             #include <mach/machine.h>


### PR DESCRIPTION
This file includes `<sys/sysctl.h>` if the CPU is ARM, which breaks compilation with the upcoming glibc 2.32 release because that header has been removed. The header only seems to be needed for `sysctlbyname`, which is only used on iOS. Change the `#ifdef` to avoid including it when not needed.

This fixes a build failure in Fedora rawhide: https://bugzilla.redhat.com/show_bug.cgi?id=1841324