### PR TITLE
Fix crash in ApplicationContextSDL based applications that lose focus…

### DIFF
--- a/Components/Bites/include/OgreApplicationContextBase.h
+++ b/Components/Bites/include/OgreApplicationContextBase.h
@@ -129,6 +129,8 @@ namespace OgreBites
         virtual bool windowClosing(Ogre::RenderWindow* rw) { return true; }
         virtual void windowClosed(Ogre::RenderWindow* rw) {}
         virtual void windowFocusChange(Ogre::RenderWindow* rw) {}
+        virtual void windowFocusGained (Ogre::RenderWindow* rw) {}
+        virtual void windowFocusLost (Ogre::RenderWindow* rw) {}
 
         /**
          * inspect the event and call one of the corresponding functions on the registered InputListener


### PR DESCRIPTION
… either from window minimization or by session lock (i.e. user locks desktop or machine goes to sleep).

The application still needs to override the handlers to avoid redrawing ImGui.  Example:

virtual void windowFocusGained (Ogre::RenderWindow* rw)
{
    mFocus = true;
}

virtual void windowFocusLost (Ogre::RenderWindow* rw)
{
    mFocus = false;
}

bool app::frameStarted (const Ogre::FrameEvent& evt)
{
    OgreBites::ApplicationContext::frameStarted (evt);
    if (mFocus)
    {
        Ogre::ImGuiOverlay::NewFrame (evt);
    }
}