### PR TITLE
Main: Light - _deriveShadowFarClipDistance deprecate Camera* param

### DIFF
--- a/OgreMain/include/OgreLight.h
+++ b/OgreMain/include/OgreLight.h
@@ -469,10 +469,14 @@ namespace Ogre {
         */
         Real getShadowFarClipDistance() const { return mShadowFarClipDist; }
 
-        /** Derive a shadow camera far distance from either the light, or
-            from the main camera if the light doesn't have its own setting.
+        /** Derive a shadow camera far distance
         */
-        Real _deriveShadowFarClipDistance(const Camera* maincam) const;
+        Real _deriveShadowFarClipDistance() const;
+        /// @deprecated use _deriveShadowFarClipDistance()
+        OGRE_DEPRECATED Real _deriveShadowFarClipDistance(const Camera*) const
+        {
+            return _deriveShadowFarClipDistance();
+        }
 
         /// Set the camera which this light should be relative to, for camera-relative rendering
         void _setCameraRelative(Camera* cam);

--- a/OgreMain/src/OgreLight.cpp
+++ b/OgreMain/src/OgreLight.cpp
@@ -768,7 +768,7 @@ namespace Ogre {
             return maincam->getNearClipDistance();
     }
     //---------------------------------------------------------------------
-    Real Light::_deriveShadowFarClipDistance(const Camera* maincam) const
+    Real Light::_deriveShadowFarClipDistance() const
     {
         if (mShadowFarClipDist >= 0)
             return mShadowFarClipDist;

--- a/OgreMain/src/OgreShadowCameraSetup.cpp
+++ b/OgreMain/src/OgreShadowCameraSetup.cpp
@@ -50,7 +50,7 @@ namespace Ogre
         texCam->setCustomViewMatrix(false);
         texCam->setCustomProjectionMatrix(false);
         texCam->setNearClipDistance(light->_deriveShadowNearClipDistance(cam));
-        texCam->setFarClipDistance(light->_deriveShadowFarClipDistance(cam));
+        texCam->setFarClipDistance(light->_deriveShadowFarClipDistance());
 
         // get the shadow frustum's far distance
         Real shadowDist = light->getShadowFarDistance();

--- a/OgreMain/src/OgreShadowCameraSetupFocused.cpp
+++ b/OgreMain/src/OgreShadowCameraSetupFocused.cpp
@@ -136,7 +136,7 @@ namespace Ogre
                 mTempFrustum->setFOVy(Degree(120));
 
                 mTempFrustum->setNearClipDistance(light._deriveShadowNearClipDistance(&cam));
-                mTempFrustum->setFarClipDistance(light._deriveShadowFarClipDistance(&cam));
+                mTempFrustum->setFarClipDistance(light._deriveShadowFarClipDistance());
 
                 *out_proj = mTempFrustum->getProjectionMatrix();
             }
@@ -149,7 +149,7 @@ namespace Ogre
                 out_cam->getParentSceneNode()->setPosition(light.getDerivedPosition());
                 out_cam->setFOVy(Degree(120));
                 out_cam->setNearClipDistance(light._deriveShadowNearClipDistance(&cam));
-                out_cam->setFarClipDistance(light._deriveShadowFarClipDistance(&cam));
+                out_cam->setFarClipDistance(light._deriveShadowFarClipDistance());
             }
         }
         else if (light.getType() == Light::LT_SPOTLIGHT)
@@ -169,7 +169,7 @@ namespace Ogre
                 mTempFrustum->setFOVy(Ogre::Math::Clamp<Radian>(light.getSpotlightOuterAngle() * 1.2, Radian(0), Radian(Math::PI/2.0f)));
 
                 mTempFrustum->setNearClipDistance(light._deriveShadowNearClipDistance(&cam));
-                mTempFrustum->setFarClipDistance(light._deriveShadowFarClipDistance(&cam));
+                mTempFrustum->setFarClipDistance(light._deriveShadowFarClipDistance());
 
                 *out_proj = mTempFrustum->getProjectionMatrix();
             }
@@ -182,7 +182,7 @@ namespace Ogre
                 out_cam->getParentSceneNode()->setPosition(light.getDerivedPosition());
                 out_cam->setFOVy(Ogre::Math::Clamp<Radian>(light.getSpotlightOuterAngle() * 1.2, Radian(0), Radian(Math::PI/2.0f)));
                 out_cam->setNearClipDistance(light._deriveShadowNearClipDistance(&cam));
-                out_cam->setFarClipDistance(light._deriveShadowFarClipDistance(&cam));
+                out_cam->setFarClipDistance(light._deriveShadowFarClipDistance());
             }
         }
     }
@@ -405,7 +405,7 @@ namespace Ogre
         mLightFrustumCameraCalculated = false;
 
         texCam->setNearClipDistance(light->_deriveShadowNearClipDistance(cam));
-        texCam->setFarClipDistance(light->_deriveShadowFarClipDistance(cam));
+        texCam->setFarClipDistance(light->_deriveShadowFarClipDistance());
 
         // calculate standard shadow mapping matrix
         Affine3 LView; Matrix4 LProj;


### PR DESCRIPTION
unused, because it is allowed to return zero