### PR TITLE
Main: pass native shader version to shaders as e.g. OGRE_HLSL=4

### DIFF
--- a/Docs/src/high-level-programs.md
+++ b/Docs/src/high-level-programs.md
@@ -33,7 +33,7 @@ preprocessor_defines CLEVERTECHNIQUE,NUMTHINGS=2
 This way you can use the same source code but still include small variations, each one defined as a different %Ogre program name but based on the same source code.
 
 Furthermore, %Ogre automatically sets the following defines for convenience:
-- The current shading language: e.g. @c OGRE_GLSL, @c OGRE_HLSL
+- The current shading language and native version: e.g. @c OGRE_GLSL=120, @c OGRE_HLSL=3
 - The current shader type: e.g. @c OGRE_VERTEX_SHADER, @c OGRE_FRAGMENT_SHADER
 - Whether @ref reversed-depth is enabled: @c OGRE_REVERSED_Z
 

--- a/Media/ShadowVolume/HLSL_SM4Support.hlsl
+++ b/Media/ShadowVolume/HLSL_SM4Support.hlsl
@@ -2,7 +2,7 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at https://www.ogre3d.org/licensing.
 
-#ifdef SHADER_MODEL_4
+#if OGRE_HLSL >= 4
 
 // SM4 separates sampler into Texture and SamplerState
 

--- a/OgreMain/src/OgreHighLevelGpuProgram.cpp
+++ b/OgreMain/src/OgreHighLevelGpuProgram.cpp
@@ -197,17 +197,19 @@ namespace Ogre
     {
         if(!defines.empty()) defines += ",";
 
+        auto renderSystem = Root::getSingleton().getRenderSystem();
+
         // OGRE_HLSL, OGRE_GLSL etc.
         String tmp = getLanguage();
         StringUtil::toUpperCase(tmp);
-        defines += "OGRE_"+tmp;
+        auto ver = renderSystem ? renderSystem->getNativeShadingLanguageVersion() : 0;
+        defines += StringUtil::format("OGRE_%s=%d", tmp.c_str(), ver);
 
         // OGRE_VERTEX_SHADER, OGRE_FRAGMENT_SHADER
         tmp = GpuProgram::getProgramTypeName(getType());
         StringUtil::toUpperCase(tmp);
         defines += ",OGRE_"+tmp+"_SHADER";
 
-        auto renderSystem = Root::getSingleton().getRenderSystem();
         if(renderSystem && renderSystem->isReverseDepthBufferEnabled())
             defines += ",OGRE_REVERSED_Z";
 

--- a/RenderSystems/Direct3D11/src/OgreD3D11RenderSystem.cpp
+++ b/RenderSystems/Direct3D11/src/OgreD3D11RenderSystem.cpp
@@ -806,6 +806,8 @@ namespace Ogre
 				mHLSLProgramFactory = new D3D11HLSLProgramFactory(mDevice);
 			mRealCapabilities = createRenderSystemCapabilities();
 
+            mNativeShadingLanguageVersion = 4;
+
 			// if we are using custom capabilities, then 
 			// mCurrentCapabilities has already been loaded
 			if (!mUseCustomCapabilities)

--- a/RenderSystems/Direct3D9/include/OgreD3D9RenderSystem.h
+++ b/RenderSystems/Direct3D9/include/OgreD3D9RenderSystem.h
@@ -161,7 +161,7 @@ namespace Ogre
         virtual void initialiseFromRenderSystemCapabilities(RenderSystemCapabilities* caps, RenderTarget* primary);
 
 
-        void convertVertexShaderCaps(RenderSystemCapabilities* rsc) const;
+        void convertVertexShaderCaps(RenderSystemCapabilities* rsc);
         void convertPixelShaderCaps(RenderSystemCapabilities* rsc) const;
         bool checkVertexTextureFormats(D3D9RenderWindow* renderWindow) const;
         void detachRenderTargetImpl(const String& name);

--- a/RenderSystems/Direct3D9/src/OgreD3D9RenderSystem.cpp
+++ b/RenderSystems/Direct3D9/src/OgreD3D9RenderSystem.cpp
@@ -1274,7 +1274,7 @@ namespace Ogre
         return rsc;
     }
     //---------------------------------------------------------------------
-    void D3D9RenderSystem::convertVertexShaderCaps(RenderSystemCapabilities* rsc) const
+    void D3D9RenderSystem::convertVertexShaderCaps(RenderSystemCapabilities* rsc)
     {
         ushort major = 0xFF;
         ushort minor = 0xFF;
@@ -1370,6 +1370,8 @@ namespace Ogre
             rsc->addShaderProfile("vs_1_1");
             rsc->setCapability(RSC_VERTEX_PROGRAM);
         }
+
+        mNativeShadingLanguageVersion = major;
     }
     //---------------------------------------------------------------------
     void D3D9RenderSystem::convertPixelShaderCaps(RenderSystemCapabilities* rsc) const


### PR DESCRIPTION
to get rid of namespace polluting SHADER_MODEL_4 define