### PR TITLE
Plugins: Assimp - blacklist mdc file format

### DIFF
--- a/PlugIns/Assimp/src/AssimpLoader.cpp
+++ b/PlugIns/Assimp/src/AssimpLoader.cpp
@@ -1239,7 +1239,7 @@ struct AssimpCodec : public Codec
         Assimp::Importer tmp;
         tmp.GetExtensionList(extensions);
 
-        String blacklist[] = {"mesh", "mesh.xml", "raw"};
+        String blacklist[] = {"mesh", "mesh.xml", "raw", "mdc"};
         auto stream = LogManager::getSingleton().stream();
         stream << "Supported formats:";
         // Register codecs


### PR DESCRIPTION
also registered by FreeImage for "Mintola Digital Camera". FreeImage was
first.