### PR TITLE
Improve config-path resolution

### DIFF
--- a/Components/Bites/src/OgreApplicationContextBase.cpp
+++ b/Components/Bites/src/OgreApplicationContextBase.cpp
@@ -28,6 +28,13 @@ ApplicationContextBase::ApplicationContextBase(const Ogre::String& appName)
 {
     mAppName = appName;
     mFSLayer = new Ogre::FileSystemLayer(mAppName);
+
+    if (char* val = getenv("OGRE_CONFIG_DIR"))
+    {
+        Ogre::String configDir = Ogre::StringUtil::standardisePath(val);
+        mFSLayer->setConfigPaths({ configDir });
+    }
+
     mRoot = NULL;
     mOverlaySystem = NULL;
     mFirstRun = true;

--- a/Docs/src/tutorials/setup.md
+++ b/Docs/src/tutorials/setup.md
@@ -85,7 +85,7 @@ Plugin=RenderSystem_GL
 
 We have the three DirectX systems commented out, and an active line for OpenGL. On a windows system, you may have this reversed. You can see why it might be helpful not to delete unused lines, because then you have to try and remember whether it was RenderSystem_OpenGL or RenderSystem_GL.
 
-You can also decide where %Ogre looks for plugins by changing the @c PluginFolder variable. You can use both absolute and relative paths. Additionally, you can use the @c OGRE_PLUGIN_DIR environment variable to override the value of @c PluginFolder.
+You can also decide where %Ogre looks for plugins by changing the @c PluginFolder variable. You can use both absolute and relative paths. Relative paths are resolved relative to the location of @c plugins.cfg. Additionally, you can use the @c OGRE_PLUGIN_DIR environment variable to override the value of @c PluginFolder.
 
 For example, if you have built %Ogre from source on a linux machine, then you will need a line like this at the beginning of your file:
 
@@ -99,7 +99,7 @@ By default, %Ogre would have been looking in the same directory where the @c plu
 
 ### resources.cfg
 
-This file contains a list of the directories %Ogre will use to search for resources. Resources include scripts, meshes, textures, GUI layouts, and others. You can also use both absolute and relative paths in this file, but you still cannot use environment variables. %Ogre will **not** search subdirectories, so you have to manually enter them. Here is an example:
+This file contains a list of the directories %Ogre will use to search for resources. Resources include scripts, meshes, textures, GUI layouts, and others. You can also use both absolute and relative paths in this file, but you still cannot use environment variables. Relative paths are resolved relative to the location of @c resources.cfg. %Ogre will **not** search subdirectories, so you have to manually enter them. Here is an example:
 
 ```
 [General]

--- a/Docs/src/tutorials/setup.md
+++ b/Docs/src/tutorials/setup.md
@@ -68,7 +68,7 @@ On Windows however, you will have to either add the `sdk/bin` folder to `PATH` o
 
 Ogre uses several configuration files (\*.cfg). They control things like which plugins are loaded and where your application will search for resource files. We will briefly introduce you to each of these files. You'll slowly read more about them as you progress through the tutorials as well.
 
-You can place these files the same directory as your executable or in any of [the default lookup paths described here](@ref Ogre::FileSystemLayer::getConfigFilePath).
+You can place these files the same directory as your executable or in any of [the default lookup paths described here](@ref Ogre::FileSystemLayer::getConfigFilePath). Alternatively you can set the @c OGRE_CONFIG_DIR environment variable for the configuration file location. This overrides the step "executable path" in the default lookup order.
 
 @attention %Ogre must find @c plugins.cfg and @c resources.cfg to function properly. Later tutorials will cover more of their use.
 


### PR DESCRIPTION
To allow loading config files (e.g. plugins.cfg, resources.cfg) from
arbitrary locations. Up to now it was only possible to load them from
- the CWD,
- the writable path (i.e. somewhere in HOME),
- the location Ogre was originally installed to.

Also resolve relative paths in `resources.cfg` relative to the config-file location.

This commit is especially useful, if you need to start your
application from anywhere else than the location of the config-files.