### PR TITLE
Fixes issue preventing use of latest emscripten versions

### DIFF
--- a/RenderSystems/GLSupport/src/EGL/Emscripten/OgreEmscriptenEGLWindow.cpp
+++ b/RenderSystems/GLSupport/src/EGL/Emscripten/OgreEmscriptenEGLWindow.cpp
@@ -52,7 +52,7 @@ namespace Ogre {
           mCSAA(0)
     {
         // already handled by resize
-        //emscripten_set_fullscreenchange_callback(NULL, (void*)this, 1, &EmscriptenEGLWindow::fullscreenCallback);
+        emscripten_set_fullscreenchange_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, (void*)this, 1, &EmscriptenEGLWindow::fullscreenCallback);
         emscripten_set_webglcontextlost_callback("#canvas", (void*)this, 1, &EmscriptenEGLWindow::contextLostCallback);
         emscripten_set_webglcontextrestored_callback("#canvas", (void*)this, 1, &EmscriptenEGLWindow::contextRestoredCallback);
         emscripten_set_resize_callback("#canvas", (void*)this, 1, &EmscriptenEGLWindow::canvasWindowResized);
@@ -91,6 +91,9 @@ namespace Ogre {
         
 
         EMSCRIPTEN_RESULT result = emscripten_set_canvas_element_size(mCanvasSelector.c_str(), width, height);
+        // This is a workaroud for issue: https://github.com/emscripten-core/emscripten/issues/3283.
+        // The setTimeout of 0 will ensure that this code is runs on the next JSEventLoop.
+        EM_ASM(setTimeout(function(){var canvas = document.getElementById('canvas'); canvas.width = $0; canvas.height = $1;}, 0), width, height);
         
         if(result < 0)
         {

--- a/RenderSystems/GLSupport/src/EGL/Emscripten/OgreEmscriptenEGLWindow.cpp
+++ b/RenderSystems/GLSupport/src/EGL/Emscripten/OgreEmscriptenEGLWindow.cpp
@@ -53,17 +53,17 @@ namespace Ogre {
     {
         // already handled by resize
         //emscripten_set_fullscreenchange_callback(NULL, (void*)this, 1, &EmscriptenEGLWindow::fullscreenCallback);
-        emscripten_set_webglcontextlost_callback(NULL, (void*)this, 1, &EmscriptenEGLWindow::contextLostCallback);
-        emscripten_set_webglcontextrestored_callback(NULL, (void*)this, 1, &EmscriptenEGLWindow::contextRestoredCallback);
-        emscripten_set_resize_callback(NULL, (void*)this, 1, &EmscriptenEGLWindow::canvasWindowResized);
+        emscripten_set_webglcontextlost_callback("#canvas", (void*)this, 1, &EmscriptenEGLWindow::contextLostCallback);
+        emscripten_set_webglcontextrestored_callback("#canvas", (void*)this, 1, &EmscriptenEGLWindow::contextRestoredCallback);
+        emscripten_set_resize_callback("#canvas", (void*)this, 1, &EmscriptenEGLWindow::canvasWindowResized);
     }
 
     EmscriptenEGLWindow::~EmscriptenEGLWindow()
     {
-        emscripten_set_fullscreenchange_callback(NULL, NULL, 0, NULL);
-        emscripten_set_resize_callback(NULL, NULL, 0, NULL);
-        emscripten_set_webglcontextlost_callback(NULL, NULL, 0, NULL);
-        emscripten_set_webglcontextrestored_callback(NULL, NULL, 0, NULL);
+        emscripten_set_fullscreenchange_callback("#canvas", NULL, 0, NULL);
+        emscripten_set_resize_callback("#canvas", NULL, 0, NULL);
+        emscripten_set_webglcontextlost_callback("#canvas", NULL, 0, NULL);
+        emscripten_set_webglcontextrestored_callback("#canvas", NULL, 0, NULL);
     }
 
     void EmscriptenEGLWindow::getLeftAndTopFromNativeWindow( int & left, int & top, uint width, uint height )

--- a/Samples/Emscripten/CMakeLists.txt
+++ b/Samples/Emscripten/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(MEDIA_DIR ${CMAKE_BINARY_DIR}/bin/media/)
 
 set(CMAKE_EXECUTABLE_SUFFIX ".html")
-set(CMAKE_EXE_LINKER_FLAGS "--preload-file ${MEDIA_DIR}/@. -s BINARYEN_TRAP_MODE=clamp -s EXPORTED_FUNCTIONS=\"['_passAssetAsArrayBuffer', '_clearScene', '_main']\" -s USE_SDL=2")
+set(CMAKE_EXE_LINKER_FLAGS "--preload-file ${MEDIA_DIR}/@. -s EXPORTED_FUNCTIONS=\"['_passAssetAsArrayBuffer', '_clearScene', '_main']\" -s USE_SDL=2")
 
 add_definitions(-s USE_SDL=2)
 

--- a/Samples/Emscripten/CMakeLists.txt
+++ b/Samples/Emscripten/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(MEDIA_DIR ${CMAKE_BINARY_DIR}/bin/media/)
 
 set(CMAKE_EXECUTABLE_SUFFIX ".html")
-set(CMAKE_EXE_LINKER_FLAGS "--preload-file ${MEDIA_DIR}/@. -s EXPORTED_FUNCTIONS=\"['_passAssetAsArrayBuffer', '_clearScene', '_main']\" -s USE_SDL=2")
+set(CMAKE_EXE_LINKER_FLAGS "--preload-file ${MEDIA_DIR}/@. -s MIN_WEBGL_VERSION=2 -s MAX_WEBGL_VERSION=2 -s EXPORTED_FUNCTIONS=\"[ '_passAssetAsArrayBuffer', '_clearScene', '_main']\" -s USE_SDL=2")
 
 add_definitions(-s USE_SDL=2)
 

--- a/Samples/Emscripten/CMakeLists.txt
+++ b/Samples/Emscripten/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(MEDIA_DIR ${CMAKE_BINARY_DIR}/bin/media/)
 
 set(CMAKE_EXECUTABLE_SUFFIX ".html")
-set(CMAKE_EXE_LINKER_FLAGS "--preload-file ${MEDIA_DIR}/@. -s MIN_WEBGL_VERSION=2 -s MAX_WEBGL_VERSION=2 -s EXPORTED_FUNCTIONS=\"[ '_passAssetAsArrayBuffer', '_clearScene', '_main']\" -s USE_SDL=2")
+set(CMAKE_EXE_LINKER_FLAGS "--preload-file ${MEDIA_DIR}/@. -s EXPORTED_FUNCTIONS=\"[ '_passAssetAsArrayBuffer', '_clearScene', '_main']\" -s USE_SDL=2")
 
 add_definitions(-s USE_SDL=2)
 


### PR DESCRIPTION
fixes #1697 
fixes #1686
fixes #1289
These changes enable the use the latest versions of emscripten. Latest version of emscripten has several fixes including handling of fullscreen see [changelog](https://github.com/emscripten-core/emscripten/blob/master/ChangeLog.md) not to mention it now uses LLVM backend.[ emscripten-llvm-wasm](https://v8.dev/blog/emscripten-llvm-wasm) which has several benefits.