### PR TITLE
SWIG: Overlay - add workaround for setting DisplayString parameters

### DIFF
--- a/Components/Overlay/include/OgreOverlay.i
+++ b/Components/Overlay/include/OgreOverlay.i
@@ -41,6 +41,10 @@
 %csmethodmodifiers Ogre::OverlaySystem::eventOccurred "public";
 #endif
 
+// DisplayString is implicitly constructable from String
+// this breaks when using get*, will fix this by switching to String with 1.13
+#define DisplayString String
+
 %include "OgreOverlayPrerequisites.h"
 SHARED_PTR(Font);
 %include "OgreFont.h"


### PR DESCRIPTION
getting still broken

fixes #1663