### PR TITLE
Main: make Image class more versatile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,11 @@ addons:
     - mono-mcs # compile C# bindings
     - qtbase5-dev # QtOgreBites
     - libassimp-dev
-before_script:
-    - if [ "$TRAVIS_OS_NAME" =   "osx" ]; then brew update && brew install libzzip sdl2 pugixml ; fi
+  homebrew:
+    packages:
+    - libzzip
+    - sdl2
+    - pugixml
 osx_image: xcode11.3
 env:
     - TEST=TRUE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ if (APPLE AND NOT ANDROID)
   add_definitions(-D__ASSERT_MACROS_DEFINE_VERSIONS_WITHOUT_UNDERSCORES=0)
 endif ()
 
-project(OGRE VERSION 1.12.9)
+project(OGRE VERSION 1.12.10)
 
 # extra version info
 set(OGRE_VERSION_SUFFIX "")

--- a/OgreMain/include/OgreImage.h
+++ b/OgreMain/include/OgreImage.h
@@ -62,10 +62,13 @@ namespace Ogre {
     friend class ImageCodec;
     public:
         /** Standard constructor.
-        */
-        Image();
+         *
+         * allocates a buffer of given size if buffer pointer is NULL.
+         */
+        Image(PixelFormat format = PF_UNKNOWN, uint32 width = 0, uint32 height = 0, uint32 depth = 1,
+              uchar* buffer = NULL, bool autoDelete = true);
         /** Copy-constructor - copies all the data from the target image.
-        */
+         */
         Image( const Image &img );
 
         /** Standard destructor.
@@ -75,6 +78,13 @@ namespace Ogre {
         /** Assignment operator - copies all the data from the target image.
         */
         Image & operator = ( const Image & img );
+
+        /**
+         * sets all pixels to the specified colour
+         *
+         * format conversion is performed as needed
+         */
+        void setTo(const ColourValue& col);
 
         /** Flips (mirrors) the image around the Y-axis. 
             @remarks
@@ -301,21 +311,25 @@ namespace Ogre {
         */
         DataStreamPtr encode(const String& formatextension);
 
-        /** Returns a pointer to the internal image buffer.
-        @remarks
-            Be careful with this method. You will almost certainly
-            prefer to use getPixelBox, especially with complex images
-            which include many faces or custom mipmaps.
-        */
-        uchar* getData(void);
+        /** Returns a pointer to the internal image buffer at the specified pixel location.
 
-        /** Returns a const pointer to the internal image buffer.
-        @remarks
             Be careful with this method. You will almost certainly
             prefer to use getPixelBox, especially with complex images
             which include many faces or custom mipmaps.
         */
-        const uchar * getData() const;       
+        uchar* getData(uint32 x = 0, uint32 y = 0, uint32 z = 0)
+        {
+            assert((!mBuffer && (x + y + z) == 0) || (x < mWidth && y < mHeight && z < mDepth));
+            return mBuffer + mPixelSize * (z * mWidth * mHeight + mWidth * y + x);
+        }
+
+        /// @overload
+        const uchar* getData(uint32 x = 0, uint32 y = 0, uint32 z = 0) const
+        {
+            assert(mBuffer);
+            assert(x < mWidth && y < mHeight && z < mDepth);
+            return mBuffer + mPixelSize * (z * mWidth * mHeight + mWidth * y + x);
+        }
 
         /** Returns the size of the data buffer in bytes
         */

--- a/OgreMain/src/OgreRenderTarget.cpp
+++ b/OgreMain/src/OgreRenderTarget.cpp
@@ -509,16 +509,12 @@ namespace Ogre {
     //-----------------------------------------------------------------------
     void RenderTarget::writeContentsToFile(const String& filename)
     {
-        PixelFormat pf = suggestPixelFormat();
+        Image img(suggestPixelFormat(), mWidth, mHeight);
 
-        uchar *data = OGRE_ALLOC_T(uchar, mWidth * mHeight * PixelUtil::getNumElemBytes(pf), MEMCATEGORY_RENDERSYS);
-        PixelBox pb(mWidth, mHeight, 1, pf, data);
-
+        PixelBox pb = img.getPixelBox();
         copyContentsToMemory(pb, pb);
 
-        Image().loadDynamicImage(data, mWidth, mHeight, 1, pf, false, 1, 0).save(filename);
-
-        OGRE_FREE(data, MEMCATEGORY_RENDERSYS);
+        img.save(filename);
     }
     //-----------------------------------------------------------------------
     void RenderTarget::_notifyCameraRemoved(const Camera* cam)

--- a/OgreMain/src/OgreTexture.cpp
+++ b/OgreMain/src/OgreTexture.cpp
@@ -310,14 +310,12 @@ namespace Ogre {
                 if(mGamma != 1.0f) {
                     // Apply gamma correction
                     // Do not overwrite original image but do gamma correction in temporary buffer
-                    MemoryDataStream buf(src.getConsecutiveSize());
-
-                    PixelBox corrected = PixelBox(src.getWidth(), src.getHeight(), src.getDepth(), src.format, buf.getPtr());
+                    Image tmp(src.format, src.getWidth(), getHeight(), src.getDepth());
+                    PixelBox corrected = tmp.getPixelBox();
                     PixelUtil::bulkPixelConversion(src, corrected);
-                    
-                    Image::applyGamma(corrected.data, mGamma, corrected.getConsecutiveSize(),
-                        static_cast<uchar>(PixelUtil::getNumElemBits(src.format)));
-    
+
+                    Image::applyGamma(corrected.data, mGamma, tmp.getSize(), tmp.getBPP());
+
                     // Destination: entire texture. blitFromMemory does the scaling to
                     // a power of two for us when needed
                     buffer->blitFromMemory(corrected, dst);

--- a/OgreMain/src/OgreTextureManager.cpp
+++ b/OgreMain/src/OgreTextureManager.cpp
@@ -344,9 +344,7 @@ namespace Ogre {
             return mWarningTexture;
 
         // Generate warning texture
-        PixelBox pixels(8, 8, 1, PF_R5G6B5);
-        DataStreamPtr data(new MemoryDataStream(pixels.getConsecutiveSize()));
-        pixels.data = static_pointer_cast<MemoryDataStream>(data)->getPtr();
+        Image pixels(PF_R5G6B5, 8, 8);
 
         // Yellow/black stripes
         const ColourValue black(0, 0, 0), yellow(1, 1, 0);
@@ -358,8 +356,7 @@ namespace Ogre {
             }
         }
 
-        mWarningTexture = loadRawData("Warning", ResourceGroupManager::INTERNAL_RESOURCE_GROUP_NAME,
-                                      data, pixels.getWidth(), pixels.getHeight(), pixels.format);
+        mWarningTexture = loadImage("Warning", RGN_INTERNAL, pixels);
 
         return mWarningTexture;
     }


### PR DESCRIPTION
-  allow allocating empty memory upon construction as a safe malloc replacement
- expose loadDynamicImage as a constructor
- implement setting whole Image to a specific colour