### PR TITLE
Substitute postfix iterator increment with prefix iterator increment

### DIFF
--- a/Components/Bites/src/OgreApplicationContextBase.cpp
+++ b/Components/Bites/src/OgreApplicationContextBase.cpp
@@ -428,7 +428,7 @@ void ApplicationContextBase::locateResources()
         Ogre::ConfigFile::SettingsMultiMap::const_iterator i;
 
         // go through all resource paths
-        for (i = settings.begin(); i != settings.end(); i++)
+        for (i = settings.begin(); i != settings.end(); ++i)
         {
             type = i->first;
             arch = i->second;
@@ -541,7 +541,7 @@ void ApplicationContextBase::reconfigure(const Ogre::String &renderer, Ogre::Nam
     Ogre::RenderSystem* rs = mRoot->getRenderSystemByName(renderer);
 
     // set all given render system options
-    for (Ogre::NameValuePairList::iterator it = options.begin(); it != options.end(); it++)
+    for (Ogre::NameValuePairList::iterator it = options.begin(); it != options.end(); ++it)
     {
         rs->setConfigOption(it->first, it->second);
 

--- a/Components/Bites/src/OgreGLXConfigDialog.cpp
+++ b/Components/Bites/src/OgreGLXConfigDialog.cpp
@@ -278,7 +278,7 @@ bool GLXConfigurator::CreateWindow() {
 
     const RenderSystemList& renderers = Root::getSingleton().getAvailableRenderers();
     for (RenderSystemList::const_iterator pRend = renderers.begin();
-                    pRend != renderers.end(); pRend++) {
+                    pRend != renderers.end(); ++pRend) {
         // Create callback data
         mRendererCallbackData.push_back(RendererCallbackData(this, *pRend, mb1));
 
@@ -400,7 +400,7 @@ void GLXConfigurator::SetRenderer(RenderSystem *r) {
     mRenderer = r;
 
     // Destroy each widget of GUI of previously selected renderer
-    for(std::list<Widget>::iterator i=mRenderOptionWidgets.begin(); i!=mRenderOptionWidgets.end(); i++)
+    for(std::list<Widget>::iterator i=mRenderOptionWidgets.begin(); i!=mRenderOptionWidgets.end(); ++i)
         XtDestroyWidget(*i);
     mRenderOptionWidgets.clear();
     mConfigCallbackData.back();
@@ -411,7 +411,7 @@ void GLXConfigurator::SetRenderer(RenderSystem *r) {
     ConfigOptionMap options = mRenderer->getConfigOptions();
     // Process each option and create an optionmenu widget for it
     for (ConfigOptionMap::iterator it = options.begin();
-                    it != options.end(); it++) {
+                    it != options.end(); ++it) {
         // if the config option does not have any possible value, then skip it.
         // if we create a popup with zero entries, it will crash when you click
         // on it.
@@ -450,7 +450,7 @@ void GLXConfigurator::SetRenderer(RenderSystem *r) {
         // Process each choice
         StringVector::iterator opt_it;
         for (opt_it = it->second.possibleValues.begin();
-                        opt_it != it->second.possibleValues.end(); opt_it++) {
+                        opt_it != it->second.possibleValues.end(); ++opt_it) {
             // Create callback data
             mConfigCallbackData.push_back(ConfigCallbackData(this, it->second.name, *opt_it, mb1));
 

--- a/Components/Bites/src/OgreTrays.cpp
+++ b/Components/Bites/src/OgreTrays.cpp
@@ -426,7 +426,7 @@ void SelectMenu::copyItemsFrom(SelectMenu *other){
     const Ogre::StringVector& items = other->getItems();
     Ogre::StringVector::const_iterator it, itEnd;
     itEnd = items.end();
-    for(it=items.begin(); it != itEnd; it++){
+    for(it=items.begin(); it != itEnd; ++it){
         this->addItem(*it);
     }
 }

--- a/Components/HLMS/src/OgreHlmsManager.cpp
+++ b/Components/HLMS/src/OgreHlmsManager.cpp
@@ -55,7 +55,7 @@ namespace Ogre
 		// set all materials to dirty (IsUpToDate = false)
 		RenderableVector::iterator rendIt = mBindedRenderables.begin();
 		RenderableVector::iterator rendItEnd = mBindedRenderables.end();
-		for (; rendIt != rendItEnd; rendIt++)
+		for (; rendIt != rendItEnd; ++rendIt)
 		{
 			Renderable* rend = *rendIt;
 
@@ -69,7 +69,7 @@ namespace Ogre
 
 			HlmsMatBindingMap::iterator bindingIt = hlmsMatBindingMap->begin();
 			HlmsMatBindingMap::iterator bindingItEnd = hlmsMatBindingMap->end();
-			for (; bindingIt != bindingItEnd; bindingIt++)
+			for (; bindingIt != bindingItEnd; ++bindingIt)
 			{
 				bindingIt->second->IsDirty = true;
 			}
@@ -78,7 +78,7 @@ namespace Ogre
 		// itreate over all binded renderables
 		rendIt = mBindedRenderables.begin();
 		rendItEnd = mBindedRenderables.end();
-		for (; rendIt != rendItEnd; rendIt++)
+		for (; rendIt != rendItEnd; ++rendIt)
 		{
 			Renderable* rend = *rendIt;
 
@@ -92,7 +92,7 @@ namespace Ogre
 
 			HlmsMatBindingMap::iterator bindingIt = hlmsMatBindingMap->begin();
 			HlmsMatBindingMap::iterator bindingItEnd = hlmsMatBindingMap->end();
-			for (; bindingIt != bindingItEnd; bindingIt++)
+			for (; bindingIt != bindingItEnd; ++bindingIt)
 			{
 				String passName = bindingIt->first;
 				HlmsMaterialBase* hlmsMaterial = bindingIt->second;
@@ -232,7 +232,7 @@ namespace Ogre
 	{
 		RenderableVector::iterator bindingIt = mBindedRenderables.begin();
 		RenderableVector::iterator bindingItEnd = mBindedRenderables.end();
-		for (; bindingIt != bindingItEnd; bindingIt++)
+		for (; bindingIt != bindingItEnd; ++bindingIt)
 		{
 			Renderable* rend = *bindingIt;
 			HlmsMatBindingMap* hlmsMatMap = any_cast<HlmsMatBindingMap*>(rend->getUserObjectBindings().getUserAny(HLMS_KEY));

--- a/Components/HLMS/src/OgreHlmsShaderPiecesManager.cpp
+++ b/Components/HLMS/src/OgreHlmsShaderPiecesManager.cpp
@@ -51,7 +51,7 @@ namespace Ogre
 			FileInfoList::iterator it = list->begin();
 			FileInfoList::iterator end = list->end();
 
-			for (; it != end; it++)
+			for (; it != end; ++it)
 			{
 				String name, ext;
 				StringUtil::splitBaseFilename(it->filename, name, ext);
@@ -90,7 +90,7 @@ namespace Ogre
             StringVector::iterator it = pieceFileNamesIt->second.begin();
             StringVector::iterator end = pieceFileNamesIt->second.end();
 
-            for (; it != end; it++)
+            for (; it != end; ++it)
             {
                 pieces.push_back(rgm.openResource(*it, mResorceGroup)->getAsString());
             }

--- a/Components/MeshLodGenerator/src/OgreLodCollapseCost.cpp
+++ b/Components/MeshLodGenerator/src/OgreLodCollapseCost.cpp
@@ -35,7 +35,7 @@ namespace Ogre
         data->mCollapseCostHeap.clear();
         LodData::VertexList::iterator it = data->mVertexList.begin();
         LodData::VertexList::iterator itEnd = data->mVertexList.end();
-        for (; it != itEnd; it++) {
+        for (; it != itEnd; ++it) {
             if (!it->edges.empty()) {
                 initVertexCollapseCost(data, &*it);
             } else {

--- a/Components/MeshLodGenerator/src/OgreLodCollapseCostCurvature.cpp
+++ b/Components/MeshLodGenerator/src/OgreLodCollapseCostCurvature.cpp
@@ -98,7 +98,7 @@ namespace Ogre
                 collapseEdge.normalise();
                 LodData::VEdges::iterator it = src->edges.begin();
                 LodData::VEdges::iterator itEnd = src->edges.end();
-                for (; it != itEnd; it++) {
+                for (; it != itEnd; ++it) {
                     LodData::Vertex* neighbor = it->dst;
                     if (neighbor != dst && it->refCount == 1) {
                         Vector3 otherBorderEdge = src->position - neighbor->position;
@@ -153,7 +153,7 @@ namespace Ogre
                     LodData::Vertex* otherSeam;
                     LodData::VEdges::iterator it = src->edges.begin();
                     LodData::VEdges::iterator itEnd = src->edges.end();
-                    for (; it != itEnd; it++) {
+                    for (; it != itEnd; ++it) {
                         LodData::Vertex* neighbor = it->dst;
                         if(neighbor->seam) {
                             seamNeighbors++;

--- a/Components/MeshLodGenerator/src/OgreLodCollapseCostProfiler.cpp
+++ b/Components/MeshLodGenerator/src/OgreLodCollapseCostProfiler.cpp
@@ -75,7 +75,7 @@ namespace Ogre
         mHasProfile.resize(data->mVertexList.size(), false);
         LodProfile::iterator it = mProfile.begin();
         LodProfile::iterator itEnd = mProfile.end();
-        for(;it != itEnd;it++){
+        for(;it != itEnd;++it){
             LodData::Vertex v;
             v.position = it->src;
             LodData::UniqueVertexSet::iterator src = data->mUniqueVertexSet.find(&v);

--- a/Components/MeshLodGenerator/src/OgreLodCollapser.cpp
+++ b/Components/MeshLodGenerator/src/OgreLodCollapser.cpp
@@ -55,7 +55,7 @@ namespace Ogre
         LodData::CollapseCostHeap::iterator itEnd = data->mCollapseCostHeap.end();
         while (it != itEnd) {
             assertValidVertex(data, it->second);
-            it++;
+            ++it;
         }
     }
 
@@ -64,7 +64,7 @@ namespace Ogre
         // Allows to find bugs in collapsing.
         LodData::VTriangles::iterator it = v->triangles.begin();
         LodData::VTriangles::iterator itEnd = v->triangles.end();
-        for (; it != itEnd; it++) {
+        for (; it != itEnd; ++it) {
             LodData::Triangle* t = *it;
             for (int i = 0; i < 3; i++) {
                 OgreAssert(t->vertex[i]->costHeapPosition != data->mCollapseCostHeap.end(), "");
@@ -87,12 +87,12 @@ namespace Ogre
         // This will OgreAssert if the dependencies inside computeEdgeCollapseCost changes.
         LodData::VEdges::iterator it = vertex->edges.begin();
         LodData::VEdges::iterator itEnd = vertex->edges.end();
-        for (; it != itEnd; it++) {
+        for (; it != itEnd; ++it) {
             OgreAssert(it->collapseCost == cost->computeEdgeCollapseCost(data, vertex, &*it), "");
             LodData::Vertex* neighbor = it->dst;
             LodData::VEdges::iterator it2 = neighbor->edges.begin();
             LodData::VEdges::iterator it2End = neighbor->edges.end();
-            for (; it2 != it2End; it2++) {
+            for (; it2 != it2End; ++it2) {
                 OgreAssert(it2->collapseCost == cost->computeEdgeCollapseCost(data, neighbor, &*it2), "");
             }
         }

--- a/Components/MeshLodGenerator/src/OgreLodConfigSerializer.cpp
+++ b/Components/MeshLodGenerator/src/OgreLodConfigSerializer.cpp
@@ -249,7 +249,7 @@ namespace Ogre
 
         LodConfig::LodLevelList::iterator it = mLodConfig->levels.begin();
         LodConfig::LodLevelList::iterator itEnd = mLodConfig->levels.end();
-        for(;it != itEnd; it++){
+        for(;it != itEnd; ++it){
             writeFloats(&it->distance, 1);
             writeInts((Ogre::uint32*)&it->reductionMethod, 1);
             writeFloats(&it->reductionValue, 1);
@@ -320,7 +320,7 @@ namespace Ogre
         writeInts(&size, 1);
         LodProfile::iterator it = mLodConfig->advanced.profile.begin();
         LodProfile::iterator itEnd = mLodConfig->advanced.profile.end();
-        for(;it != itEnd; it++){
+        for(;it != itEnd; ++it){
             writeObject(it->src);
             writeObject(it->dst);
             writeFloats(&it->cost, 1);

--- a/Components/MeshLodGenerator/src/OgreLodOutsideMarker.cpp
+++ b/Components/MeshLodGenerator/src/OgreLodOutsideMarker.cpp
@@ -72,7 +72,7 @@ void LodOutsideMarker::initHull()
     mOutsideData.resize(mVertexListOrig.size());
     itOut = mOutsideData.begin();
     itOutEnd = mOutsideData.end();
-    for (; itOut != itOutEnd; itOut++) {
+    for (; itOut != itOutEnd; ++itOut) {
         // reset output variables
         itOut->isOuterWallVertex = false;
         itOut->isInsideHull = false;
@@ -86,7 +86,7 @@ void LodOutsideMarker::initHull()
         LodData::VertexList::iterator v, vEnd;
         v = mVertexListOrig.begin();
         vEnd = mVertexListOrig.end();
-        for (; v != vEnd; v++) {
+        for (; v != vEnd; ++v) {
             Vector3& pos = v->position;
             if (pos.y < miny) {
                 miny = pos.y;
@@ -102,7 +102,7 @@ void LodOutsideMarker::initHull()
         LodData::VertexList::iterator v, vEnd;
         v = mVertexListOrig.begin();
         vEnd = mVertexListOrig.end();
-        for (; v != vEnd; v++) {
+        for (; v != vEnd; ++v) {
             Real dist = vertex[0]->position.squaredDistance(v->position);
             if (dist > maxdist) {
                 maxdist = dist;
@@ -118,7 +118,7 @@ void LodOutsideMarker::initHull()
         LodData::VertexList::iterator v, vEnd;
         v = mVertexListOrig.begin();
         vEnd = mVertexListOrig.end();
-        for (; v != vEnd; v++) {
+        for (; v != vEnd; ++v) {
             Real dist = getPointToLineSqraredDistance(vertex[0], vertex[1], &*v);
             if (dist > maxdist) {
                 maxdist = dist;
@@ -136,7 +136,7 @@ void LodOutsideMarker::initHull()
         LodData::VertexList::iterator v, vEnd;
         v = mVertexListOrig.begin();
         vEnd = mVertexListOrig.end();
-        for (; v != vEnd; v++) {
+        for (; v != vEnd; ++v) {
             Real dist = std::abs(plane.getDistance(v->position));
             if (dist > maxdist) {
                 maxdist = dist;
@@ -203,7 +203,7 @@ LodOutsideMarker::CHVertex* LodOutsideMarker::getFurthestVertex(CHTriangle* tri)
     LodData::VertexList::iterator v, vEnd;
     v = mVertexListOrig.begin();
     vEnd = mVertexListOrig.end();
-    for (; v != vEnd; v++) {
+    for (; v != vEnd; ++v) {
         if (getOutsideData(&*v)->isInsideHull) {
             continue;
         }
@@ -236,7 +236,7 @@ void LodOutsideMarker::getVisibleTriangles( const CHVertex* target, CHTrianglePL
 
     CHTriangleList::iterator it = mHull.begin();
     CHTriangleList::iterator itEnd = mHull.end();
-    for (; it != itEnd; it++) {
+    for (; it != itEnd; ++it) {
         if (it->removed) {
             continue;
         }
@@ -354,7 +354,7 @@ void LodOutsideMarker::getHorizon( const CHTrianglePList& tri, CHEdgeList& horiz
     // Create edge list and remove triangles
     CHTrianglePList::const_iterator it2 = tri.begin();
     CHTrianglePList::const_iterator it2End = tri.end();
-    for (; it2 != it2End; it2++) {
+    for (; it2 != it2End; ++it2) {
         addEdge(horizon, (*it2)->vertex[0], (*it2)->vertex[1]);
         addEdge(horizon, (*it2)->vertex[1], (*it2)->vertex[2]);
         addEdge(horizon, (*it2)->vertex[2], (*it2)->vertex[0]);
@@ -392,7 +392,7 @@ void LodOutsideMarker::fillHorizon(CHEdgeList& horizon, CHVertex* target)
     tri.removed = false;
     CHEdgeList::iterator it = horizon.begin();
     CHEdgeList::iterator itEnd = horizon.end();
-    for (;it != itEnd; it++) {
+    for (;it != itEnd; ++it) {
         tri.vertex[0] = it->first;
         tri.vertex[1] = it->second;
         tri.computeNormal();
@@ -548,18 +548,18 @@ void LodOutsideMarker::markVertices()
     OutsideDataList::iterator v, vEnd;
     v = mOutsideData.begin();
     vEnd = mOutsideData.end();
-    for (;v != vEnd; v++) {
+    for (;v != vEnd; ++v) {
         v->isOuterWallVertex = false;
     }
     std::vector<CHVertex*> stack;
     CHTriangleList::iterator tri, triEnd;
     tri = mHull.begin();
     triEnd = mHull.end();
-    for (; tri != triEnd; tri++) {
+    for (; tri != triEnd; ++tri) {
         stack.clear();
         v = mOutsideData.begin();
         vEnd = mOutsideData.end();
-        for (;v != vEnd; v++) {
+        for (;v != vEnd; ++v) {
             v->isOuterWallVertexInPass = false;
         }
         addHullTriangleVertices(stack, &*tri);
@@ -569,7 +569,7 @@ void LodOutsideMarker::markVertices()
             LodData::VTriangles::iterator it, itEnd;
             it = vert->triangles.begin();
             itEnd = vert->triangles.end();
-            for (; it != itEnd; it++) {
+            for (; it != itEnd; ++it) {
                 if (tri->normal.dotProduct((*it)->normal) > mWalkAngle) {
                     addHullTriangleVertices(stack, *it);
                 }

--- a/Components/Overlay/src/OgreTextAreaOverlayElement.cpp
+++ b/Components/Overlay/src/OgreTextAreaOverlayElement.cpp
@@ -209,7 +209,7 @@ namespace Ogre {
             if( newLine )
             {
                 Real len = 0.0f;
-                for( DisplayString::iterator j = i; j != iend; j++ )
+                for( DisplayString::iterator j = i; j != iend; ++j )
                 {
                     Font::CodePoint character = j.getCharacter();
                     if (character == UNICODE_CR
@@ -251,7 +251,7 @@ namespace Ogre {
                 if (character == UNICODE_CR)
                 {
                     DisplayString::iterator peeki = i;
-                    peeki++;
+                    ++peeki;
                     if (peeki != iend && peeki.getCharacter() == UNICODE_LF)
                     {
                         i = peeki; // skip both as one newline

--- a/Components/Overlay/src/OgreUTFString.cpp
+++ b/Components/Overlay/src/OgreUTFString.cpp
@@ -936,7 +936,7 @@ namespace Ogre {
 #ifdef WCHAR_UTF16 // if we're already working in UTF-16, this is easy
         code_point tmp;
         std::wstring::const_iterator i, ie = wstr.end();
-        for ( i = wstr.begin(); i != ie; i++ ) {
+        for ( i = wstr.begin(); i != ie; ++i ) {
             tmp = static_cast<code_point>( *i );
             mData.push_back( tmp );
         }
@@ -944,7 +944,7 @@ namespace Ogre {
         code_point cp[3] = {0, 0, 0};
         unicode_char tmp;
         std::wstring::const_iterator i, ie = wstr.end();
-        for ( i = wstr.begin(); i != ie; i++ ) {
+        for ( i = wstr.begin(); i != ie; ++i ) {
             tmp = static_cast<unicode_char>( *i );
             size_t l = _utf32_to_utf16( tmp, cp );
             if ( l > 0 ) mData.push_back( cp[0] );
@@ -988,7 +988,7 @@ namespace Ogre {
         size_t utf16len;          // UTF-16 length
 
         std::string::const_iterator i, ie = str.end();
-        for ( i = str.begin(); i != ie; i++ ) {
+        for ( i = str.begin(); i != ie; ++i ) {
             utf8len = _utf8_char_length( static_cast<unsigned char>( *i ) ); // estimate bytes to load
             for ( size_t j = 0; j < utf8len; j++ ) { // load the needed UTF-8 bytes
                 utf8buf[j] = ( static_cast<unsigned char>( *( i + j ) ) ); // we don't increment 'i' here just in case the estimate is wrong (shouldn't happen, but we're being careful)
@@ -1917,8 +1917,8 @@ namespace Ogre {
                         throw invalid_data( "bad UTF-8 continuation byte" );
                 }
             }
-            length++;
-            i++;
+            ++length;
+            ++i;
         }
         return length;
     }

--- a/Components/RTShaderSystem/src/OgreShaderFunctionAtom.cpp
+++ b/Components/RTShaderSystem/src/OgreShaderFunctionAtom.cpp
@@ -422,7 +422,7 @@ void AssignmentAtom::writeSourceCode(std::ostream& os, const String& targetLangu
     OperandVector::const_iterator outOp = mOperands.begin();
     // find the output operand
     while(outOp->getSemantic() != Operand::OPS_OUT)
-        outOp++;
+        ++outOp;
     writeOperands(os, outOp, mOperands.end());
     os << "\t=\t";
     writeOperands(os, mOperands.begin(), outOp);
@@ -441,7 +441,7 @@ void SampleTextureAtom::writeSourceCode(std::ostream& os, const String& targetLa
     OperandVector::const_iterator outOp = mOperands.begin();
     // find the output operand
     while(outOp->getSemantic() != Operand::OPS_OUT)
-        outOp++;
+        ++outOp;
     writeOperands(os, outOp, mOperands.end());
     os << "\t=\t";
 
@@ -485,12 +485,12 @@ void BinaryOpAtom::writeSourceCode(std::ostream& os, const String& targetLanguag
     // find the output operand
     OperandVector::const_iterator outOp = mOperands.begin();
     while(outOp->getSemantic() != Operand::OPS_OUT)
-        outOp++;
+        ++outOp;
 
     // find the second operand
     OperandVector::const_iterator secondOp = ++(mOperands.begin());
     while(outOp->getIndirectionLevel() != 0)
-        secondOp++;
+        ++secondOp;
 
     writeOperands(os, outOp, mOperands.end());
     os << "\t=\t";

--- a/OgreMain/src/OgreMaterialSerializer.cpp
+++ b/OgreMain/src/OgreMaterialSerializer.cpp
@@ -153,7 +153,7 @@ namespace Ogre
             Material::LodValueList::const_iterator valueIt = pMat->getUserLodValues().begin();
             // Skip zero value
             if (!pMat->getUserLodValues().empty())
-                valueIt++;
+                ++valueIt;
             String attributeVal;
             while (valueIt != pMat->getUserLodValues().end())
             {

--- a/OgreMain/src/OgreScriptCompiler.cpp
+++ b/OgreMain/src/OgreScriptCompiler.cpp
@@ -804,7 +804,7 @@ namespace Ogre
                 overlayObject(*overrides[i].first,
                     static_cast<ObjectAbstractNode&>(**overrides[i].second));
                 insertPos = overrides[i].second;
-                insertPos++;
+                ++insertPos;
             }
             else
             {
@@ -1312,7 +1312,7 @@ namespace Ogre
             ConcreteNodeList::iterator iter = node->children.begin();
             impl->target = (*iter)->token;
 
-            iter++;
+            ++iter;
             impl->source = (*iter)->token;
 
             asn = AbstractNodePtr(impl);
@@ -1377,7 +1377,7 @@ namespace Ogre
             if(riter != node->children.rend())
             {
                 temp1 = *riter;
-                riter++;
+                ++riter;
             }
             if(riter != node->children.rend())
                 temp2 = *riter;

--- a/OgreMain/src/OgreScriptLexer.cpp
+++ b/OgreMain/src/OgreScriptLexer.cpp
@@ -235,9 +235,9 @@ namespace Ogre {
 
             // Separate check for newlines just to track line numbers
             if(c == cr || (c == lf && lastc != cr))
-                line++;
+                ++line;
 
-            i++;
+            ++i;
         }
 
         // Check for valid exit states

--- a/OgreMain/src/OgreScriptTranslator.cpp
+++ b/OgreMain/src/OgreScriptTranslator.cpp
@@ -4398,7 +4398,7 @@ namespace Ogre{
                                            "invalid array size");
                         continue;
                     }
-                    arrayStart++;
+                    ++arrayStart;
                 }
             }
 

--- a/OgreMain/src/OgreString.cpp
+++ b/OgreMain/src/OgreString.cpp
@@ -215,7 +215,7 @@ namespace Ogre {
     {
         String::iterator it = str.begin();
         *it = toupper(*it);
-        for (; it != str.end() - 1; it++)
+        for (; it != str.end() - 1; ++it)
         {
             if (*it == ' ') 
             {

--- a/PlugIns/CgProgramManager/src/OgreCgProgram.cpp
+++ b/PlugIns/CgProgramManager/src/OgreCgProgram.cpp
@@ -395,7 +395,7 @@ namespace Ogre {
 		// save params
 		GpuConstantDefinitionMap::const_iterator iter = mParametersMap.begin();
 		GpuConstantDefinitionMap::const_iterator iterE = mParametersMap.end();
-		for (; iter != iterE ; iter++)
+		for (; iter != iterE ; ++iter)
 		{
 			const String & paramName = iter->first;
 			const GpuConstantDefinition & def = iter->second;
@@ -899,7 +899,7 @@ namespace Ogre {
 
 		GpuConstantDefinitionMap::const_iterator iter = mParametersMap.begin();
 		GpuConstantDefinitionMap::const_iterator iterE = mParametersMap.end();
-		for (; iter != iterE ; iter++)
+		for (; iter != iterE ; ++iter)
 		{
 			GpuConstantDefinition def = iter->second;
 

--- a/PlugIns/OctreeZone/src/OgreOctreeZone.cpp
+++ b/PlugIns/OctreeZone/src/OgreOctreeZone.cpp
@@ -500,7 +500,7 @@ namespace Ogre
         Portal* portal;
         PortalList::iterator pi, piend;
         piend = mPortals.end();
-        for (pi = mPortals.begin(); pi != piend; pi++)
+        for (pi = mPortals.begin(); pi != piend; ++pi)
         {
             portal = *pi;
 
@@ -821,7 +821,7 @@ namespace Ogre
                                                             exclude);
                     }
                 }
-                pit++;
+                ++pit;
             }
         }
 
@@ -872,7 +872,7 @@ namespace Ogre
                                                             exclude);
                     }
                 }
-                pit++;
+                ++pit;
             }
         }
 
@@ -923,7 +923,7 @@ namespace Ogre
                                                             exclude);
                     }
                 }
-                pit++;
+                ++pit;
             }
         }
 
@@ -975,7 +975,7 @@ namespace Ogre
                                                             exclude);
                     }
                 }
-                pit++;
+                ++pit;
             }
         }
     }

--- a/PlugIns/PCZSceneManager/src/OgreDefaultZone.cpp
+++ b/PlugIns/PCZSceneManager/src/OgreDefaultZone.cpp
@@ -445,7 +445,7 @@ namespace Ogre
         Portal* portal;
         PortalList::iterator pi, piend;
         piend = mPortals.end();
-        for (pi = mPortals.begin(); pi != piend; pi++)
+        for (pi = mPortals.begin(); pi != piend; ++pi)
         {
             portal = *pi;
 
@@ -754,7 +754,7 @@ namespace Ogre
                                                             exclude);
                     }
                 }
-                pit++;
+                ++pit;
             }
         }
     }
@@ -848,7 +848,7 @@ namespace Ogre
                                                             exclude);
                     }
                 }
-                pit++;
+                ++pit;
             }
         }
 
@@ -943,7 +943,7 @@ namespace Ogre
                                                             exclude);
                     }
                 }
-                pit++;
+                ++pit;
             }
         }
 
@@ -1039,7 +1039,7 @@ namespace Ogre
                                                             exclude);
                     }
                 }
-                pit++;
+                ++pit;
             }
         }
 

--- a/PlugIns/PCZSceneManager/src/OgrePCZFrustum.cpp
+++ b/PlugIns/PCZSceneManager/src/OgrePCZFrustum.cpp
@@ -70,7 +70,7 @@ namespace Ogre
         {
             PCPlane * plane = *pit;
             // go to next entry
-            pit++;
+            ++pit;
             //delete the entry in the list
             OGRE_DELETE_T(plane, PCPlane, MEMCATEGORY_SCENE_CONTROL);
         }
@@ -111,7 +111,7 @@ namespace Ogre
             {
                 return false;
             }
-            pit++;
+            ++pit;
         }
         return true;
     }
@@ -147,7 +147,7 @@ namespace Ogre
                     return false;
                 }
             }
-            pit++;
+            ++pit;
         }
         return true;
     }
@@ -175,7 +175,7 @@ namespace Ogre
             {
                 return false;
             }
-            pit++;
+            ++pit;
         }
         // if portal is of type AABB or Sphere, then use simple bound check against planes
         if (portal->getType() == PortalBase::PORTAL_TYPE_AABB)
@@ -255,7 +255,7 @@ namespace Ogre
                 // ALL corners on negative side therefore out of view
                 return false;
             }
-            pit++;
+            ++pit;
         }
         // no plane culled all the portal points and the norm
         // was facing the frustum, so this portal is visible
@@ -296,7 +296,7 @@ namespace Ogre
             {
                 return false;
             }
-            pit++;
+            ++pit;
         }
         return true;
     }
@@ -328,7 +328,7 @@ namespace Ogre
                 return false;
             }
 
-            pit++;
+            ++pit;
         }
         return true;
     }
@@ -354,7 +354,7 @@ namespace Ogre
             {
                 return false;
             }
-            pit++;
+            ++pit;
         }
         // if portal is of type AABB or Sphere, then use simple bound check against planes
         if (portal->getType() == PortalBase::PORTAL_TYPE_AABB)
@@ -405,7 +405,7 @@ namespace Ogre
                 Plane::Side side =plane->getSide(portal->getDerivedCorner(corner));
                 if (side == Plane::NEGATIVE_SIDE) return false;
             }
-            pit++;
+            ++pit;
         }
         // no plane culled all the portal points and the norm
         // was facing the frustum, so this portal is fully visible
@@ -461,7 +461,7 @@ namespace Ogre
                 all_inside = false;
                 break;
             }
-            pit++;
+            ++pit;
         }
 
         if ( all_inside )
@@ -535,7 +535,7 @@ namespace Ogre
                     visible = false;
                     break;
                 }
-                pit++;
+                ++pit;
             }
             if (visible)
             {
@@ -619,7 +619,7 @@ namespace Ogre
             }
             else
             {
-                pit++;
+                ++pit;
             }
         }
 
@@ -636,7 +636,7 @@ namespace Ogre
             // put the plane back in the reservoir
             mCullingPlaneReservoir.push_front(plane);
             // go to next entry
-            pit++;
+            ++pit;
         }
         mActiveCullingPlanes.clear();
     }

--- a/PlugIns/PCZSceneManager/src/OgrePCZLight.cpp
+++ b/PlugIns/PCZSceneManager/src/OgrePCZLight.cpp
@@ -163,7 +163,7 @@ namespace Ogre
             return true;
 
         // if any zones affected by this light have updated portals, then this light needs updating too
-        for (ZoneList::iterator iter = affectedZonesList.begin() ; iter != affectedZonesList.end(); iter++)
+        for (ZoneList::iterator iter = affectedZonesList.begin() ; iter != affectedZonesList.end(); ++iter)
         { 
             if((*iter)->getPortalsUpdated()) return true;   // return immediately to prevent further iterating
         }

--- a/PlugIns/PCZSceneManager/src/OgrePCZSceneManager.cpp
+++ b/PlugIns/PCZSceneManager/src/OgrePCZSceneManager.cpp
@@ -65,7 +65,7 @@ namespace Ogre
         // delete ALL portals
         Portal * p;
         PortalList::iterator i = mPortals.begin();
-        for (i = mPortals.begin(); i != mPortals.end(); i++)
+        for (i = mPortals.begin(); i != mPortals.end(); ++i)
         {
             p = *i;
             OGRE_DELETE p;
@@ -94,7 +94,7 @@ namespace Ogre
         // delete ALL portals
         Portal * p;
         PortalList::iterator i = mPortals.begin();
-        for (i = mPortals.begin(); i != mPortals.end(); i++)
+        for (i = mPortals.begin(); i != mPortals.end(); ++i)
         {
             p = *i;
             OGRE_DELETE p;
@@ -174,7 +174,7 @@ namespace Ogre
                 mPortals.erase(it);
                 break;
             }
-            it++;
+            ++it;
         }
         if (thePortal)
         {
@@ -245,7 +245,7 @@ namespace Ogre
                 mAntiPortals.erase(it);
                 break;
             }
-            it++;
+            ++it;
         }
         if (thePortal)
         {
@@ -380,7 +380,7 @@ namespace Ogre
         // tell all the zones about the new camera
         ZoneMap::iterator i;
         PCZone * zone;
-        for (i = mZones.begin(); i != mZones.end(); i++)
+        for (i = mZones.begin(); i != mZones.end(); ++i)
         {
             zone = i->second;
             zone->notifyCameraCreated( c );
@@ -459,7 +459,7 @@ namespace Ogre
         // tell all the zones about the new WorldGeometryRenderQueue
         ZoneMap::iterator i;
         PCZone * zone;
-        for (i = mZones.begin(); i != mZones.end(); i++)
+        for (i = mZones.begin(); i != mZones.end(); ++i)
         {
             zone = i->second;
             zone->notifyWorldGeometryRenderQueue( qid );
@@ -474,7 +474,7 @@ namespace Ogre
         // notify all the zones that a scene render is starting
         ZoneMap::iterator i;
         PCZone * zone;
-        for (i = mZones.begin(); i != mZones.end(); i++)
+        for (i = mZones.begin(); i != mZones.end(); ++i)
         {
             zone = i->second;
             zone->notifyBeginRenderScene();
@@ -885,7 +885,7 @@ namespace Ogre
     {
         ZoneMap::iterator i;
         PCZone * zone;
-        for (i = mZones.begin(); i != mZones.end(); i++)
+        for (i = mZones.begin(); i != mZones.end(); ++i)
         {
             zone = i->second;
             if (zone->requiresZoneSpecificNodeData())
@@ -1118,14 +1118,14 @@ namespace Ogre
         PCZone* zone;
         iend = mZones.end();
         bool foundMatch;
-        for (i = mZones.begin(); i != iend; i++)
+        for (i = mZones.begin(); i != iend; ++i)
         {
             zone = i->second;
             // go through all the portals in the zone
             Portal* portal;
             PortalList::iterator pi, piend;
             piend = zone->mPortals.end();
-            for (pi = zone->mPortals.begin(); pi != piend; pi++)
+            for (pi = zone->mPortals.begin(); pi != piend; ++pi)
             {
                 portal = *pi;
                 //portal->updateDerivedValues();
@@ -1153,7 +1153,7 @@ namespace Ogre
                                 portal2->setTargetPortal(portal);
                             }
                         }
-                        j++;
+                        ++j;
                     }
                     if (foundMatch == false)
                     {
@@ -1240,7 +1240,7 @@ namespace Ogre
             // no start zone specified, so check all zones
             ZoneMap::iterator i;
             PCZone * zone;
-            for (i = mZones.begin(); i != mZones.end(); i++)
+            for (i = mZones.begin(); i != mZones.end(); ++i)
             {
                 zone = i->second;
                 zone->_findNodes( box, list, visitedPortals, false, false, exclude );
@@ -1264,7 +1264,7 @@ namespace Ogre
             // no start zone specified, so check all zones
             ZoneMap::iterator i;
             PCZone * zone;
-            for (i = mZones.begin(); i != mZones.end(); i++)
+            for (i = mZones.begin(); i != mZones.end(); ++i)
             {
                 zone = i->second;
                 zone->_findNodes( sphere, list, visitedPortals, false, false, exclude );
@@ -1288,7 +1288,7 @@ namespace Ogre
             // no start zone specified, so check all zones
             ZoneMap::iterator i;
             PCZone * zone;
-            for (i = mZones.begin(); i != mZones.end(); i++)
+            for (i = mZones.begin(); i != mZones.end(); ++i)
             {
                 zone = i->second;
                 zone->_findNodes( volume, list, visitedPortals, false, false, exclude );
@@ -1311,7 +1311,7 @@ namespace Ogre
         {
             ZoneMap::iterator i;
             PCZone * zone;
-            for (i = mZones.begin(); i != mZones.end(); i++)
+            for (i = mZones.begin(); i != mZones.end(); ++i)
             {
                 zone = i->second;
                 zone->_findNodes( r, list, visitedPortals, false, false, exclude );
@@ -1351,7 +1351,7 @@ namespace Ogre
         // send option to each zone
         ZoneMap::iterator i;
         PCZone * zone;
-        for (i = mZones.begin(); i != mZones.end(); i++)
+        for (i = mZones.begin(); i != mZones.end(); ++i)
         {
             zone = i->second;
              if (zone->setOption(key, val ) == true)
@@ -1440,7 +1440,7 @@ namespace Ogre
         while ( zoneIterator != mZones.end() )
         {
             (zoneIterator->second)->setPortalsUpdated(false);
-            zoneIterator++;
+            ++zoneIterator;
         }
     }
     //---------------------------------------------------------------------

--- a/PlugIns/PCZSceneManager/src/OgrePCZone.cpp
+++ b/PlugIns/PCZSceneManager/src/OgrePCZone.cpp
@@ -75,7 +75,7 @@ namespace Ogre
         Portal* portal2;
         PortalList::iterator pi2, piend2;
         piend2 = mPortals.end();
-        for (pi2 = mPortals.begin(); pi2 != piend2; pi2++)
+        for (pi2 = mPortals.begin(); pi2 != piend2; ++pi2)
         {
             portal2 = *pi2;
             //portal2->updateDerivedValues();

--- a/PlugIns/PCZSceneManager/src/OgrePortalBase.cpp
+++ b/PlugIns/PCZSceneManager/src/OgrePortalBase.cpp
@@ -523,7 +523,7 @@ bool PortalBase::intersects(const PlaneBoundedVolume& pbv)
                     {
                         return false;
                     }
-                    it++;
+                    ++it;
                 };
             }
             break;

--- a/RenderSystems/Direct3D11/src/OgreD3D11VideoModeList.cpp
+++ b/RenderSystems/Direct3D11/src/OgreD3D11VideoModeList.cpp
@@ -98,7 +98,7 @@ namespace Ogre
 							// Check to see if it is already in the list (to filter out refresh rates)
 							BOOL found = FALSE;
 							std::vector<D3D11VideoMode>::iterator it;
-							for (it = mModeList.begin(); it != mModeList.end(); it++)
+							for (it = mModeList.begin(); it != mModeList.end(); ++it)
 							{
 								DXGI_OUTPUT_DESC oldOutput = it->getDisplayMode();
 								DXGI_MODE_DESC oldDisp = it->getModeDesc();

--- a/RenderSystems/GLSupport/src/GLX/OgreGLXGLSupport.cpp
+++ b/RenderSystems/GLSupport/src/GLX/OgreGLXGLSupport.cpp
@@ -369,7 +369,7 @@ namespace Ogre
         {
             std::map<int,int>::iterator it;
 
-            for (it = fields.begin(); it != fields.end(); it++)
+            for (it = fields.begin(); it != fields.end(); ++it)
             {
                 it->second = 0;
 
@@ -393,7 +393,7 @@ namespace Ogre
 
             std::map<int,int>::iterator it;
 
-            for (it = fields.begin(); it != fields.end(); it++)
+            for (it = fields.begin(); it != fields.end(); ++it)
             {
                 if (it->first != GLX_CONFIG_CAVEAT && fields[it->first] > alternative.fields[it->first])
                     return true;

--- a/Samples/DeferredShading/src/DeferredLightCP.cpp
+++ b/Samples/DeferredShading/src/DeferredLightCP.cpp
@@ -73,7 +73,7 @@ void DeferredLightRenderOperation::execute(SceneManager *sm, RenderSystem *rs)
     injectTechnique(sm, tech, mAmbientLight, 0);
 
     const LightList& lightList = sm->_getLightsAffectingFrustum();
-    for (LightList::const_iterator it = lightList.begin(); it != lightList.end(); it++) 
+    for (LightList::const_iterator it = lightList.begin(); it != lightList.end(); ++it) 
     {
         Light* light = *it;
         Ogre::LightList ll;

--- a/Samples/Simple/src/MeshLod.cpp
+++ b/Samples/Simple/src/MeshLod.cpp
@@ -89,7 +89,7 @@ void Sample_MeshLod::setupControls( int uimode /*= 0*/ )
     StringVector::iterator it, itEnd;
     it = meshes->begin();
     itEnd = meshes->end();
-    for(; it != itEnd; it++){
+    for(; it != itEnd; ++it){
         models->addItem(*it);
     }
 
@@ -444,7 +444,7 @@ bool Sample_MeshLod::getResourceFullPath(MeshPtr& mesh, String& outPath)
     FileInfoList::iterator it, itEnd;
     it = locPtr->begin();
     itEnd = locPtr->end();
-    for (; it != itEnd; it++) {
+    for (; it != itEnd; ++it) {
         if (stricmp(name.c_str(), it->filename.c_str()) == 0) {
             info = &*it;
             break;

--- a/Tests/OgreMain/src/MeshSerializerTests.cpp
+++ b/Tests/OgreMain/src/MeshSerializerTests.cpp
@@ -233,7 +233,7 @@ TEST_F(MeshSerializerTests,Mesh_Version_1_2)
         StringVector::iterator it, itEnd;
         it = meshes->begin();
         itEnd = meshes->end();
-        for (; it != itEnd; it++) {
+        for (; it != itEnd; ++it) {
             try {
                 mMesh = MeshManager::getSingleton().load(*it, groups[i]);
             }
@@ -257,7 +257,7 @@ TEST_F(MeshSerializerTests,Mesh_Version_1_2)
         meshes = ResourceGroupManager::getSingleton().findResourceNames(groups[i], "*.skeleton");
         it = meshes->begin();
         itEnd = meshes->end();
-        for (; it != itEnd; it++) {
+        for (; it != itEnd; ++it) {
             mSkeleton = SkeletonManager::getSingleton().load(*it, groups[i]);
             getResourceFullPath(mSkeleton, mSkeletonFullPath);
             if (!copyFile(mSkeletonFullPath + ".bak", mSkeletonFullPath)) {
@@ -469,7 +469,7 @@ void MeshSerializerTests::assertVertexDataClone(VertexData* a, VertexData* b, Me
             bindingIterator aIt = aBindings.begin();
             bindingIterator aEndIt = aBindings.end();
             bindingIterator bIt = bBindings.begin();
-            for (; aIt != aEndIt; aIt++, bIt++) {
+            for (; aIt != aEndIt; ++aIt, ++bIt) {
                 EXPECT_TRUE(aIt->first == bIt->first);
                 EXPECT_TRUE((aIt->second.get() == NULL) == (bIt->second.get() == NULL));
                 if (a) {
@@ -487,7 +487,7 @@ void MeshSerializerTests::assertVertexDataClone(VertexData* a, VertexData* b, Me
             bindingIterator aIt = aElements.begin();
             bindingIterator aEndIt = aElements.end();
             bindingIterator bIt;
-            for (; aIt != aEndIt; aIt++) {
+            for (; aIt != aEndIt; ++aIt) {
                 bIt = std::find(bElements.begin(), bElements.end(), *aIt);
                 EXPECT_TRUE(bIt != bElements.end());
 
@@ -529,7 +529,7 @@ void MeshSerializerTests::assertVertexDataClone(VertexData* a, VertexData* b, Me
             bindingIterator aIt = aAnimData.begin();
             bindingIterator aEndIt = aAnimData.end();
             bindingIterator bIt = bAnimData.begin();
-            for (; aIt != aEndIt; aIt++, bIt++) {
+            for (; aIt != aEndIt; ++aIt, ++bIt) {
                 EXPECT_TRUE(aIt->parametric == bIt->parametric);
                 EXPECT_TRUE(aIt->targetBufferIndex == bIt->targetBufferIndex);
             }
@@ -554,7 +554,7 @@ bool MeshSerializerTests::isHashMapClone(const std::unordered_map<K, V>& a, cons
     typename std::unordered_map<K, V>::const_iterator it, itFind, itEnd;
     it = a.begin();
     itEnd = a.end();
-    for (; it != itEnd; it++) {
+    for (; it != itEnd; ++it) {
         itFind = b.find(it->first);
         if (itFind == b.end() || itFind->second != it->second) {
             return false;
@@ -618,7 +618,7 @@ void MeshSerializerTests::getResourceFullPath(const ResourcePtr& resource, Strin
     FileInfoList::iterator it, itEnd;
     it = locPtr->begin();
     itEnd = locPtr->end();
-    for (; it != itEnd; it++) {
+    for (; it != itEnd; ++it) {
         if (stricmp(name.c_str(), it->filename.c_str()) == 0) {
             info = &*it;
             break;

--- a/Tools/MayaExport/src/mesh.cpp
+++ b/Tools/MayaExport/src/mesh.cpp
@@ -1343,7 +1343,7 @@ namespace OgreMayaExporter
             // Rationalise the bone assignements list
             pMesh->_rationaliseBoneAssignments(pMesh->sharedVertexData->vertexCount,vbas);
             // Add bone assignements to the mesh
-            for (Ogre::Mesh::VertexBoneAssignmentList::iterator bi = vbas.begin(); bi != vbas.end(); bi++)
+            for (Ogre::Mesh::VertexBoneAssignmentList::iterator bi = vbas.begin(); bi != vbas.end(); ++bi)
             {
                 pMesh->addBoneAssignment(bi->second);
             }

--- a/Tools/MayaExport/src/submesh.cpp
+++ b/Tools/MayaExport/src/submesh.cpp
@@ -455,7 +455,7 @@ namespace OgreMayaExporter
                 // Rationalise the bone assignements list
                 pSubmesh->parent->_rationaliseBoneAssignments(pSubmesh->vertexData->vertexCount,vbas);
                 // Add bone assignements to the submesh
-                for (Ogre::SubMesh::VertexBoneAssignmentList::iterator bi = vbas.begin(); bi != vbas.end(); bi++)
+                for (Ogre::SubMesh::VertexBoneAssignmentList::iterator bi = vbas.begin(); bi != vbas.end(); ++bi)
                 {
                     pSubmesh->addBoneAssignment(bi->second);
                 }


### PR DESCRIPTION
I searched and replaced the postfix iterator increments with the prefix version because the temporaries are not needed and cannot be optimized away.
Probably it's a micro optimization but it doesn't harm.
See https://stackoverflow.com/questions/24901/is-there-a-performance-difference-between-i-and-i-in-c for reference.