### PR TITLE
destroyInstance method shoud be marked virtual

### DIFF
--- a/OgreMain/include/OgreMovableObject.h
+++ b/OgreMain/include/OgreMovableObject.h
@@ -608,7 +608,7 @@ namespace Ogre {
             const String& name, SceneManager* manager, 
             const NameValuePairList* params = 0);
         /** Destroy an instance of the object */
-        void destroyInstance(MovableObject* obj) { delete obj; }
+        virtual void destroyInstance(MovableObject* obj) { delete obj; }
 
         /** Does this factory require the allocation of a 'type flag', used to 
             selectively include / exclude this type from scene queries?


### PR DESCRIPTION
Overriding of destroyInstance of class MovableObjectFactory is used in OgreOggSound. And what is point to keep it non-virtual when user must define creation logic in createInstanceImpl anyway?