### PR TITLE
Added cast from OverlayElement to OverlayContainer

### DIFF
--- a/Components/Overlay/include/OgreOverlay.i
+++ b/Components/Overlay/include/OgreOverlay.i
@@ -52,6 +52,12 @@ SHARED_PTR(Font);
 %ignore Ogre::Overlay::get2DElementsIterator;
 %include "OgreOverlay.h"
 SHARED_PTR(OverlayElement);
+%extend Ogre::OverlayElement {
+  OverlayContainer* castOverlayContainer()
+  {
+    return dynamic_cast<Ogre::OverlayContainer*>($self);
+  }
+}
 %include "OgreOverlayElement.h"
 %include "OgreOverlayElementFactory.h"
 SHARED_PTR(OverlayContainer);


### PR DESCRIPTION
I needed to cast from OverlayElement to OverlayContainer to recreate this tutorial: http://wiki.ogre3d.org/Creating+Overlays+via+Code