### PR TITLE
handle missing RSC_POINT_SPRITES support in RTSS

### DIFF
--- a/Components/RTShaderSystem/src/OgreShaderFFPTexturing.cpp
+++ b/Components/RTShaderSystem/src/OgreShaderFFPTexturing.cpp
@@ -555,6 +555,12 @@ bool FFPTexturing::preAddToRenderState(const RenderState* renderState, Pass* src
 {
     mIsPointSprite = srcPass->getPointSpritesEnabled();
 
+    if (auto rs = Root::getSingleton().getRenderSystem())
+    {
+        if (mIsPointSprite && !rs->getCapabilities()->hasCapability(RSC_POINT_SPRITES))
+            return false;
+    }
+
     //count the number of texture units we need to process
     size_t validTexUnits = 0;
     for (const auto tu : srcPass->getTextureUnitStates())

--- a/OgreMain/src/OgrePass.cpp
+++ b/OgreMain/src/OgrePass.cpp
@@ -337,8 +337,6 @@ namespace Ogre {
     //-----------------------------------------------------------------------
     void Pass::setPointSpritesEnabled(bool enabled)
     {
-        if (!Root::getSingleton().getRenderSystem()->getCapabilities()->hasCapability(RSC_POINT_SPRITES))
-            return;
         mPointSpritesEnabled = enabled;
     }
     //-----------------------------------------------------------------------


### PR DESCRIPTION
otherwise it would still attempt to use texcoords