### PR TITLE
Always include shadow casting lights in local list

### DIFF
--- a/OgreMain/src/OgreSceneManager.cpp
+++ b/OgreMain/src/OgreSceneManager.cpp
@@ -364,7 +364,7 @@ void SceneManager::_populateLightList(const Vector3& position, Real radius,
         // Calc squared distance
         lt->_calcTempSquareDist(position);
 
-        if (lt->getType() == Light::LT_DIRECTIONAL)
+        if (lt->getType() == Light::LT_DIRECTIONAL || (lt->getCastShadows() && isShadowTechniqueTextureBased()))
         {
             // Always included
             destList.push_back(lt);

--- a/OgreMain/src/OgreSceneManager.cpp
+++ b/OgreMain/src/OgreSceneManager.cpp
@@ -364,7 +364,7 @@ void SceneManager::_populateLightList(const Vector3& position, Real radius,
         // Calc squared distance
         lt->_calcTempSquareDist(position);
 
-        if (lt->getType() == Light::LT_DIRECTIONAL || (lt->getCastShadows() && isShadowTechniqueTextureBased()))
+        if (lt->getType() == Light::LT_DIRECTIONAL || (lt->getCastShadows() && isShadowTechniqueIntegrated()))
         {
             // Always included
             destList.push_back(lt);

--- a/OgreMain/src/OgreSceneManager.cpp
+++ b/OgreMain/src/OgreSceneManager.cpp
@@ -2211,6 +2211,9 @@ void SceneManager::renderSingleObject(Renderable* rend, const Pass* pass,
 
                 for (const auto it : *pLightListToUse)
                 {
+                    if (!it->getCastShadows())
+                        continue;
+
                     // potentially need to update content_type shadow texunit
                     // corresponding to this light
                     size_t textureCountPerLight = mShadowRenderer.mShadowTextureCountPerType[it->getType()];

--- a/OgreMain/src/OgreSceneManager.cpp
+++ b/OgreMain/src/OgreSceneManager.cpp
@@ -376,7 +376,7 @@ void SceneManager::_populateLightList(const Vector3& position, Real radius,
             {
                 destList.push_back(lt);
             }
-      }
+        }
     }
 
     // Sort (stable to guarantee ordering on directional lights)
@@ -2204,39 +2204,42 @@ void SceneManager::renderSingleObject(Renderable* rend, const Pass* pass,
                 pLightListToUse = &rendLightList;
             }
 
-          if (isShadowTechniqueIntegrated() && mLightsDirtyCounter > 0) {
-            size_t shadowTexIndex = mShadowRenderer.getShadowTexIndex(lightIndex);
-            unsigned short numShadowTextureLights = 0;
+            if (isShadowTechniqueIntegrated() && mLightsDirtyCounter > 0)
+            {
+                size_t shadowTexIndex = mShadowRenderer.getShadowTexIndex(lightIndex);
+                unsigned short numShadowTextureLights = 0;
 
-            for (const auto it : *pLightListToUse) {
-              // potentially need to update content_type shadow texunit
-              // corresponding to this light
-              size_t textureCountPerLight = mShadowRenderer.mShadowTextureCountPerType[it->getType()];
-              size_t textureCounterPerLight = 0;
+                for (const auto it : *pLightListToUse)
+                {
+                    // potentially need to update content_type shadow texunit
+                    // corresponding to this light
+                    size_t textureCountPerLight = mShadowRenderer.mShadowTextureCountPerType[it->getType()];
+                    size_t textureCounterPerLight = 0;
 
-              for (size_t j = 0; j < textureCountPerLight && shadowTexIndex < mShadowRenderer.mShadowTextures.size(); ++j) {
-                // link the numShadowTextureLights'th shadow texture unit
-                ushort tuindex = pass->_getTextureUnitWithContentTypeIndex(TextureUnitState::CONTENT_SHADOW, numShadowTextureLights);
-                if (tuindex > pass->getNumTextureUnitStates()) break;
+                    for (size_t j = 0; j < textureCountPerLight && shadowTexIndex < mShadowRenderer.mShadowTextures.size(); ++j)
+                    {
+                        // link the numShadowTextureLights'th shadow texture unit
+                        ushort tuindex = pass->_getTextureUnitWithContentTypeIndex(TextureUnitState::CONTENT_SHADOW, numShadowTextureLights);
+                        if (tuindex > pass->getNumTextureUnitStates()) break;
 
-                TextureUnitState *tu = pass->getTextureUnitState(tuindex);
+                        TextureUnitState *tu = pass->getTextureUnitState(tuindex);
 
-                //pick up correct shadow texture index by light's frame index + texture counter per light
-                const TexturePtr &shadowTex = mShadowRenderer.mShadowTextures[mShadowRenderer.mShadowTextureIndexLightList[it->_getIndexInFrame()] + textureCounterPerLight];
-                tu->_setTexturePtr(shadowTex);
+                        //pick up correct shadow texture index by light's frame index + texture counter per light
+                        const TexturePtr &shadowTex = mShadowRenderer.mShadowTextures[mShadowRenderer.mShadowTextureIndexLightList[it->_getIndexInFrame()] + textureCounterPerLight];
+                        tu->_setTexturePtr(shadowTex);
 
-                Camera *cam = shadowTex->getBuffer()->getRenderTarget()->getViewport(0)->getCamera();
-                tu->setProjectiveTexturing(!pass->hasVertexProgram(), cam);
-                mAutoParamDataSource->setTextureProjector(cam, numShadowTextureLights);
-                ++numShadowTextureLights;
-                ++shadowTexIndex;
-                ++textureCounterPerLight;
-                // Have to set TU on rendersystem right now, although
-                // autoparams will be set later
-                mDestRenderSystem->_setTextureUnitSettings(tuindex, *tu);
-              }
+                        Camera *cam = shadowTex->getBuffer()->getRenderTarget()->getViewport(0)->getCamera();
+                        tu->setProjectiveTexturing(!pass->hasVertexProgram(), cam);
+                        mAutoParamDataSource->setTextureProjector(cam, numShadowTextureLights);
+                        ++numShadowTextureLights;
+                        ++shadowTexIndex;
+                        ++textureCounterPerLight;
+                        // Have to set TU on rendersystem right now, although
+                        // autoparams will be set later
+                        mDestRenderSystem->_setTextureUnitSettings(tuindex, *tu);
+                    }
+                }
             }
-          }
 
           lightsLeft = 0;
         }

--- a/OgreMain/src/OgreSceneManager.cpp
+++ b/OgreMain/src/OgreSceneManager.cpp
@@ -397,15 +397,6 @@ void SceneManager::_populateLightList(const Vector3& position, Real radius,
     {
         std::stable_sort(destList.begin(), destList.end(), lightLess());
     }
-
-    //Skip this, light indexes updated in findLightsAffectingFrustum
-
-    // Now assign indexes in the list so they can be examined if needed
-    //size_t lightIndex = 0;
-    //for (LightList::iterator li = destList.begin(); li != destList.end(); ++li, ++lightIndex)
-    //{
-    //    (*li)->_notifyIndexInFrame(lightIndex);
-    //}
 }
 //-----------------------------------------------------------------------
 void SceneManager::_populateLightList(const SceneNode* sn, Real radius, LightList& destList, uint32 lightMask) 


### PR DESCRIPTION
Culling of shadow casting lights from SceneNode's local list cause mismatch with frame shadow texture list. This breaks a texture shadowing if there are at least two spotlights that casts shadows in the scene. Here is small fix for this.