### PR TITLE
GLSupport: Win32 - use CreateContextAttribs

### DIFF
--- a/RenderSystems/GLSupport/include/win32/OgreWin32Context.h
+++ b/RenderSystems/GLSupport/include/win32/OgreWin32Context.h
@@ -37,7 +37,8 @@ namespace Ogre {
     {
     public:
         Win32Context(HDC     HDC,
-                     HGLRC   Glrc);
+                     HGLRC   Glrc,
+                     Win32GLSupport &glsupport);
         virtual ~Win32Context();
 
         /** See GLContext */
@@ -52,6 +53,7 @@ namespace Ogre {
     protected:
         HDC     mHDC;
         HGLRC   mGlrc;
+        Win32GLSupport &mGLSupport;
     };
 }
 

--- a/RenderSystems/GLSupport/include/win32/OgreWin32GLSupport.h
+++ b/RenderSystems/GLSupport/include/win32/OgreWin32GLSupport.h
@@ -68,6 +68,8 @@ namespace Ogre
 
         bool selectPixelFormat(HDC hdc, int colourDepth, int multisample, bool hwGamma);
 
+        HGLRC createNewContext(HDC hdc, HGLRC shareList);
+
         virtual unsigned int getDisplayMonitorCount() const;
     private:
         Win32Window *mInitialWindow;

--- a/RenderSystems/GLSupport/include/win32/OgreWin32RenderTexture.h
+++ b/RenderSystems/GLSupport/include/win32/OgreWin32RenderTexture.h
@@ -37,7 +37,7 @@ namespace Ogre {
     class _OgreGLExport Win32PBuffer : public GLPBuffer
     {
     public:
-        Win32PBuffer(PixelComponentType format, size_t width, size_t height);
+        Win32PBuffer(PixelComponentType format, size_t width, size_t height, Win32GLSupport &glsupport);
         ~Win32PBuffer();
         
         GLContext *getContext() const { return mContext; }

--- a/RenderSystems/GLSupport/src/win32/OgreWin32Context.cpp
+++ b/RenderSystems/GLSupport/src/win32/OgreWin32Context.cpp
@@ -33,12 +33,14 @@ THE SOFTWARE.
 #include "OgreException.h"
 #include "OgreGLRenderSystemCommon.h"
 #include "OgreRoot.h"
+#include "OgreWin32GLSupport.h"
 
 namespace Ogre {
 
-    Win32Context::Win32Context(HDC HDC, HGLRC Glrc):
+    Win32Context::Win32Context(HDC HDC, HGLRC Glrc, Win32GLSupport &glsupport):
         mHDC(HDC),
-        mGlrc(Glrc)
+        mGlrc(Glrc),
+        mGLSupport(glsupport)
     {
     }
     
@@ -61,30 +63,16 @@ namespace Ogre {
 
     GLContext* Win32Context::clone() const
     {
-        // Create new context based on own HDC
-        HGLRC newCtx = wglCreateContext(mHDC);
-        
-        if (!newCtx)
-        {
-            OGRE_EXCEPT(Exception::ERR_INTERNAL_ERROR, 
-                "Error calling wglCreateContext", "Win32Context::clone");
-        }
-
         HGLRC oldrc = wglGetCurrentContext();
+        // Create new context based on own HDC
+        HGLRC newCtx = mGLSupport.createNewContext(mHDC, oldrc);
+        
         HDC oldhdc = wglGetCurrentDC();
-        wglMakeCurrent(NULL, NULL);
-        // Share lists with old context
-        if (!wglShareLists(mGlrc, newCtx))
-        {
-            String errorMsg = translateWGLError();
-            wglDeleteContext(newCtx);
-            OGRE_EXCEPT(Exception::ERR_RENDERINGAPI_ERROR, String("wglShareLists() failed: ") + errorMsg, "Win32Context::clone");
-        }
+
         // restore old context
         wglMakeCurrent(oldhdc, oldrc);
-        
 
-        return new Win32Context(mHDC, newCtx);
+        return new Win32Context(mHDC, newCtx, mGLSupport);
     }
 
     void Win32Context::releaseContext()

--- a/RenderSystems/GLSupport/src/win32/OgreWin32RenderTexture.cpp
+++ b/RenderSystems/GLSupport/src/win32/OgreWin32RenderTexture.cpp
@@ -38,14 +38,14 @@ THE SOFTWARE.
 
 namespace Ogre {
 
-     Win32PBuffer::Win32PBuffer(PixelComponentType format, size_t width, size_t height):
+     Win32PBuffer::Win32PBuffer(PixelComponentType format, size_t width, size_t height, Win32GLSupport &glsupport):
         GLPBuffer(format, width, height),
         mContext(0)
     {
         createPBuffer();
 
         // Create context
-        mContext = new Win32Context(mHDC, mGlrc);
+        mContext = new Win32Context(mHDC, mGlrc, glsupport);
 #if 0
         if(mUseBind)
         {

--- a/RenderSystems/GLSupport/src/win32/OgreWin32Window.cpp
+++ b/RenderSystems/GLSupport/src/win32/OgreWin32Window.cpp
@@ -472,17 +472,8 @@ namespace Ogre {
         }
         if (mOwnsGLContext)
         {
-            mGlrc = wglCreateContext(mHDC);
-            if (!mGlrc)
-                OGRE_EXCEPT(Exception::ERR_RENDERINGAPI_ERROR, 
-                "wglCreateContext failed: " + translateWGLError(), "Win32Window::create");
-        }
-
-        if (old_context && old_context != mGlrc)
-        {
-            // Share lists with old context
-            if (!wglShareLists(old_context, mGlrc))
-                OGRE_EXCEPT(Exception::ERR_RENDERINGAPI_ERROR, "wglShareLists() failed", " Win32Window::create");
+            // New context is shared with previous one
+            mGlrc = mGLSupport.createNewContext(mHDC, old_context);
         }
 
         if (!wglMakeCurrent(mHDC, mGlrc))
@@ -505,7 +496,7 @@ namespace Ogre {
         }
 
         // Create RenderSystem context
-        mContext = new Win32Context(mHDC, mGlrc);
+        mContext = new Win32Context(mHDC, mGlrc, mGLSupport);
 
         mActive = true;
         setHidden(hidden);


### PR DESCRIPTION
for context ceation. Similar to GLX. Allows using renderdoc.