### PR TITLE
Main: MovableObject - make getVisibilityFlags getQueryFlags virtual

### DIFF
--- a/Components/Terrain/include/OgreTerrainQuadTreeNode.h
+++ b/Components/Terrain/include/OgreTerrainQuadTreeNode.h
@@ -223,7 +223,10 @@ namespace Ogre
         bool pointIntersectsNode(long x, long y);
 
         /// Get the AABB (local coords) of this node
-        const AxisAlignedBox& getAABB() const;
+        const AxisAlignedBox& getBoundingBox(void) const { return mAABB; }
+
+        /// @deprecated use getBoundingBox
+        OGRE_DEPRECATED const AxisAlignedBox& getAABB() const;
         /// Get the bounding radius of this node
         Real getBoundingRadius() const;
         /// Get the local centre of this node, relative to parent terrain centre

--- a/Components/Terrain/src/OgreTerrain.cpp
+++ b/Components/Terrain/src/OgreTerrain.cpp
@@ -239,7 +239,7 @@ namespace Ogre
         if (!mQuadTree)
             return AxisAlignedBox::BOX_NULL;
         else
-            return mQuadTree->getAABB();
+            return mQuadTree->getBoundingBox();
     }
     //---------------------------------------------------------------------
     AxisAlignedBox Terrain::getWorldAABB() const

--- a/Components/Terrain/src/OgreTerrainAutoUpdateLod.cpp
+++ b/Components/Terrain/src/OgreTerrainAutoUpdateLod.cpp
@@ -104,10 +104,10 @@ namespace Ogre
         {
             // Get distance to this terrain node (to closest point of the box)
             // head towards centre of the box (note, box may not cover mLocalCentre because of height)
-            Vector3 dir(node->getAABB().getCenter() - localPos);
+            Vector3 dir(node->getBoundingBox().getCenter() - localPos);
             dir.normalise();
             Ray ray(localPos, dir);
-            std::pair<bool, Real> intersectRes = Math::intersects(ray, node->getAABB());
+            std::pair<bool, Real> intersectRes = Math::intersects(ray, node->getBoundingBox());
 
             // ray will always intersect, we just want the distance
             dist = intersectRes.second;

--- a/Components/Terrain/src/OgreTerrainQuadTreeNode.cpp
+++ b/Components/Terrain/src/OgreTerrainQuadTreeNode.cpp
@@ -556,7 +556,7 @@ namespace Ogre
                     mChildren[i]->updateVertexData(positions, deltas, rect, cpuData);
 
                     // merge bounds from children
-                    AxisAlignedBox childBox = mChildren[i]->getAABB();
+                    AxisAlignedBox childBox = mChildren[i]->getBoundingBox();
                     // this box is relative to child centre
                     Vector3 boxoffset = mChildren[i]->getLocalCentre() - getLocalCentre();
                     childBox.setMinimum(childBox.getMinimum() + boxoffset);
@@ -1499,7 +1499,7 @@ namespace Ogre
     //---------------------------------------------------------------------
     const AxisAlignedBox& TerrainQuadTreeNode::Movable::getBoundingBox(void) const
     {
-        return mParent->getAABB();
+        return mParent->getBoundingBox();
     }
     //---------------------------------------------------------------------
     Real TerrainQuadTreeNode::Movable::getBoundingRadius(void) const

--- a/OgreMain/include/OgreMovableObject.h
+++ b/OgreMain/include/OgreMovableObject.h
@@ -414,7 +414,7 @@ namespace Ogre {
         void removeQueryFlags(uint32 flags) { mQueryFlags &= ~flags; }
         
         /// Returns the query flags relevant for this object
-        uint32 getQueryFlags(void) const { return mQueryFlags; }
+        virtual uint32 getQueryFlags(void) const { return mQueryFlags; }
 
         /** Set the default query flags for all future MovableObject instances.
         */
@@ -442,7 +442,7 @@ namespace Ogre {
         void removeVisibilityFlags(uint32 flags) { mVisibilityFlags &= ~flags; }
         
         /// Returns the visibility flags relevant for this object
-        uint32 getVisibilityFlags(void) const { return mVisibilityFlags; }
+        virtual uint32 getVisibilityFlags(void) const { return mVisibilityFlags; }
 
         /** Set the default visibility flags for all future MovableObject instances.
         */


### PR DESCRIPTION
to fix TerrainQuadTreeNode which stores this in its parent