### PR TITLE
fix spelling errors reported by lintian

### DIFF
--- a/CMake/Utils/PrecompiledHeader.cmake
+++ b/CMake/Utils/PrecompiledHeader.cmake
@@ -382,7 +382,7 @@ MACRO(ADD_NATIVE_PRECOMPILED_HEADER _targetName _input)
         # For Xcode, cmake needs my patch to process
         # GCC_PREFIX_HEADER and GCC_PRECOMPILE_PREFIX_HEADER as target properties
 
-        # When buiding out of the tree, precompiled may not be located
+        # When building out of the tree, precompiled may not be located
         # Use full path instead.
         GET_FILENAME_COMPONENT(fullPath ${_input} ABSOLUTE)
 

--- a/Components/RTShaderSystem/include/OgreShaderFunction.h
+++ b/Components/RTShaderSystem/include/OgreShaderFunction.h
@@ -172,7 +172,7 @@ public:
         return _getParameterByContent(mOutputParameters, content, type);
     }
 
-    /// @deprecated local parameters do not have index or sematic. use resolveLocalParameter(const String&, GpuConstantType)
+    /// @deprecated local parameters do not have index or semantic. use resolveLocalParameter(const String&, GpuConstantType)
     ParameterPtr resolveLocalParameter(Parameter::Semantic semantic, int index, const String& name, GpuConstantType type);
 
     /** Resolve local parameter of this function    
@@ -191,7 +191,7 @@ public:
         return resolveLocalParameter(Parameter::SPS_UNKNOWN, 0, name, type);
     }
 
-    /// @deprecated local parameters do not have index or sematic. use resolveLocalParameter(const String&, GpuConstantType)
+    /// @deprecated local parameters do not have index or semantic. use resolveLocalParameter(const String&, GpuConstantType)
     ParameterPtr resolveLocalParameter(Parameter::Semantic semantic, int index, const Parameter::Content content, GpuConstantType type);
 
     /** Resolve local parameter of this function

--- a/Components/RTShaderSystem/src/OgreShaderFunction.cpp
+++ b/Components/RTShaderSystem/src/OgreShaderFunction.cpp
@@ -450,7 +450,7 @@ void Function::addInputParameter(ParameterPtr parameter)
     if (_getParameterBySemantic(mInputParameters, parameter->getSemantic(), parameter->getIndex()).get() != NULL)
     {
         OGRE_EXCEPT( Exception::ERR_INVALIDPARAMS, 
-            "Parameter <" + parameter->getName() + "> has equal sematic parameter in function <" + getName() + ">",             
+            "Parameter <" + parameter->getName() + "> has equal semantic parameter in function <" + getName() + ">",
             "Function::addInputParameter" );
     }
 
@@ -464,7 +464,7 @@ void Function::addOutputParameter(ParameterPtr parameter)
     if (_getParameterBySemantic(mOutputParameters, parameter->getSemantic(), parameter->getIndex()).get() != NULL)
     {
         OGRE_EXCEPT( Exception::ERR_INVALIDPARAMS, 
-            "Parameter <" + parameter->getName() + "> has equal sematic parameter in function <" + getName() + ">",             
+            "Parameter <" + parameter->getName() + "> has equal semantic parameter in function <" + getName() + ">",
             "Function::addOutputParameter" );
     }
 

--- a/OgreMain/include/OgreString.h
+++ b/OgreMain/include/OgreString.h
@@ -112,12 +112,12 @@ namespace Ogre {
         /** Returns a StringVector that contains all the substrings delimited
             by the characters in the passed <code>delims</code> argument,
             or in the <code>doubleDelims</code> argument, which is used to include (normal)
-            delimeters in the tokenised string. For example, "strings like this".
+            delimiters in the tokenised string. For example, "strings like this".
             @param str
             @param
             delims A list of delimiter characters to split by
             @param
-            doubleDelims A list of double delimeters characters to tokenise by
+            doubleDelims A list of double delimiters characters to tokenise by
             @param
             maxSplits The maximum number of splits to perform (0 for unlimited splits). If this
             parameters is > 0, the splitting process will stop after this many splits, left to right.

--- a/OgreMain/src/OgreDataStream.cpp
+++ b/OgreMain/src/OgreDataStream.cpp
@@ -573,7 +573,7 @@ namespace Ogre {
         if (delim.size() > 1)
         {
             LogManager::getSingleton().logWarning(
-                "FileStreamDataStream::readLine - using only first delimeter");
+                "FileStreamDataStream::readLine - using only first delimiter");
         }
         // Deal with both Unix & Windows LFs
         bool trimCR = false;

--- a/OgreMain/src/OgreHighLevelGpuProgram.cpp
+++ b/OgreMain/src/OgreHighLevelGpuProgram.cpp
@@ -305,7 +305,7 @@ namespace Ogre
             // find following newline (or EOF)
             size_t newLineAfter = std::min(inSource.find('\n', afterIncludePos), inSource.size());
             // find include file string container
-            char endDelimeter = '"';
+            char endDelimiter = '"';
             size_t startIt = inSource.find('"', afterIncludePos);
             if (startIt == String::npos || startIt > newLineAfter)
             {
@@ -319,14 +319,14 @@ namespace Ogre
                 }
                 else
                 {
-                    endDelimeter = '>';
+                    endDelimiter = '>';
                 }
             }
-            size_t endIt = inSource.find(endDelimeter, startIt+1);
+            size_t endIt = inSource.find(endDelimiter, startIt+1);
             if (endIt == String::npos || endIt <= startIt)
             {
                 OGRE_EXCEPT(Exception::ERR_INTERNAL_ERROR,
-                            "Badly formed #include directive (expected " + String(1, endDelimeter) +
+                            "Badly formed #include directive (expected " + String(1, endDelimiter) +
                                 ") in file " + fileName + ": " +
                                 inSource.substr(includePos, newLineAfter - includePos));
             }

--- a/OgreMain/src/OgreStaticGeometry.cpp
+++ b/OgreMain/src/OgreStaticGeometry.cpp
@@ -1168,7 +1168,7 @@ namespace Ogre {
         // We need to search the edge list for silhouette edges
         if (!mEdgeList)
         {
-            OGRE_EXCEPT(Exception::ERR_INVALIDPARAMS, "You enabled stencil shadows after the buid process!");
+            OGRE_EXCEPT(Exception::ERR_INVALIDPARAMS, "You enabled stencil shadows after the build process!");
         }
 
         // Init shadow renderable list if required

--- a/RenderSystems/GL/src/OgreGLRenderToVertexBuffer.cpp
+++ b/RenderSystems/GL/src/OgreGLRenderToVertexBuffer.cpp
@@ -257,7 +257,7 @@ namespace Ogre {
         //TODO : Implement more?
         default:
             OGRE_EXCEPT(Exception::ERR_RENDERINGAPI_ERROR, 
-                "Unsupported vertex element sematic in render to vertex buffer", 
+                "Unsupported vertex element semantic in render to vertex buffer",
                 "OgreGLRenderToVertexBuffer::getSemanticVaryingName");
         }
     }
@@ -277,7 +277,7 @@ namespace Ogre {
         //TODO : Implement more?
         default:
             OGRE_EXCEPT(Exception::ERR_RENDERINGAPI_ERROR, 
-                "Unsupported vertex element sematic in render to vertex buffer", 
+                "Unsupported vertex element semantic in render to vertex buffer",
                 "OgreGLRenderToVertexBuffer::getGLSemanticType");
             
         }

--- a/RenderSystems/GL/src/nvparse/_vs1.0_lexer.cpp
+++ b/RenderSystems/GL/src/nvparse/_vs1.0_lexer.cpp
@@ -4284,7 +4284,7 @@ bool ParseBuiltInMacroParms(MACROENTRY *parsedMacro, char *parmStr)
 	foundParm = strdup(parmStr);
 	if (foundParm == NULL)
 	{
-		LexError("Out of memory parsing bultin macro parameters.\n");
+		LexError("Out of memory parsing builtin macro parameters.\n");
 		return false;
 	}
 
@@ -4305,7 +4305,7 @@ bool ParseBuiltInMacroParms(MACROENTRY *parsedMacro, char *parmStr)
 		if (curMT == NULL)
 		{
 			free(parmStr);
-			LexError("Out of memory parsing bultin macro parameters.\n");
+			LexError("Out of memory parsing builtin macro parameters.\n");
 			return false;
 		} 
 		curMT->next = NULL;

--- a/RenderSystems/GL/src/nvparse/vs1.0_tokens.l
+++ b/RenderSystems/GL/src/nvparse/vs1.0_tokens.l
@@ -2173,7 +2173,7 @@ bool ParseBuiltInMacroParms(MACROENTRY *parsedMacro, char *parmStr)
 	foundParm = strdup(parmStr);
 	if (foundParm == NULL)
 	{
-		LexError("Out of memory parsing bultin macro parameters.\n");
+		LexError("Out of memory parsing builtin macro parameters.\n");
 		return false;
 	}
 
@@ -2194,7 +2194,7 @@ bool ParseBuiltInMacroParms(MACROENTRY *parsedMacro, char *parmStr)
 		if (curMT == NULL)
 		{
 			free(parmStr);
-			LexError("Out of memory parsing bultin macro parameters.\n");
+			LexError("Out of memory parsing builtin macro parameters.\n");
 			return false;
 		} 
 		curMT->next = NULL;

--- a/RenderSystems/GL3Plus/src/OgreGL3PlusRenderToVertexBuffer.cpp
+++ b/RenderSystems/GL3Plus/src/OgreGL3PlusRenderToVertexBuffer.cpp
@@ -304,7 +304,7 @@ namespace Ogre {
             //TODO : Implement more?
         default:
             OGRE_EXCEPT(Exception::ERR_RENDERINGAPI_ERROR,
-                        "Unsupported vertex element sematic in render to vertex buffer",
+                        "Unsupported vertex element semantic in render to vertex buffer",
                         "OgreGL3PlusRenderToVertexBuffer::getSemanticVaryingName");
         }
     }

--- a/RenderSystems/GLES2/src/GLSLES/src/OgreGLSLESCgProgram.cpp
+++ b/RenderSystems/GLES2/src/GLSLES/src/OgreGLSLESCgProgram.cpp
@@ -161,7 +161,7 @@ namespace Ogre {
             // find following newline (or EOF)
             size_t newLineAfter = inSource.find("\n", afterRegisterPos);
             // find register file string container
-            String endDelimeter = "\"";
+            String endDelimiter = "\"";
             size_t startIt = inSource.find("\"", afterRegisterPos);
             if (startIt == String::npos || startIt > newLineAfter)
             {
@@ -176,14 +176,14 @@ namespace Ogre {
                 }
                 else
                 {
-                    endDelimeter = ")";
+                    endDelimiter = ")";
                 }
             }
-            size_t endIt = inSource.find(endDelimeter, startIt+1);
+            size_t endIt = inSource.find(endDelimiter, startIt+1);
             if (endIt == String::npos || endIt <= startIt)
             {
                 OGRE_EXCEPT(Exception::ERR_INTERNAL_ERROR,
-                    "Badly formed register directive (expected " + endDelimeter + ") in file "
+                    "Badly formed register directive (expected " + endDelimiter + ") in file "
                     + mFilename + ": " + inSource.substr(registerPos, newLineAfter-registerPos),
                     "GLSLESCgProgram::deleteRegisterFromCg");
             }

--- a/RenderSystems/GLES2/src/OgreGLES2RenderToVertexBuffer.cpp
+++ b/RenderSystems/GLES2/src/OgreGLES2RenderToVertexBuffer.cpp
@@ -236,7 +236,7 @@ namespace Ogre {
         //TODO : Implement more?
         default:
             OGRE_EXCEPT(Exception::ERR_RENDERINGAPI_ERROR, 
-                "Unsupported vertex element sematic in render to vertex buffer", 
+                "Unsupported vertex element semantic in render to vertex buffer",
                 "OgreGLES2RenderToVertexBuffer::getSemanticVaryingName");
         }
     }

--- a/Tools/XSIExport/OGREXSI_Readme.html
+++ b/Tools/XSIExport/OGREXSI_Readme.html
@@ -513,7 +513,7 @@ It is now possible to automate the exporting process by using
 
   <li><b>calculateTangents</b>: Calculate Tangents (normal mapping). (default: false)</li>
 
-  <li><b>tangentSemantic</b>: Tangent Sematic. True for tangent, false for texture coords. (default: true)</li>
+  <li><b>tangentSemantic</b>: Tangent semantic. True for tangent, false for texture coords. (default: true)</li>
 
   <li><b>tangentsSplitMirrored</b>: Split tangents at UV mirror. (default: false)</li>
 

--- a/Tools/XSIExport/include/OgreXSIMeshExporter.h
+++ b/Tools/XSIExport/include/OgreXSIMeshExporter.h
@@ -300,7 +300,7 @@ namespace Ogre {
         /** Try to look up an existing vertex with the same information, or
             create a new one.
         @remarks
-            Note that we buid up the list of unique position indexes that are
+            Note that we build up the list of unique position indexes that are
             actually used by each ProtoSubMesh as we go. When new positions
             are found, they are added and a remap entry created to take account
             of the fact that there may be extra vertices created in between, or


### PR DESCRIPTION
https://games-team.pages.debian.net/-/ogre/-/jobs/1292553/artifacts/debian/output/lintian.html

complains about a few typos in strings. I couldn't find all of them but also found a few additional occurrences in variable names etc.