### PR TITLE
RTSS: assert that we have a sceneManager in synchronizeWithLightSettings

### DIFF
--- a/Components/RTShaderSystem/src/OgreShaderGenerator.cpp
+++ b/Components/RTShaderSystem/src/OgreShaderGenerator.cpp
@@ -1883,8 +1883,10 @@ void ShaderGenerator::SGScheme::synchronizeWithLightSettings()
     SceneManager* sceneManager = ShaderGenerator::getSingleton().getActiveSceneManager();
     RenderState* curRenderState = getRenderState();
 
-    if (sceneManager != NULL && curRenderState->getLightCountAutoUpdate())
+    if (curRenderState->getLightCountAutoUpdate())
     {
+        OgreAssert(sceneManager, "no active SceneManager. Did you forget to call ShaderGenerator::addSceneManager?");
+
         const LightList& lightList =  sceneManager->_getLightsAffectingFrustum();
         
         Vector3i sceneLightCount(0, 0, 0);

--- a/Tests/Components/RTShaderSystemTests.cpp
+++ b/Tests/Components/RTShaderSystemTests.cpp
@@ -63,6 +63,7 @@ TEST_F(RTShaderSystem, createShaderBasedTechnique)
     auto mat = MaterialManager::getSingleton().create("TestMat", RGN_DEFAULT);
 
     EXPECT_TRUE(shaderGen.createShaderBasedTechnique(mat->getTechniques()[0], "MyScheme"));
+    shaderGen.getRenderState("MyScheme")->setLightCountAutoUpdate(false);
 
     EXPECT_EQ(mat->getTechniques().size(), size_t(1));
     shaderGen.validateMaterial("MyScheme", *mat);
@@ -83,6 +84,7 @@ TEST_F(RTShaderSystem, MaterialSerializer)
     auto mat = MaterialManager::getSingleton().create("TestMat", RGN_DEFAULT);
 
     shaderGen.createShaderBasedTechnique(mat->getTechniques()[0], "MyScheme");
+    shaderGen.getRenderState("MyScheme")->setLightCountAutoUpdate(false);
 
     auto rstate = shaderGen.getRenderState("MyScheme", *mat);
     rstate->addTemplateSubRenderState(shaderGen.createSubRenderState<RTShader::FFPColour>());


### PR DESCRIPTION
this is a common issue when addSceneManager is omitted by accident