### PR TITLE
D3D*: fix braindead CSAA naming and mode selection

### DIFF
--- a/OgreMain/src/OgreRenderSystem.cpp
+++ b/OgreMain/src/OgreRenderSystem.cpp
@@ -196,10 +196,12 @@ namespace Ogre {
             miscParams.emplace("FSAA", std::to_string(fsaa));
 
             // D3D specific
-            String hint;
-            fsaaMode >> hint;
             if(!fsaaMode.eof())
+            {
+                String hint;
+                fsaaMode >> hint;
                 miscParams.emplace("FSAAHint", hint);
+            }
         }
 
         if((opt = mOptions.find("VSync")) != end)


### PR DESCRIPTION
also allows using CSAA on AMD with D3D9 and fixes parsing of CSAA level

fixes #1419