### PR TITLE
Main: GpuProgramParams - use unified constant storage

### DIFF
--- a/Components/RTShaderSystem/src/OgreShaderProgramProcessor.cpp
+++ b/Components/RTShaderSystem/src/OgreShaderProgramProcessor.cpp
@@ -84,7 +84,7 @@ void ProgramProcessor::bindAutoParameters(Program* pCpuProgram, GpuProgramPtr pG
                 // Update variability in the float map.
                 if (gpuConstDef->isSampler() == false)
                 {
-                    GpuLogicalBufferStructPtr floatLogical = pGpuParams->getFloatLogicalBufferStruct();
+                    GpuLogicalBufferStructPtr floatLogical = pGpuParams->getLogicalBufferStruct();
                     if (floatLogical.get())
                     {
                         for (GpuLogicalIndexUseMap::const_iterator i = floatLogical->map.begin(); i != floatLogical->map.end(); ++i)

--- a/OgreMain/include/Ogre.i
+++ b/OgreMain/include/Ogre.i
@@ -169,6 +169,7 @@ JNIEnv* OgreJNIGetEnv() {
 %ignore Ogre::HardwareBuffer::UsageEnum;
 %ignore Ogre::TextureUsage;
 %ignore Ogre::GpuConstantType;
+%ignore Ogre::GpuProgramParameters::ElementType;
 %ignore Ogre::Capabilities;
 %typemap(csbase) Ogre::SceneManager::QueryTypeMask "uint";
 %csmethodmodifiers *::ToString "public override";

--- a/OgreMain/include/OgreGpuProgram.h
+++ b/OgreMain/include/OgreGpuProgram.h
@@ -165,13 +165,7 @@ namespace Ogre {
         programs or high-level programs which set their params the same way.
         This is a shared pointer because if the program is recompiled and the parameters
         change, this definition will alter, but previous params may reference the old def. */
-    mutable GpuLogicalBufferStructPtr mFloatLogicalToPhysical;
-    /// @copydoc mFloatLogicalToPhysical
-    mutable GpuLogicalBufferStructPtr mDoubleLogicalToPhysical;
-    /// @copydoc mFloatLogicalToPhysical
-    mutable GpuLogicalBufferStructPtr mIntLogicalToPhysical;
-    /// static nullPtr
-    static GpuLogicalBufferStructPtr mBoolLogicalToPhysical;
+    mutable GpuLogicalBufferStructPtr mLogicalToPhysical;
     /** Parameter name -> ConstantDefinition map, shared instance used by all parameter objects.
         This is a shared pointer because if the program is recompiled and the parameters
         change, this definition will alter, but previous params may reference the old def.

--- a/OgreMain/include/OgreHighLevelGpuProgram.h
+++ b/OgreMain/include/OgreHighLevelGpuProgram.h
@@ -92,7 +92,7 @@ namespace Ogre {
         /** Build the constant definition map, must be overridden.
         @note The implementation must fill in the (inherited) mConstantDefs field at a minimum, 
             and if the program requires that parameters are bound using logical 
-            parameter indexes then the mFloatLogicalToPhysical and mIntLogicalToPhysical
+            parameter indexes then the mLogicalToPhysical and mIntLogicalToPhysical
             maps must also be populated.
         */
         virtual void buildConstantDefinitions() const = 0;

--- a/OgreMain/src/OgreHighLevelGpuProgram.cpp
+++ b/OgreMain/src/OgreHighLevelGpuProgram.cpp
@@ -255,8 +255,7 @@ namespace Ogre
         getConstantDefinitions();
         params->_setNamedConstants(mConstantDefs);
         // also set logical / physical maps for programs which use this
-        params->_setLogicalIndexes(mFloatLogicalToPhysical, mDoubleLogicalToPhysical,
-                                   mIntLogicalToPhysical);
+        params->_setLogicalIndexes(mLogicalToPhysical);
     }
 
     //-----------------------------------------------------------------------

--- a/OgreMain/src/OgreMaterialSerializer.cpp
+++ b/OgreMain/src/OgreMaterialSerializer.cpp
@@ -1586,7 +1586,7 @@ namespace Ogre
         // This will represent the values which have been set
 
         // float params
-        GpuLogicalBufferStructPtr floatLogical = params->getFloatLogicalBufferStruct();
+        GpuLogicalBufferStructPtr floatLogical = params->getLogicalBufferStruct();
         if( floatLogical )
         {
             OGRE_LOCK_MUTEX(floatLogical->mutex);
@@ -1611,63 +1611,6 @@ namespace Ogre
                                          logicalUse.physicalIndex, logicalUse.currentSize,
                                          params, defaultParams, level, useMainBuffer);
             }
-        }
-
-        // double params
-        GpuLogicalBufferStructPtr doubleLogical = params->getDoubleLogicalBufferStruct();
-        if( doubleLogical )
-        {
-            OGRE_LOCK_MUTEX(doubleLogical->mutex);
-
-            for(GpuLogicalIndexUseMap::const_iterator i = doubleLogical->map.begin();
-                i != doubleLogical->map.end(); ++i)
-            {
-                size_t logicalIndex = i->first;
-                const GpuLogicalIndexUse& logicalUse = i->second;
-
-                const GpuProgramParameters::AutoConstantEntry* autoEntry =
-                    params->findDoubleAutoConstantEntry(logicalIndex);
-                const GpuProgramParameters::AutoConstantEntry* defaultAutoEntry = 0;
-                if (defaultParams)
-                {
-                    defaultAutoEntry = defaultParams->findDoubleAutoConstantEntry(logicalIndex);
-                }
-
-                writeGpuProgramParameter("param_indexed",
-                                         StringConverter::toString(logicalIndex), autoEntry,
-                                         defaultAutoEntry, false, true, false, false,
-                                         logicalUse.physicalIndex, logicalUse.currentSize,
-                                         params, defaultParams, level, useMainBuffer);
-            }
-        }
-
-        // int params
-        GpuLogicalBufferStructPtr intLogical = params->getIntLogicalBufferStruct();
-        if( intLogical )
-        {
-            OGRE_LOCK_MUTEX(intLogical->mutex);
-
-            for(GpuLogicalIndexUseMap::const_iterator i = intLogical->map.begin();
-                i != intLogical->map.end(); ++i)
-            {
-                size_t logicalIndex = i->first;
-                const GpuLogicalIndexUse& logicalUse = i->second;
-
-                const GpuProgramParameters::AutoConstantEntry* autoEntry = 
-                    params->findIntAutoConstantEntry(logicalIndex);
-                const GpuProgramParameters::AutoConstantEntry* defaultAutoEntry = 0;
-                if (defaultParams)
-                {
-                    defaultAutoEntry = defaultParams->findIntAutoConstantEntry(logicalIndex);
-                }
-
-                writeGpuProgramParameter("param_indexed", 
-                                         StringConverter::toString(logicalIndex), autoEntry, 
-                                         defaultAutoEntry, false, false, true, false,
-                                         logicalUse.physicalIndex, logicalUse.currentSize,
-                                         params, defaultParams, level, useMainBuffer);
-            }
-
         }
     }
     //-----------------------------------------------------------------------

--- a/OgreMain/src/OgreRenderSystem.cpp
+++ b/OgreMain/src/OgreRenderSystem.cpp
@@ -91,10 +91,9 @@ namespace Ogre {
         if(mFixedFunctionParams)
             return;
 
-        GpuLogicalBufferStructPtr nullPtr;
         GpuLogicalBufferStructPtr logicalBufferStruct(new GpuLogicalBufferStruct());
         mFixedFunctionParams.reset(new GpuProgramParameters);
-        mFixedFunctionParams->_setLogicalIndexes(logicalBufferStruct, nullPtr, nullPtr);
+        mFixedFunctionParams->_setLogicalIndexes(logicalBufferStruct);
         mFixedFunctionParams->setAutoConstant(0, GpuProgramParameters::ACT_WORLD_MATRIX);
         mFixedFunctionParams->setAutoConstant(4, GpuProgramParameters::ACT_VIEW_MATRIX);
         mFixedFunctionParams->setAutoConstant(8, GpuProgramParameters::ACT_PROJECTION_MATRIX);

--- a/PlugIns/CgProgramManager/src/OgreCgProgram.cpp
+++ b/PlugIns/CgProgramManager/src/OgreCgProgram.cpp
@@ -894,8 +894,7 @@ namespace Ogre {
 		if ( mProgramString.empty() )
 			return;
 
-		mConstantDefs->floatBufferSize = mFloatLogicalToPhysical->bufferSize;
-		mConstantDefs->intBufferSize = mIntLogicalToPhysical->bufferSize;
+		mConstantDefs->bufferSize = mLogicalToPhysical->bufferSize;
 
 		GpuConstantDefinitionMap::const_iterator iter = mParametersMap.begin();
 		GpuConstantDefinitionMap::const_iterator iterE = mParametersMap.end();
@@ -906,20 +905,10 @@ namespace Ogre {
 			mConstantDefs->map.emplace(iter->first, iter->second);
 
 			// Record logical / physical mapping
-			if (def.isFloat())
-			{
-							OGRE_LOCK_MUTEX(mFloatLogicalToPhysical->mutex);
-				mFloatLogicalToPhysical->map.emplace(def.logicalIndex,
-						GpuLogicalIndexUse(def.physicalIndex, def.arraySize * def.elementSize, GPV_GLOBAL));
-				mFloatLogicalToPhysical->bufferSize += def.arraySize * def.elementSize;
-			}
-			else
-			{
-							OGRE_LOCK_MUTEX(mIntLogicalToPhysical->mutex);
-				mIntLogicalToPhysical->map.emplace(def.logicalIndex,
-						GpuLogicalIndexUse(def.physicalIndex, def.arraySize * def.elementSize, GPV_GLOBAL));
-				mIntLogicalToPhysical->bufferSize += def.arraySize * def.elementSize;
-			}
+			OGRE_LOCK_MUTEX(mLogicalToPhysical->mutex);
+			mLogicalToPhysical->map.emplace(def.logicalIndex,
+					GpuLogicalIndexUse(def.physicalIndex, def.arraySize * def.elementSize, GPV_GLOBAL, def.isFloat() ? BCT_FLOAT: BCT_INT));
+			mLogicalToPhysical->bufferSize += def.arraySize * def.elementSize;
 		}
 	}
 	//---------------------------------------------------------------------
@@ -1008,14 +997,7 @@ namespace Ogre {
 					else
 					{
 						// base position on existing buffer contents
-						if (def.isFloat())
-						{
-							def.physicalIndex = mFloatLogicalToPhysical->bufferSize;
-						}
-						else
-						{
-							def.physicalIndex = mIntLogicalToPhysical->bufferSize;
-						}
+						def.physicalIndex = mLogicalToPhysical->bufferSize*4;
 					}
 
 					def.logicalIndex = logicalIndex;
@@ -1028,20 +1010,10 @@ namespace Ogre {
 					}
 
 					// Record logical / physical mapping
-					if (def.isFloat())
-					{
-											OGRE_LOCK_MUTEX(mFloatLogicalToPhysical->mutex);
-						mFloatLogicalToPhysical->map.emplace(def.logicalIndex,
-								GpuLogicalIndexUse(def.physicalIndex, def.arraySize * def.elementSize, GPV_GLOBAL));
-						mFloatLogicalToPhysical->bufferSize += def.arraySize * def.elementSize;
-					}
-					else
-					{
-											OGRE_LOCK_MUTEX(mIntLogicalToPhysical->mutex);
-						mIntLogicalToPhysical->map.emplace(def.logicalIndex,
-								GpuLogicalIndexUse(def.physicalIndex, def.arraySize * def.elementSize, GPV_GLOBAL));
-						mIntLogicalToPhysical->bufferSize += def.arraySize * def.elementSize;
-					}
+					OGRE_LOCK_MUTEX(mFloatLogicalToPhysical->mutex);
+					mLogicalToPhysical->map.emplace(def.logicalIndex,
+							GpuLogicalIndexUse(def.physicalIndex, def.arraySize * def.elementSize, GPV_GLOBAL, def.isFloat() ? BCT_FLOAT : BCT_INT));
+					mLogicalToPhysical->bufferSize += def.arraySize * def.elementSize;
 
 					break;
 				}

--- a/RenderSystems/Direct3D9/src/OgreD3D9HLSLProgram.cpp
+++ b/RenderSystems/Direct3D9/src/OgreD3D9HLSLProgram.cpp
@@ -296,8 +296,7 @@ namespace Ogre {
     //-----------------------------------------------------------------------
     void D3D9HLSLProgram::buildConstantDefinitions() const
     {
-        mConstantDefs->floatBufferSize = mFloatLogicalToPhysical->bufferSize;
-        mConstantDefs->intBufferSize = mIntLogicalToPhysical->bufferSize;
+        mConstantDefs->bufferSize = mLogicalToPhysical->bufferSize;
 
         GpuConstantDefinitionMap::const_iterator iter = mParametersMap.begin();
         GpuConstantDefinitionMap::const_iterator iterE = mParametersMap.end();
@@ -308,20 +307,10 @@ namespace Ogre {
             mConstantDefs->map.emplace(iter->first, iter->second);
 
             // Record logical / physical mapping
-            if (def.isFloat())
-            {
-                            OGRE_LOCK_MUTEX(mFloatLogicalToPhysical->mutex);
-                mFloatLogicalToPhysical->map.emplace(def.logicalIndex,
-                        GpuLogicalIndexUse(def.physicalIndex, def.arraySize * def.elementSize, GPV_GLOBAL));
-                mFloatLogicalToPhysical->bufferSize += def.arraySize * def.elementSize;
-            }
-            else
-            {
-                            OGRE_LOCK_MUTEX(mIntLogicalToPhysical->mutex);
-                mIntLogicalToPhysical->map.emplace(def.logicalIndex,
-                        GpuLogicalIndexUse(def.physicalIndex, def.arraySize * def.elementSize, GPV_GLOBAL));
-                mIntLogicalToPhysical->bufferSize += def.arraySize * def.elementSize;
-            }
+            OGRE_LOCK_MUTEX(mLogicalToPhysical->mutex);
+            mLogicalToPhysical->map.emplace(def.logicalIndex,
+                    GpuLogicalIndexUse(def.physicalIndex, def.arraySize * def.elementSize, GPV_GLOBAL, def.isFloat() ? BCT_FLOAT : BCT_INT));
+            mLogicalToPhysical->bufferSize += def.arraySize * def.elementSize;
         }
         
     }
@@ -378,22 +367,11 @@ namespace Ogre {
                 def.logicalIndex = paramIndex;
                 // populate type, array size & element size
                 populateDef(desc, def);
-                if (def.isFloat())
-                {
-                    def.physicalIndex = mFloatLogicalToPhysical->bufferSize;
-                    OGRE_LOCK_MUTEX(mFloatLogicalToPhysical->mutex);
-                    mFloatLogicalToPhysical->map.emplace(paramIndex,
-                        GpuLogicalIndexUse(def.physicalIndex, def.arraySize * def.elementSize, GPV_GLOBAL));
-                    mFloatLogicalToPhysical->bufferSize += def.arraySize * def.elementSize;
-                }
-                else
-                {
-                    def.physicalIndex = mIntLogicalToPhysical->bufferSize;
-                    OGRE_LOCK_MUTEX(mIntLogicalToPhysical->mutex);
-                    mIntLogicalToPhysical->map.emplace(paramIndex,
-                        GpuLogicalIndexUse(def.physicalIndex, def.arraySize * def.elementSize, GPV_GLOBAL));
-                    mIntLogicalToPhysical->bufferSize += def.arraySize * def.elementSize;
-                }
+                def.physicalIndex = mLogicalToPhysical->bufferSize*4;
+                OGRE_LOCK_MUTEX(mLogicalToPhysical->mutex);
+                mLogicalToPhysical->map.emplace(paramIndex,
+                    GpuLogicalIndexUse(def.physicalIndex, def.arraySize * def.elementSize, GPV_GLOBAL, def.isFloat() ? BCT_FLOAT : BCT_INT));
+                mLogicalToPhysical->bufferSize += def.arraySize * def.elementSize;
 
                 if( mParametersMap.find(name) == mParametersMap.end())
                 {

--- a/RenderSystems/GL/src/GLSL/src/OgreGLSLLinkProgram.cpp
+++ b/RenderSystems/GL/src/GLSL/src/OgreGLSLLinkProgram.cpp
@@ -241,33 +241,11 @@ namespace Ogre {
 
                     GLsizei glArraySize = (GLsizei)def->arraySize;
 
-                    bool shouldUpdate = true;
+                    void* val = def->isSampler() ? (void*)params->getRegPointer(def->physicalIndex)
+                                                 : (void*)params->getFloatPointer(def->physicalIndex);
 
-                    switch (def->constType)
-                    {
-                        case GCT_INT1:
-                        case GCT_INT2:
-                        case GCT_INT3:
-                        case GCT_INT4:
-                        case GCT_SAMPLER1D:
-                        case GCT_SAMPLER1DSHADOW:
-                        case GCT_SAMPLER2D:
-                        case GCT_SAMPLER2DSHADOW:
-                        case GCT_SAMPLER2DARRAY:
-                        case GCT_SAMPLER3D:
-                        case GCT_SAMPLERCUBE:
-                            shouldUpdate = mUniformCache->updateUniform(currentUniform->mLocation,
-                                                                        params->getIntPointer(def->physicalIndex),
-                                                                        static_cast<GLsizei>(def->elementSize * def->arraySize * sizeof(int)));
-                            break;
-                        default:
-                            shouldUpdate = mUniformCache->updateUniform(currentUniform->mLocation,
-                                                                        params->getFloatPointer(def->physicalIndex),
-                                                                        static_cast<GLsizei>(def->elementSize * def->arraySize * sizeof(float)));
-                            break;
-
-                    }
-
+                    bool shouldUpdate = mUniformCache->updateUniform(currentUniform->mLocation, val,
+                                                                     def->elementSize * def->arraySize * 4);
                     if(!shouldUpdate)
                         continue;
 
@@ -353,8 +331,7 @@ namespace Ogre {
                     case GCT_SAMPLERCUBE:
                         // samplers handled like 1-element ints
                     case GCT_INT1:
-                        glUniform1ivARB(currentUniform->mLocation, glArraySize, 
-                            (GLint*)params->getIntPointer(def->physicalIndex));
+                        glUniform1ivARB(currentUniform->mLocation, glArraySize, (GLint*)val);
                         break;
                     case GCT_INT2:
                         glUniform2ivARB(currentUniform->mLocation, glArraySize, 

--- a/RenderSystems/GL/src/GLSL/src/OgreGLSLProgram.cpp
+++ b/RenderSystems/GL/src/GLSL/src/OgreGLSLProgram.cpp
@@ -263,8 +263,7 @@ namespace Ogre {
 
         // Therefore instead, parse the source code manually and extract the uniforms
         createParameterMappingStructures(true);
-        mFloatLogicalToPhysical.reset();
-        mIntLogicalToPhysical.reset();
+        mLogicalToPhysical.reset();
 
         GLSLLinkProgramManager::getSingleton().extractUniformsFromGLSL(
             mSource, *mConstantDefs, mName);

--- a/RenderSystems/GL/src/OgreGLGpuNvparseProgram.cpp
+++ b/RenderSystems/GL/src/OgreGLGpuNvparseProgram.cpp
@@ -72,18 +72,13 @@ void GLGpuNvparseProgram::bindProgramParameters(GpuProgramParametersSharedPtr pa
     // NB, register combiners uses 2 constants per texture stage (0 and 1)
     // We have stored these as (stage * 2) + const_index in the physical buffer
     // There are no other parameters in a register combiners shader
-    const FloatConstantList& floatList = 
-        params->getFloatConstantList();
-    size_t index = 0;
-    for (FloatConstantList::const_iterator i = floatList.begin();
-        i != floatList.end(); ++i, ++index)
+    const float* floatList = params->getFloatPointer(0);
+    for (size_t i = 0; i < params->getConstantList().size()/4; ++i)
     {
-        GLenum combinerStage = GL_COMBINER0_NV + (unsigned int)(index / 2);
-        GLenum pname = GL_CONSTANT_COLOR0_NV + (index % 2);
-        glCombinerStageParameterfvNV(combinerStage, pname, &(*i));
-        
+        GLenum combinerStage = GL_COMBINER0_NV + (unsigned int)(i / 2);
+        GLenum pname = GL_CONSTANT_COLOR0_NV + (i % 2);
+        glCombinerStageParameterfvNV(combinerStage, pname, floatList + i);
     }
-
 }
 void GLGpuNvparseProgram::unloadImpl(void)
 {

--- a/RenderSystems/GL/src/OgreGLGpuProgram.cpp
+++ b/RenderSystems/GL/src/OgreGLGpuProgram.cpp
@@ -119,7 +119,7 @@ void GLArbGpuProgram::bindProgramParameters(GpuProgramParametersSharedPtr params
     GLenum type = getProgramType();
     
     // only supports float constants
-    GpuLogicalBufferStructPtr floatStruct = params->getFloatLogicalBufferStruct();
+    GpuLogicalBufferStructPtr floatStruct = params->getLogicalBufferStruct();
 
     for (GpuLogicalIndexUseMap::const_iterator i = floatStruct->map.begin();
         i != floatStruct->map.end(); ++i)

--- a/RenderSystems/GL/src/atifs/src/ATI_FS_GLGpuProgram.cpp
+++ b/RenderSystems/GL/src/atifs/src/ATI_FS_GLGpuProgram.cpp
@@ -68,7 +68,7 @@ void ATI_FS_GLGpuProgram::unbindProgram(void)
 void ATI_FS_GLGpuProgram::bindProgramParameters(GpuProgramParametersSharedPtr params, uint16 mask)
 {
     // only supports float constants
-    GpuLogicalBufferStructPtr floatStruct = params->getFloatLogicalBufferStruct();
+    GpuLogicalBufferStructPtr floatStruct = params->getLogicalBufferStruct();
 
     for (GpuLogicalIndexUseMap::const_iterator i = floatStruct->map.begin();
         i != floatStruct->map.end(); ++i)

--- a/RenderSystems/GL3Plus/src/GLSL/src/OgreGLSLMonolithicProgram.cpp
+++ b/RenderSystems/GL3Plus/src/GLSL/src/OgreGLSLMonolithicProgram.cpp
@@ -274,7 +274,10 @@ namespace Ogre {
                     case GCT_SAMPLER3D:
                     case GCT_SAMPLERCUBE:
                     case GCT_SAMPLERRECT:
-                        // Samplers handled like 1-element ints
+                        // Samplers handled like 1-element ints, but use register storage
+                        OGRE_CHECK_GL_ERROR(glUniform1iv(currentUniform->mLocation, glArraySize,
+                                    (GLint*)params->getRegPointer(def->physicalIndex)));
+                        break;
                     case GCT_INT1:
                         OGRE_CHECK_GL_ERROR(glUniform1iv(currentUniform->mLocation, glArraySize,
                                                          (GLint*)params->getIntPointer(def->physicalIndex)));

--- a/RenderSystems/GL3Plus/src/GLSL/src/OgreGLSLShader.cpp
+++ b/RenderSystems/GL3Plus/src/GLSL/src/OgreGLSLShader.cpp
@@ -517,32 +517,20 @@ namespace Ogre {
             // also allow index based referencing
             GpuLogicalIndexUse use;
 
-            if (def.isFloat())
+            if (def.isFloat() || def.isDouble() || def.isInt() || def.isUnsignedInt() || def.isBool())
             {
-                def.physicalIndex = mConstantDefs->floatBufferSize;
-                mConstantDefs->floatBufferSize += def.arraySize * def.elementSize;
+                def.physicalIndex = mConstantDefs->bufferSize*4;
+                mConstantDefs->bufferSize += def.arraySize * def.elementSize;
 
                 use.physicalIndex = def.physicalIndex;
                 use.currentSize = def.arraySize * def.elementSize;
-                mFloatLogicalToPhysical->map.emplace(def.logicalIndex, use);
+                mLogicalToPhysical->map.emplace(def.logicalIndex, use);
             }
-            else if (def.isDouble())
+            else if(def.isSampler())
             {
-                def.physicalIndex = mConstantDefs->doubleBufferSize;
-                mConstantDefs->doubleBufferSize += def.arraySize * def.elementSize;
-
-                use.physicalIndex = def.physicalIndex;
-                use.currentSize = def.arraySize * def.elementSize;
-                mDoubleLogicalToPhysical->map.emplace(def.logicalIndex, use);
-            }
-            else if (def.isInt() || def.isSampler() || def.isUnsignedInt() || def.isBool())
-            {
-                def.physicalIndex = mConstantDefs->intBufferSize;
-                mConstantDefs->intBufferSize += def.arraySize * def.elementSize;
-
-                use.physicalIndex = def.physicalIndex;
-                use.currentSize = def.arraySize * def.elementSize;
-                mIntLogicalToPhysical->map.emplace(def.logicalIndex, use);
+                def.physicalIndex = mConstantDefs->registerCount;
+                mConstantDefs->registerCount += def.arraySize * def.elementSize;
+                // no index based referencing
             }
             else
             {
@@ -620,8 +608,7 @@ namespace Ogre {
             return;
         }
 
-        mFloatLogicalToPhysical.reset();
-        mIntLogicalToPhysical.reset();
+        mLogicalToPhysical.reset();
 
         // We need an accurate list of all the uniforms in the shader, but we
         // can't get at them until we link all the shaders into a program object.

--- a/RenderSystems/GLES2/src/GLSLES/src/OgreGLSLESLinkProgram.cpp
+++ b/RenderSystems/GLES2/src/GLSLES/src/OgreGLSLESLinkProgram.cpp
@@ -199,33 +199,13 @@ namespace Ogre {
                 {
                     GLsizei glArraySize = (GLsizei)def->arraySize;
 
-                    bool shouldUpdate = true;
-
                     // this is a monolitic program so we can use the cache of any attached shader
                     GLUniformCache* uniformCache =  mShaders[GPT_VERTEX_PROGRAM]->getUniformCache();
-                    switch (def->constType)
-                    {
-                        case GCT_INT1:
-                        case GCT_INT2:
-                        case GCT_INT3:
-                        case GCT_INT4:
-                        case GCT_SAMPLER1D:
-                        case GCT_SAMPLER1DSHADOW:
-                        case GCT_SAMPLER2D:
-                        case GCT_SAMPLER2DSHADOW:
-                        case GCT_SAMPLER3D:
-                        case GCT_SAMPLERCUBE:
-                            shouldUpdate = uniformCache->updateUniform(currentUniform->mLocation,
-                                                                       params->getIntPointer(def->physicalIndex),
-                                                                       static_cast<GLsizei>(def->elementSize * glArraySize * sizeof(int)));
-                            break;
-                        default:
-                            shouldUpdate = uniformCache->updateUniform(currentUniform->mLocation,
-                                                                       params->getFloatPointer(def->physicalIndex),
-                                                                       static_cast<GLsizei>(def->elementSize * glArraySize * sizeof(float)));
-                            break;
-                    }
+                    void* val = def->isSampler() ? (void*)params->getRegPointer(def->physicalIndex)
+                                                 : (void*)params->getFloatPointer(def->physicalIndex);
 
+                    bool shouldUpdate = uniformCache->updateUniform(currentUniform->mLocation, val,
+                                                                    def->elementSize * glArraySize * 4);
                     if(!shouldUpdate)
                         continue;
 
@@ -294,7 +274,7 @@ namespace Ogre {
                         // Samplers handled like 1-element ints
                     case GCT_INT1:
                         OGRE_CHECK_GL_ERROR(glUniform1iv(currentUniform->mLocation, glArraySize,
-                                                         (GLint*)params->getIntPointer(def->physicalIndex)));
+                                                         (GLint*)val));
                         break;
                     case GCT_INT2:
                         OGRE_CHECK_GL_ERROR(glUniform2iv(currentUniform->mLocation, glArraySize, 

--- a/RenderSystems/GLES2/src/GLSLES/src/OgreGLSLESProgram.cpp
+++ b/RenderSystems/GLES2/src/GLSLES/src/OgreGLSLESProgram.cpp
@@ -270,8 +270,7 @@ namespace Ogre {
 
         // Therefore instead, parse the source code manually and extract the uniforms
         createParameterMappingStructures(true);
-        mFloatLogicalToPhysical.reset();
-        mIntLogicalToPhysical.reset();
+        mLogicalToPhysical.reset();
         GLSLESProgramManager::getSingleton().extractUniformsFromGLSL(mSource, *mConstantDefs, mName);
     }
 

--- a/RenderSystems/GLES2/src/GLSLES/src/OgreGLSLESProgramPipeline.cpp
+++ b/RenderSystems/GLES2/src/GLSLES/src/OgreGLSLESProgramPipeline.cpp
@@ -182,31 +182,11 @@ namespace Ogre
                 if (def->variability & mask)
                 {
                     GLsizei glArraySize = (GLsizei)def->arraySize;
-                    bool shouldUpdate = true;
-                    switch (def->constType)
-                    {
-                        case GCT_INT1:
-                        case GCT_INT2:
-                        case GCT_INT3:
-                        case GCT_INT4:
-                        case GCT_SAMPLER1D:
-                        case GCT_SAMPLER1DSHADOW:
-                        case GCT_SAMPLER2D:
-                        case GCT_SAMPLER2DSHADOW:
-                        case GCT_SAMPLER3D:
-                        case GCT_SAMPLERCUBE:
-                        case GCT_SAMPLER2DARRAY:
-                            shouldUpdate = uniformCache->updateUniform(currentUniform->mLocation,
-                                                                        params->getIntPointer(def->physicalIndex),
-                                                                        static_cast<GLsizei>(def->elementSize * def->arraySize * sizeof(int)));
-                            break;
-                        default:
-                            shouldUpdate = uniformCache->updateUniform(currentUniform->mLocation,
-                                                                        params->getFloatPointer(def->physicalIndex),
-                                                                        static_cast<GLsizei>(def->elementSize * def->arraySize * sizeof(float)));
-                            break;
-                    }
+                    void* val = def->isSampler() ? (void*)params->getRegPointer(def->physicalIndex)
+                                                 : (void*)params->getFloatPointer(def->physicalIndex);
 
+                    bool shouldUpdate = uniformCache->updateUniform(currentUniform->mLocation, val,
+                                                                    def->elementSize * def->arraySize * 4);
                     if(!shouldUpdate)
                         continue;
 
@@ -251,7 +231,7 @@ namespace Ogre
                             // Samplers handled like 1-element ints
                         case GCT_INT1:
                             OGRE_CHECK_GL_ERROR(glProgramUniform1ivEXT(progID, currentUniform->mLocation, glArraySize, 
-                                                                       params->getIntPointer(def->physicalIndex)));
+                                                                       (int*)val));
                             break;
                         case GCT_INT2:
                             OGRE_CHECK_GL_ERROR(glProgramUniform2ivEXT(progID, currentUniform->mLocation, glArraySize, 

--- a/RenderSystems/GLSupport/src/GLSL/OgreGLSLProgramManagerCommon.cpp
+++ b/RenderSystems/GLSupport/src/GLSL/OgreGLSLProgramManagerCommon.cpp
@@ -288,20 +288,15 @@ namespace Ogre {
                 // Complete def and add
                 // increment physical buffer location
                 def.logicalIndex = 0; // not valid in GLSL
-                if (def.isFloat())
+                if (def.isFloat() || def.isDouble() || def.isInt() || def.isUnsignedInt() || def.isBool())
                 {
-                    def.physicalIndex = defs.floatBufferSize;
-                    defs.floatBufferSize += def.arraySize * def.elementSize;
+                    def.physicalIndex = defs.bufferSize * 4;
+                    defs.bufferSize += def.arraySize * def.elementSize;
                 }
-                else if (def.isDouble())
+                else if(def.isSampler())
                 {
-                    def.physicalIndex = defs.doubleBufferSize;
-                    defs.doubleBufferSize += def.arraySize * def.elementSize;
-                }
-                else if (def.isInt() || def.isSampler() || def.isUnsignedInt() || def.isBool())
-                {
-                    def.physicalIndex = defs.intBufferSize;
-                    defs.intBufferSize += def.arraySize * def.elementSize;
+                    def.physicalIndex = defs.registerCount;
+                    defs.registerCount += def.arraySize * def.elementSize;
                 }
                 else
                 {

--- a/RenderSystems/Metal/src/OgreMetalProgram.mm
+++ b/RenderSystems/Metal/src/OgreMetalProgram.mm
@@ -365,28 +365,14 @@ namespace Ogre {
                 def.arraySize   = 1;
                 def.variability = GPV_GLOBAL;
 
-                if (def.isFloat())
-                {
-                    def.physicalIndex = mFloatLogicalToPhysical->bufferSize;
-                    OGRE_LOCK_MUTEX(mFloatLogicalToPhysical->mutex);
-                        mFloatLogicalToPhysical->map.insert(
-                        GpuLogicalIndexUseMap::value_type(def.logicalIndex,
-                        GpuLogicalIndexUse(def.physicalIndex,
-                                           def.arraySize * def.elementSize, GPV_GLOBAL)));
-                    mFloatLogicalToPhysical->bufferSize += def.arraySize * def.elementSize;
-                    mConstantDefs->floatBufferSize = mFloatLogicalToPhysical->bufferSize;
-                }
-                else
-                {
-                    def.physicalIndex = mIntLogicalToPhysical->bufferSize;
-                    OGRE_LOCK_MUTEX(mIntLogicalToPhysical->mutex);
-                        mIntLogicalToPhysical->map.insert(
-                        GpuLogicalIndexUseMap::value_type(def.logicalIndex,
-                        GpuLogicalIndexUse(def.physicalIndex,
-                                           def.arraySize * def.elementSize, GPV_GLOBAL)));
-                    mIntLogicalToPhysical->bufferSize += def.arraySize * def.elementSize;
-                    mConstantDefs->intBufferSize = mIntLogicalToPhysical->bufferSize;
-                }
+                def.physicalIndex = mLogicalToPhysical->bufferSize*4;
+                OGRE_LOCK_MUTEX(mLogicalToPhysical->mutex);
+                mLogicalToPhysical->map.insert(
+                GpuLogicalIndexUseMap::value_type(def.logicalIndex,
+                GpuLogicalIndexUse(def.physicalIndex,
+                                    def.arraySize * def.elementSize, GPV_GLOBAL, BCT_UNKNOWN)));
+                mLogicalToPhysical->bufferSize += def.arraySize * def.elementSize;
+                mConstantDefs->bufferSize = mLogicalToPhysical->bufferSize;
 
                 String varName = arg.name.UTF8String;
 
@@ -427,28 +413,14 @@ namespace Ogre {
                 }
                 def.variability = GPV_GLOBAL;
 
-                if (def.isFloat())
-                {
-                    def.physicalIndex = mFloatLogicalToPhysical->bufferSize;
-                    OGRE_LOCK_MUTEX(mFloatLogicalToPhysical->mutex);
-                        mFloatLogicalToPhysical->map.insert(
-                        GpuLogicalIndexUseMap::value_type(def.logicalIndex,
-                        GpuLogicalIndexUse(def.physicalIndex,
-                                           def.arraySize * def.elementSize, GPV_GLOBAL)));
-                    mFloatLogicalToPhysical->bufferSize += def.arraySize * def.elementSize;
-                    mConstantDefs->floatBufferSize = mFloatLogicalToPhysical->bufferSize;
-                }
-                else
-                {
-                    def.physicalIndex = mIntLogicalToPhysical->bufferSize;
-                    OGRE_LOCK_MUTEX(mIntLogicalToPhysical->mutex);
-                        mIntLogicalToPhysical->map.insert(
-                        GpuLogicalIndexUseMap::value_type(def.logicalIndex,
-                        GpuLogicalIndexUse(def.physicalIndex,
-                                           def.arraySize * def.elementSize, GPV_GLOBAL)));
-                    mIntLogicalToPhysical->bufferSize += def.arraySize * def.elementSize;
-                    mConstantDefs->intBufferSize = mIntLogicalToPhysical->bufferSize;
-                }
+                def.physicalIndex = mLogicalToPhysical->bufferSize;
+                OGRE_LOCK_MUTEX(mLogicalToPhysical->mutex);
+                mLogicalToPhysical->map.insert(
+                GpuLogicalIndexUseMap::value_type(def.logicalIndex,
+                GpuLogicalIndexUse(def.physicalIndex,
+                                    def.arraySize * def.elementSize, GPV_GLOBAL, BCT_UNKNOWN)));
+                mLogicalToPhysical->bufferSize += def.arraySize * def.elementSize;
+                mConstantDefs->bufferSize = mLogicalToPhysical->bufferSize;
 
                 String varName = member.name.UTF8String;
 
@@ -521,11 +493,7 @@ namespace Ogre {
         {
             const GpuConstantDefinition& def = *itor;
 
-            void * RESTRICT_ALIAS src;
-            if( def.isFloat() )
-                src = (void *)&(*(params->getFloatConstantList().begin() + def.physicalIndex));
-            else
-                src = (void *)&(*(params->getIntConstantList().begin() + def.physicalIndex));
+            const void * RESTRICT_ALIAS src = params->getConstantList().data() + def.physicalIndex;
 
             memcpy( &dstData[def.logicalIndex], src, def.elementSize * def.arraySize * sizeof(float) );
 

--- a/RenderSystems/Metal/src/OgreMetalRenderSystem.mm
+++ b/RenderSystems/Metal/src/OgreMetalRenderSystem.mm
@@ -363,9 +363,9 @@ namespace Ogre
             vpParams->setNamedAutoConstant("mvpMtx", GpuProgramParameters::ACT_WORLDVIEWPROJ_MATRIX);
 
             // create const buffer to back VP (currently unused)
-            if(auto sz = vpParams->getFloatConstantList().size())
+            if(auto sz = vpParams->getConstantList().size())
             {
-                mAutoParamsBuffer.reset(new MetalHardwareBufferCommon(sz * sizeof(float), HBU_CPU_TO_GPU,
+                mAutoParamsBuffer.reset(new MetalHardwareBufferCommon(sz, HBU_CPU_TO_GPU,
                                                                       false, 4, NULL, &mDevice));
             }
         }
@@ -998,7 +998,7 @@ namespace Ogre
         // update const buffer
         #if 1
         [mActiveRenderEncoder setVertexBytes:params->getFloatPointer(0)
-            length:params->getFloatConstantList().size()*sizeof(float) atIndex:16];
+            length:params->getConstantList().size() atIndex:16];
         #else
         // TODO rather use this:
         size_t unused;

--- a/RenderSystems/Tiny/src/OgreTinyRenderSystem.cpp
+++ b/RenderSystems/Tiny/src/OgreTinyRenderSystem.cpp
@@ -33,10 +33,9 @@ namespace Ogre {
         initConfigOptions();
 
         // create params
-        GpuLogicalBufferStructPtr nullPtr;
         GpuLogicalBufferStructPtr logicalBufferStruct(new GpuLogicalBufferStruct());
         mFixedFunctionParams.reset(new GpuProgramParameters);
-        mFixedFunctionParams->_setLogicalIndexes(logicalBufferStruct, nullPtr, nullPtr);
+        mFixedFunctionParams->_setLogicalIndexes(logicalBufferStruct);
         mFixedFunctionParams->setAutoConstant(0, GpuProgramParameters::ACT_WORLDVIEWPROJ_MATRIX);
         mFixedFunctionParams->setAutoConstant(4, GpuProgramParameters::ACT_TEXTURE_MATRIX);
         mFixedFunctionParams->setAutoConstant(8, GpuProgramParameters::ACT_DERIVED_AMBIENT_LIGHT_COLOUR);


### PR DESCRIPTION
store all constants in a single byte buffer instead of splitting them by
type.
This will allow backing them by HW UBOs and updating with a single
memcpy.