### PR TITLE
build fix: remove unnecessary #ifdef __FreeBSD__

### DIFF
--- a/OgreMain/include/OgreBitwise.h
+++ b/OgreMain/include/OgreBitwise.h
@@ -30,7 +30,7 @@ THE SOFTWARE.
 
 #include "OgrePrerequisites.h"
 
-#ifdef __FreeBSD__
+#ifdef bswap16
 #undef bswap16
 #undef bswap32
 #undef bswap64


### PR DESCRIPTION
bswapX macros are defined on other BSD systems too, so it's easier to just undefine them if they're already defined.

this fixes the build on NetBSD.