### PR TITLE
Improve RTShaderSystem diagnostic support by logging a description and file path when using a cached shader program

### DIFF
--- a/Components/RTShaderSystem/include/OgreShaderProgram.h
+++ b/Components/RTShaderSystem/include/OgreShaderProgram.h
@@ -200,7 +200,7 @@ protected:
     /** Class constructor.
     @param type The type of this program.
     */
-    Program(GpuProgramType type);
+    Program(GpuProgramType type, const String& desc = String());
 
     /** Destroy all parameters of this program. */
     void destroyParameters();

--- a/Components/RTShaderSystem/include/OgreShaderRenderState.h
+++ b/Components/RTShaderSystem/include/OgreShaderRenderState.h
@@ -195,7 +195,7 @@ protected:
     
     /** Create CPU programs that represent this render state.   
     */
-    void createCpuPrograms();
+    void createCpuPrograms(const String& desc);
 
     /** Create the program set of this render state.
     */

--- a/Components/RTShaderSystem/src/OgreShaderProgram.cpp
+++ b/Components/RTShaderSystem/src/OgreShaderProgram.cpp
@@ -31,11 +31,11 @@ namespace Ogre {
 namespace RTShader {
 
 //-----------------------------------------------------------------------------
-Program::Program(GpuProgramType type)
+Program::Program(GpuProgramType type, const String& desc)
 {
     mType               = type;
     // all programs must have an entry point, nobody cares about FFT
-    mEntryPointFunction = new Function("main", "", Function::FFT_VS_MAIN);
+    mEntryPointFunction = new Function("main", desc, Function::FFT_VS_MAIN);
     mSkeletalAnimation  = false;
     mColumnMajorMatrices = true;
 

--- a/Components/RTShaderSystem/src/OgreShaderProgramManager.cpp
+++ b/Components/RTShaderSystem/src/OgreShaderProgramManager.cpp
@@ -278,16 +278,13 @@ GpuProgramPtr ProgramManager::createGpuProgram(Program* shaderProgram,
 
     // Generate program name.
     String programName = generateHash(source, shaderProgram->getPreprocessorDefines());
-    const char* programType = " ";
     if (shaderProgram->getType() == GPT_VERTEX_PROGRAM)
     {
         programName += "_VS";
-        programType = " vertex shader ";
     }
     else if (shaderProgram->getType() == GPT_FRAGMENT_PROGRAM)
     {
         programName += "_FS";
-        programType = " fragment shader ";
     }
 
     // Try to get program by name.
@@ -298,8 +295,8 @@ GpuProgramPtr ProgramManager::createGpuProgram(Program* shaderProgram,
     if(pGpuProgram) {
         if (!cachePath.empty())
             LogManager::getSingleton().logMessage(shaderProgram->getEntryPointFunction()->getDescription()
-                + programType
-                + "cached as "
+                + ' ' + to_string(shaderProgram->getType())
+                + " shader cached as "
                 + programName
                 );
         return static_pointer_cast<GpuProgram>(pGpuProgram);
@@ -343,7 +340,7 @@ GpuProgramPtr ProgramManager::createGpuProgram(Program* shaderProgram,
         }
 
         LogManager::getSingleton().logMessage(shaderProgram->getEntryPointFunction()->getDescription()
-            + programType
+            + ' ' + to_string(shaderProgram->getType()) + " shader "
             + loadStore
             + programFileName
             );

--- a/Components/RTShaderSystem/src/OgreShaderProgramWriter.cpp
+++ b/Components/RTShaderSystem/src/OgreShaderProgramWriter.cpp
@@ -66,7 +66,6 @@ void ProgramWriter::writeFunctionTitle(std::ostream& os, Function* function)
 {
     os << "//-----------------------------------------------------------------------------" << std::endl;
     os << "// Function Name: " <<  function->getName() << std::endl;
-    os << "// Function Desc: " <<  function->getDescription() << std::endl;
     os << "//-----------------------------------------------------------------------------" << std::endl;
 }
 

--- a/Components/RTShaderSystem/src/OgreShaderRenderState.cpp
+++ b/Components/RTShaderSystem/src/OgreShaderRenderState.cpp
@@ -144,7 +144,10 @@ void TargetRenderState::bindUniformParameters(Program* pCpuProgram, const GpuPro
 
 void TargetRenderState::acquirePrograms(Pass* pass)
 {
-    createCpuPrograms();
+    auto desc = StringUtil::format("pass %d of '%s'",
+        pass->getIndex(),
+        pass->getParent()->getParent()->getName().c_str());
+    createCpuPrograms(desc);
 
     try
     {
@@ -152,9 +155,7 @@ void TargetRenderState::acquirePrograms(Pass* pass)
     }
     catch(Ogre::Exception& e)
     {
-        LogManager::getSingleton().logError(StringUtil::format("RTSS - creating GpuPrograms for pass %d of '%s' failed",
-                                                               pass->getIndex(),
-                                                               pass->getParent()->getParent()->getName().c_str()));
+        LogManager::getSingleton().logError(StringUtil::format("RTSS - creating GpuPrograms for %s failed", desc.c_str());
         throw;
     }
 
@@ -210,15 +211,15 @@ static void fixupFFPLighting(TargetRenderState* renderState)
 }
 
 //-----------------------------------------------------------------------
-void TargetRenderState::createCpuPrograms()
+void TargetRenderState::createCpuPrograms(const String& desc)
 {
     sortSubRenderStates();
 
     fixupFFPLighting(this);
 
     ProgramSet* programSet = createProgramSet();
-    programSet->setCpuProgram(std::unique_ptr<Program>(new Program(GPT_VERTEX_PROGRAM)));
-    programSet->setCpuProgram(std::unique_ptr<Program>(new Program(GPT_FRAGMENT_PROGRAM)));
+    programSet->setCpuProgram(std::unique_ptr<Program>(new Program(GPT_VERTEX_PROGRAM, desc)));
+    programSet->setCpuProgram(std::unique_ptr<Program>(new Program(GPT_FRAGMENT_PROGRAM, desc)));
 
     for (SubRenderStateListIterator it=mSubRenderStateList.begin(); it != mSubRenderStateList.end(); ++it)
     {

--- a/Components/RTShaderSystem/src/OgreShaderRenderState.cpp
+++ b/Components/RTShaderSystem/src/OgreShaderRenderState.cpp
@@ -155,7 +155,7 @@ void TargetRenderState::acquirePrograms(Pass* pass)
     }
     catch(Ogre::Exception& e)
     {
-        LogManager::getSingleton().logError(StringUtil::format("RTSS - creating GpuPrograms for %s failed", desc.c_str());
+        LogManager::getSingleton().logError(StringUtil::format("RTSS - creating GpuPrograms for %s failed", desc.c_str()));
         throw;
     }
 


### PR DESCRIPTION
This PR adds the cached shader program file names and description to the Ogre log.

This PR has only one effect when not using the cache:
- The empty function description line is not written into the shader source code. Writing a description would unnecessarily change the hash, preventing reuse of otherwse identical shaders.