### PR TITLE
Overlay: add setVisible to OgreOverlay and OgreOverlayElement

### DIFF
--- a/Components/Overlay/include/OgreOverlay.h
+++ b/Components/Overlay/include/OgreOverlay.h
@@ -136,6 +136,9 @@ namespace Ogre {
         /** Hides the overlay if it was visible. */
         void hide(void);
 
+        /** Shows or hides this overlay. */
+        void setVisible(bool visible);
+
         /** Adds a 2D 'container' to the overlay.
         @remarks
             Containers are created and managed using the OverlayManager. A container

--- a/Components/Overlay/include/OgreOverlayElement.h
+++ b/Components/Overlay/include/OgreOverlayElement.h
@@ -204,6 +204,9 @@ namespace Ogre {
         /** Hides this element if it was visible. */
         virtual void hide(void);
 
+        /** Shows or hides this element. */
+        virtual void setVisible(bool visible);
+
         /** Returns whether or not the element is visible. */
         bool isVisible(void) const;
 

--- a/Components/Overlay/src/OgreOverlay.cpp
+++ b/Components/Overlay/src/OgreOverlay.cpp
@@ -116,6 +116,11 @@ namespace Ogre {
         mVisible = false;
     }
     //---------------------------------------------------------------------
+    void Overlay::setVisible(bool visible)
+    {
+        mVisible = visible;
+    }
+    //---------------------------------------------------------------------
     void Overlay::initialise(void)
     {
         OverlayContainerList::iterator i, iend;

--- a/Components/Overlay/src/OgreOverlayElement.cpp
+++ b/Components/Overlay/src/OgreOverlayElement.cpp
@@ -118,6 +118,11 @@ namespace Ogre {
         mVisible = false;
     }
     //---------------------------------------------------------------------
+    void OverlayElement::setVisible(bool visible)
+    {
+        mVisible = visible;
+    }
+    //---------------------------------------------------------------------
     bool OverlayElement::isVisible(void) const
     {
         return mVisible;


### PR DESCRIPTION
Just added `setVisible` because with `show` and `hide` I have to evaluate what function to call in my code which results in a branch.

I do not like that now `show`, `hide` and `setVisible` are all virtual in `OgreOverlayElement`.
There are better alternatives to allow the inherited classes special behavour on visibility changes in this case.
But I do not want to introduce a breaking API change.