### PR TITLE
When the mesh has no material assigned an assertion is triggered

### DIFF
--- a/Tools/MeshUpgrader/src/main.cpp
+++ b/Tools/MeshUpgrader/src/main.cpp
@@ -969,8 +969,14 @@ struct MaterialCreator : public MeshSerializerListener
 {
     void processMaterialName(Mesh *mesh, String *name)
     {
-        // create material because we do not load any .material files
-        MaterialManager::getSingleton().createOrRetrieve(*name, mesh->getGroup());
+		if(name->empty()) {
+            OGRE_EXCEPT(Exception::ERR_INVALIDPARAMS,
+                "The provided mesh file has an empty material name. See https://ogrecave.github.io/ogre/api/latest/_mesh-_tools.html#Exporters");
+		}
+        else {
+            // create material because we do not load any .material files
+            MaterialManager::getSingleton().createOrRetrieve(*name, mesh->getGroup());
+        }
     }
 
     void processSkeletonName(Mesh *mesh, String *name) {}
@@ -1167,7 +1173,7 @@ int main(int numargs, char** args)
     }
     catch (Exception& e)
     {
-        cout << "Exception caught: " << e.getDescription();
+        cout << "Exception caught: " << e.getDescription() << std::endl;
         retCode = 1;
     }
 


### PR DESCRIPTION
It is possible to generate a `.mesh` without an assigned material so the name will be blank.

In this case the following assert is triggered:
```
File: D:\OGRE2\Sources\ogre-master\OgreMain\src\OgreResourceManager.cpp, Line 50
Expression: (!name.empty()) && ("resource name must not be empty")
```