### PR TITLE
Revert "[OGRE-155] TextAreaOverlayElement: fix for mSpaceWidth field …

### DIFF
--- a/Components/Overlay/include/OgreTextAreaOverlayElement.h
+++ b/Components/Overlay/include/OgreTextAreaOverlayElement.h
@@ -237,7 +237,6 @@ namespace Ogre
         FontPtr mFont;
         Real mCharHeight;
         ushort mPixelCharHeight;
-        bool mSpaceWidthOverridden;
         Real mSpaceWidth;
         ushort mPixelSpaceWidth;
         size_t mAllocSize;

--- a/Components/Overlay/src/OgreTextAreaOverlayElement.cpp
+++ b/Components/Overlay/src/OgreTextAreaOverlayElement.cpp
@@ -69,7 +69,6 @@ namespace Ogre {
 
         mCharHeight = 0.02;
         mPixelCharHeight = 12;
-        mSpaceWidthOverridden = false;
         mSpaceWidth = 0;
         mPixelSpaceWidth = 0;
         mViewportAspectCoef = 1;
@@ -197,7 +196,7 @@ namespace Ogre {
         float top = -( (_getDerivedTop() * 2.0f ) - 1.0f );
 
         // Derive space with from a number 0
-        if(!mSpaceWidthOverridden)
+        if(mSpaceWidth == 0)
         {
             mSpaceWidth = mFont->getGlyphAspectRatio(UNICODE_ZERO) * mCharHeight;
         }
@@ -416,7 +415,6 @@ namespace Ogre {
 
     void TextAreaOverlayElement::setSpaceWidth( Real width )
     {
-        mSpaceWidthOverridden = true;
         if (mMetricsMode != GMM_RELATIVE)
         {
             mPixelSpaceWidth = static_cast<unsigned short>(width);


### PR DESCRIPTION
…getting stuck with wrong value in certain cases. Thanks to Christopher Christensen."

This reverts commit 54843d3865f343996e155e28c02241150f19316d.

the fix was incomplete and is no longer needed.