### PR TITLE
Main InstanceManager - unshare LODs as well

### DIFF
--- a/OgreMain/src/OgreInstanceManager.cpp
+++ b/OgreMain/src/OgreInstanceManager.cpp
@@ -513,7 +513,7 @@ namespace Ogre
     typedef std::map<uint32, uint32> IndicesMap;
 
     template< typename TIndexType >
-    IndicesMap getUsedIndices(IndexData* idxData)
+    void collectUsedIndices(IndicesMap& indicesMap, IndexData* idxData)
     {
         HardwareBufferLockGuard indexLock(idxData->indexBuffer,
                                           idxData->indexStart * sizeof(TIndexType),
@@ -521,33 +521,40 @@ namespace Ogre
                                           HardwareBuffer::HBL_READ_ONLY);
         TIndexType *data = (TIndexType*)indexLock.pData;
 
-        IndicesMap indicesMap;
-        for (size_t i = 0; i < idxData->indexCount; i++) 
+        for (size_t i = 0; i < idxData->indexCount; i++)
         {
             TIndexType index = data[i];
-            if (indicesMap.find(index) == indicesMap.end()) 
+            if (indicesMap.find(index) == indicesMap.end())
             {
                 //We need to guarantee that the size is read before an entry is added, hence these are on separate lines.
                 uint32 size = (uint32)(indicesMap.size());
                 indicesMap[index] = size;
             }
         }
-
-        return indicesMap;
     }
     //-----------------------------------------------------------------------
     template< typename TIndexType >
-    void copyIndexBuffer(IndexData* idxData, IndicesMap& indicesMap)
+    void copyIndexBuffer(IndexData* idxData, const IndicesMap& indicesMap, size_t indexStart)
     {
+        size_t start = std::max(indexStart, idxData->indexStart);
+        size_t count = idxData->indexCount - (start - idxData->indexStart);
+
+        //We get errors if we try to lock a zero size buffer.
+        if (count == 0) {
+            return;
+        }
         HardwareBufferLockGuard indexLock(idxData->indexBuffer,
-                                          idxData->indexStart * sizeof(TIndexType),
-                                          idxData->indexCount * sizeof(TIndexType),
+                                          start * sizeof(TIndexType),
+                                          count * sizeof(TIndexType),
                                           HardwareBuffer::HBL_NORMAL);
         TIndexType *data = (TIndexType*)indexLock.pData;
 
-        for (uint32 i = 0; i < idxData->indexCount; i++) 
+        for (size_t i = 0; i < count; i++)
         {
-            data[i] = (TIndexType)indicesMap[data[i]];
+            //Access data and write on two separate lines, to avoid compiler confusion.
+            auto originalPos = data[i];
+            auto indexEntry = indicesMap.find(originalPos);
+            data[i] = (TIndexType)(indexEntry->second);
         }
     }
     //-----------------------------------------------------------------------
@@ -568,8 +575,22 @@ namespace Ogre
 
             IndexData *indexData = subMesh->indexData;
             HardwareIndexBuffer::IndexType idxType = indexData->indexBuffer->getType();
-            IndicesMap indicesMap = (idxType == HardwareIndexBuffer::IT_16BIT) ? getUsedIndices<uint16>(indexData) :
-                                                                                 getUsedIndices<uint32>(indexData);
+            IndicesMap indicesMap;
+            if (idxType == HardwareIndexBuffer::IT_16BIT) {
+                collectUsedIndices<uint16>(indicesMap, indexData);
+            } else {
+                collectUsedIndices<uint32>(indicesMap, indexData);
+            }
+
+            //Also collect indices for all LOD faces.
+            for (auto& lodIndex : subMesh->mLodFaceList) {
+                //Typically the LOD indices would use the same buffer type as the main index. But we'll check to make extra sure.
+                if (lodIndex->indexBuffer->getType() == HardwareIndexBuffer::IT_16BIT) {
+                    collectUsedIndices<uint16>(indicesMap, lodIndex);
+                } else {
+                    collectUsedIndices<uint32>(indicesMap, lodIndex);
+                }
+            }
 
 
             VertexData *newVertexData = new VertexData();
@@ -600,12 +621,35 @@ namespace Ogre
 
             if (idxType == HardwareIndexBuffer::IT_16BIT)
             {
-                copyIndexBuffer<uint16>(indexData, indicesMap);
+                copyIndexBuffer<uint16>(indexData, indicesMap, 0);
             }
             else
             {
-                copyIndexBuffer<uint32>(indexData, indicesMap);
+                copyIndexBuffer<uint32>(indexData, indicesMap, 0);
             }
+
+            //Need to adjust all of the LOD faces too.
+            size_t lastIndexEnd = 0;
+            for (size_t i = 0; i < subMesh->mLodFaceList.size(); ++i) {
+				auto lodIndex = subMesh->mLodFaceList[i];
+				//When using "generated" mesh lods, the indices are shared, so that index[n] would overlap with
+				//index[n]. We need to take this into account to make sure we don't process data twice (with incorrect
+				//data as a result). We check if the index either is the first one, or if it has a different buffer
+				//than the previous one we processed. Since the overlap seems to be progressing we only need to keep
+				// track of the last used index.
+                if (i == 0 || lodIndex->indexBuffer != subMesh->mLodFaceList[i - 1]->indexBuffer) {
+                    lastIndexEnd = 0;
+                }
+
+                //Typically the LOD indices would use the same buffer type as the main index. But we'll check to make extra sure.
+                if (lodIndex->indexBuffer->getType() == HardwareIndexBuffer::IT_16BIT) {
+                    copyIndexBuffer<uint16>(lodIndex, indicesMap, lastIndexEnd);
+                } else {
+                    copyIndexBuffer<uint32>(lodIndex, indicesMap, lastIndexEnd);
+                }
+                lastIndexEnd = lodIndex->indexStart + lodIndex->indexCount;
+
+			}
 
             // Store new attributes
             subMesh->useSharedVertices = false;


### PR DESCRIPTION
This fixes a segfault which will appear if a mesh with shared vertices and existing edge data is used.
It's triggered by the calls to "buildEdgeList()", since when doing this the LODs will be accessed.
And since they haven't been altered, they will rely on the now deleted shared geometry, and
their indices will be out of bounds, causing segfault.