### PR TITLE
Main: DefaultDebugDrawer -Skip bounding boxes that are infinite.

### DIFF
--- a/OgreMain/src/OgreDefaultDebugDrawer.cpp
+++ b/OgreMain/src/OgreDefaultDebugDrawer.cpp
@@ -148,6 +148,10 @@ void DefaultDebugDrawer::drawBone(const Node* node)
 void DefaultDebugDrawer::drawSceneNode(const SceneNode* node)
 {
     const auto& aabb = node->_getWorldAABB();
+    //Skip all bounding boxes that are infinite.
+    if (aabb.isInfinite()) {
+        return;
+    }
     if (mDrawType & DT_AXES)
     {
         Vector3f hs(aabb.getHalfSize());


### PR DESCRIPTION
Since this will cause an assert error when built in debug mode,
and undefined behaviour if not.