### PR TITLE
Main: Math - Use Möller-Trumbore ray-triangle intersection algorithm

### DIFF
--- a/Docs/src/bibliography.bib
+++ b/Docs/src/bibliography.bib
@@ -128,3 +128,14 @@
   journal={Unpublished paper, available at http://www.flipcode.com/articles/article_geomipmaps.pdf},
   year={2000}
 }
+
+@article{moller1997fast,
+  title={Fast, minimum storage ray-triangle intersection},
+  author={M{\"o}ller, Tomas and Trumbore, Ben},
+  journal={Journal of graphics tools},
+  volume={2},
+  number={1},
+  pages={21--28},
+  year={1997},
+  publisher={Taylor \& Francis}
+}

--- a/OgreMain/include/OgreMath.h
+++ b/OgreMain/include/OgreMath.h
@@ -612,29 +612,7 @@ namespace Ogre
         static bool intersects(const Ray& ray, const AxisAlignedBox& box,
             Real* d1, Real* d2);
 
-        /** Ray / triangle intersection, returns boolean result and distance.
-        @param ray
-            The ray.
-        @param a
-            The triangle's first vertex.
-        @param b
-            The triangle's second vertex.
-        @param c
-            The triangle's third vertex.
-        @param normal
-            The triangle plane's normal (passed in rather than calculated
-            on demand since the caller may already have it), doesn't need
-            normalised since we don't care.
-        @param positiveSide
-            Intersect with "positive side" of the triangle
-        @param negativeSide
-            Intersect with "negative side" of the triangle
-        */
-        static RayTestResult intersects(const Ray& ray, const Vector3& a,
-            const Vector3& b, const Vector3& c, const Vector3& normal,
-            bool positiveSide = true, bool negativeSide = true);
-
-        /** Ray / triangle intersection, returns boolean result and distance.
+        /** Ray / triangle intersection @cite moller1997fast, returns boolean result and distance.
         @param ray
             The ray.
         @param a
@@ -644,13 +622,21 @@ namespace Ogre
         @param c
             The triangle's third vertex.
         @param positiveSide
-            Intersect with "positive side" of the triangle
+            Intersect with "positive side" of the triangle (as determined by vertex winding)
         @param negativeSide
-            Intersect with "negative side" of the triangle
+            Intersect with "negative side" of the triangle (as determined by vertex winding)
         */
         static RayTestResult intersects(const Ray& ray, const Vector3& a,
             const Vector3& b, const Vector3& c,
             bool positiveSide = true, bool negativeSide = true);
+
+        /// @deprecated normal parameter is not used any more
+        OGRE_DEPRECATED static RayTestResult intersects(const Ray& ray, const Vector3& a, const Vector3& b,
+                                                        const Vector3& c, const Vector3& normal,
+                                                        bool positiveSide = true, bool negativeSide = true)
+        {
+            return intersects(ray, a, b, c, positiveSide, negativeSide);
+        }
 
         /** Sphere / box intersection test. */
         static bool intersects(const Sphere& sphere, const AxisAlignedBox& box);

--- a/OgreMain/src/OgreMath.cpp
+++ b/OgreMain/src/OgreMath.cpp
@@ -592,105 +592,38 @@ namespace Ogre
         return true;
     }
     //-----------------------------------------------------------------------
-    std::pair<bool, Real> Math::intersects(const Ray& ray, const Vector3& a,
-        const Vector3& b, const Vector3& c, const Vector3& normal,
-        bool positiveSide, bool negativeSide)
+    std::pair<bool, Real> Math::intersects(const Ray& ray, const Vector3& a, const Vector3& b,
+                                           const Vector3& c, bool positiveSide, bool negativeSide)
     {
-        //
-        // Calculate intersection with plane.
-        //
-        Real t;
-        {
-            Real denom = normal.dotProduct(ray.getDirection());
+        const Real EPSILON = 1e-6f;
+        Vector3 E1 = b - a;
+        Vector3 E2 = c - a;
+        Vector3 P = ray.getDirection().crossProduct(E2);
+        Real det = E1.dotProduct(P);
 
-            // Check intersect side
-            if (denom > + std::numeric_limits<Real>::epsilon())
-            {
-                if (!negativeSide)
-                    return std::pair<bool, Real>(false, (Real)0);
-            }
-            else if (denom < - std::numeric_limits<Real>::epsilon())
-            {
-                if (!positiveSide)
-                    return std::pair<bool, Real>(false, (Real)0);
-            }
-            else
-            {
-                // Parallel or triangle area is close to zero when
-                // the plane normal not normalised.
-                return std::pair<bool, Real>(false, (Real)0);
-            }
+        // if determinant is near zero, ray lies in plane of triangle
+        if((!positiveSide || det <= EPSILON) && (!negativeSide || det >= -EPSILON))
+            return {false, (Real)0};
+        Real inv_det = 1.0f / det;
 
-            t = normal.dotProduct(a - ray.getOrigin()) / denom;
+        // calculate u parameter and test bounds
+        Vector3 T = ray.getOrigin() - a;
+        Real u = T.dotProduct(P) * inv_det;
+        if(u < 0.0f || u > 1.0f)
+            return {false, (Real)0};
 
-            if (t < 0)
-            {
-                // Intersection is behind origin
-                return std::pair<bool, Real>(false, (Real)0);
-            }
-        }
+        // calculate v parameter and test bounds
+        Vector3 Q = T.crossProduct(E1);
+        Real v = ray.getDirection().dotProduct(Q) * inv_det;
+        if (v < 0.0f || u + v > 1.0f)
+            return {false, (Real)0};
 
-        //
-        // Calculate the largest area projection plane in X, Y or Z.
-        //
-        size_t i0, i1;
-        {
-            Real n0 = Math::Abs(normal[0]);
-            Real n1 = Math::Abs(normal[1]);
-            Real n2 = Math::Abs(normal[2]);
+        // calculate t, ray intersects triangle
+        Real t = E2.dotProduct(Q) * inv_det;
+        if (t < 0.0f)
+            return {false, (Real)0};
 
-            i0 = 1; i1 = 2;
-            if (n1 > n2)
-            {
-                if (n1 > n0) i0 = 0;
-            }
-            else
-            {
-                if (n2 > n0) i1 = 0;
-            }
-        }
-
-        //
-        // Check the intersection point is inside the triangle.
-        //
-        {
-            Real u1 = b[i0] - a[i0];
-            Real v1 = b[i1] - a[i1];
-            Real u2 = c[i0] - a[i0];
-            Real v2 = c[i1] - a[i1];
-            Real u0 = t * ray.getDirection()[i0] + ray.getOrigin()[i0] - a[i0];
-            Real v0 = t * ray.getDirection()[i1] + ray.getOrigin()[i1] - a[i1];
-
-            Real alpha = u0 * v2 - u2 * v0;
-            Real beta  = u1 * v0 - u0 * v1;
-            Real area  = u1 * v2 - u2 * v1;
-
-            // epsilon to avoid float precision error
-            const Real EPSILON = 1e-6f;
-
-            Real tolerance = - EPSILON * area;
-
-            if (area > 0)
-            {
-                if (alpha < tolerance || beta < tolerance || alpha+beta > area-tolerance)
-                    return std::pair<bool, Real>(false, (Real)0);
-            }
-            else
-            {
-                if (alpha > tolerance || beta > tolerance || alpha+beta < area-tolerance)
-                    return std::pair<bool, Real>(false, (Real)0);
-            }
-        }
-
-        return std::pair<bool, Real>(true, (Real)t);
-    }
-    //-----------------------------------------------------------------------
-    std::pair<bool, Real> Math::intersects(const Ray& ray, const Vector3& a,
-        const Vector3& b, const Vector3& c,
-        bool positiveSide, bool negativeSide)
-    {
-        Vector3 normal = calculateBasicFaceNormalWithoutNormalize(a, b, c);
-        return intersects(ray, a, b, c, normal, positiveSide, negativeSide);
+        return {true, t};
     }
     //-----------------------------------------------------------------------
     bool Math::intersects(const Sphere& sphere, const AxisAlignedBox& box)

--- a/Tests/OgreMain/src/General.cpp
+++ b/Tests/OgreMain/src/General.cpp
@@ -407,3 +407,21 @@ TEST_F(HighLevelGpuProgramTest, resolveIncludes)
 
     ASSERT_EQ(res.substr(0, ref.size()), ref);
 }
+
+TEST(Math, TriangleRayIntersection)
+{
+    Vector3 tri[3] = {{-1, 0, 0}, {1, 0, 0}, {0, 1, 0}};
+    auto ray = Ray({0, 0.5, 1}, {0, 0, -1});
+
+    EXPECT_TRUE(Math::intersects(ray, tri[0], tri[1], tri[2], true, true).first);
+    EXPECT_TRUE(Math::intersects(ray, tri[0], tri[1], tri[2], true, false).first);
+    EXPECT_FALSE(Math::intersects(ray, tri[0], tri[1], tri[2], false, true).first);
+    EXPECT_FALSE(Math::intersects(ray, tri[0], tri[1], tri[2], false, false).first);
+
+    ray = Ray({0, 0.5, -1}, {0, 0, 1});
+
+    EXPECT_TRUE(Math::intersects(ray, tri[0], tri[1], tri[2], true, true).first);
+    EXPECT_FALSE(Math::intersects(ray, tri[0], tri[1], tri[2], true, false).first);
+    EXPECT_TRUE(Math::intersects(ray, tri[0], tri[1], tri[2], false, true).first);
+    EXPECT_FALSE(Math::intersects(ray, tri[0], tri[1], tri[2], false, false).first);
+}


### PR DESCRIPTION
it does not require a normal and is 25% faster for the common case,
where we hit the triangle plane and even 50% faster if we would compute
a normal first.
When shooting the ray away from the triangle, it is >45% slower though.