### PR TITLE
Main: simplify & inline getElement(N) helper functions

### DIFF
--- a/OgreMain/include/OgreAnimationTrack.h
+++ b/OgreMain/include/OgreAnimationTrack.h
@@ -147,10 +147,10 @@ namespace Ogre
         unsigned short getHandle(void) const { return mHandle; }
 
         /** Returns the number of keyframes in this animation. */
-        virtual unsigned short getNumKeyFrames(void) const;
+        size_t getNumKeyFrames(void) const { return mKeyFrames.size(); }
 
         /** Returns the KeyFrame at the specified index. */
-        virtual KeyFrame* getKeyFrame(unsigned short index) const;
+        KeyFrame* getKeyFrame(size_t index) const { return mKeyFrames.at(index); }
 
         /** Gets the 2 KeyFrame objects which are active at the time given, and the blend value between them.
         @remarks

--- a/OgreMain/include/OgreCompositionTargetPass.h
+++ b/OgreMain/include/OgreCompositionTargetPass.h
@@ -131,14 +131,11 @@ namespace Ogre {
         /** Remove a pass. It will also be destroyed.
         */
         void removePass(size_t idx);
-        /** Get a pass.
-        @deprecated use getPasses()
-        */
-        OGRE_DEPRECATED CompositionPass *getPass(size_t idx);
+        /** Get a pass.*/
+        CompositionPass *getPass(size_t idx) const { return mPasses.at(idx); }
         /** Get the number of passes.
-        @deprecated use getPasses()
         */
-        OGRE_DEPRECATED size_t getNumPasses();
+        size_t getNumPasses() const { return mPasses.size(); }
         
         /// Get the Passes in this TargetPass
         const Passes& getPasses() const {

--- a/OgreMain/include/OgreCompositionTechnique.h
+++ b/OgreMain/include/OgreCompositionTechnique.h
@@ -98,18 +98,15 @@ namespace Ogre {
         void removeTextureDefinition(size_t idx);
         
         /** Get a local texture definition.
-        @deprecated use getTextureDefinitions()
         */
-        OGRE_DEPRECATED TextureDefinition *getTextureDefinition(size_t idx);
+        TextureDefinition *getTextureDefinition(size_t idx) const { return mTextureDefinitions.at(idx); }
         
         /** Get a local texture definition with a specific name.
         */
-        TextureDefinition *getTextureDefinition(const String& name);
+        TextureDefinition *getTextureDefinition(const String& name) const;
 
-        /** Get the number of local texture definitions.
-        @deprecated use getTextureDefinitions()
-        */
-        OGRE_DEPRECATED size_t getNumTextureDefinitions();
+        /** Get the number of local texture definitions.*/
+        size_t getNumTextureDefinitions() const { return mTextureDefinitions.size(); }
         
         /** Remove all Texture Definitions
         */
@@ -130,14 +127,11 @@ namespace Ogre {
         void removeTargetPass(size_t idx);
         
         /** Get a target pass.
-        @deprecated use getTargetPasses()
         */
-        OGRE_DEPRECATED CompositionTargetPass *getTargetPass(size_t idx);
+        CompositionTargetPass* getTargetPass(size_t idx) const { return mTargetPasses.at(idx); }
         
-        /** Get the number of target passes.
-        @deprecated use getTargetPasses()
-        */
-        OGRE_DEPRECATED size_t getNumTargetPasses();
+        /** Get the number of target passes. */
+        size_t getNumTargetPasses() const { return mTargetPasses.size(); }
         
         /** Remove all target passes.
         */
@@ -151,7 +145,7 @@ namespace Ogre {
         
         /** Get output (final) target pass
          */
-        CompositionTargetPass *getOutputTargetPass();
+        CompositionTargetPass *getOutputTargetPass() const { return mOutputTarget; }
         
         /** Determine if this technique is supported on the current rendering device. 
         @param allowTextureDegradation True to accept a reduction in texture depth

--- a/OgreMain/include/OgreCompositor.h
+++ b/OgreMain/include/OgreCompositor.h
@@ -67,11 +67,11 @@ namespace Ogre {
         
         /** Get a technique.
         */
-        CompositionTechnique *getTechnique(size_t idx);
+        CompositionTechnique *getTechnique(size_t idx) const { return mTechniques.at(idx); }
         
         /** Get the number of techniques.
         */
-        size_t getNumTechniques();
+        size_t getNumTechniques() const { return mTechniques.size(); }
         
         /** Remove all techniques
         */
@@ -86,7 +86,7 @@ namespace Ogre {
             which typically happens on loading it. Therefore, if this method returns
             an empty list, try calling Compositor::load.
         */
-        CompositionTechnique *getSupportedTechnique(size_t idx);
+        CompositionTechnique *getSupportedTechnique(size_t idx) const { return mSupportedTechniques.at(idx); }
         
         /** Get the number of supported techniques.
         @remarks
@@ -94,7 +94,7 @@ namespace Ogre {
             which typically happens on loading it. Therefore, if this method returns
             an empty list, try calling Compositor::load.
         */
-        size_t getNumSupportedTechniques();
+        size_t getNumSupportedTechniques() const { return mSupportedTechniques.size(); }
         
         /** Gets an iterator over all the Techniques which are supported by the current card. 
         @remarks

--- a/OgreMain/include/OgreCompositorChain.h
+++ b/OgreMain/include/OgreCompositorChain.h
@@ -88,15 +88,15 @@ namespace Ogre {
         */
         void removeAllCompositors();
         
-        /// @deprecated use getCompositorInstances
-        OGRE_DEPRECATED CompositorInstance *getCompositor(size_t index);
-
         /** Get compositor instance by name. Returns null if not found.
         */
-        CompositorInstance* getCompositor(const String& name);
+        CompositorInstance* getCompositor(const String& name) const;
+
+        /// @overload
+        CompositorInstance *getCompositor(size_t index) const { return mInstances.at(index); }
 
         /// Get compositor position by name. Returns #NPOS if not found.
-        size_t getCompositorPosition(const String& name);
+        size_t getCompositorPosition(const String& name) const;
 
         /** Get the original scene compositor instance for this chain (internal use). 
         */

--- a/OgreMain/include/OgreCompositorInstance.h
+++ b/OgreMain/include/OgreCompositorInstance.h
@@ -245,11 +245,11 @@ namespace Ogre {
         
         /** Get Compositor of which this is an instance
         */
-        Compositor *getCompositor();
+        Compositor *getCompositor() const { return mCompositor; }
         
         /** Get CompositionTechnique used by this instance
         */
-        CompositionTechnique *getTechnique();
+        CompositionTechnique *getTechnique() const { return mTechnique; }
 
         /** Change the technique we're using to render this compositor. 
         @param tech

--- a/OgreMain/include/OgreEntity.h
+++ b/OgreMain/include/OgreEntity.h
@@ -359,9 +359,8 @@ namespace Ogre {
         const MeshPtr& getMesh(void) const;
 
         /** Gets a pointer to a SubEntity, ie a part of an Entity.
-         @deprecated use getSubEntities()
         */
-        SubEntity* getSubEntity(size_t index) const;
+        SubEntity* getSubEntity(size_t index) const { return mSubEntityList.at(index); }
 
         /** Gets a pointer to a SubEntity by name
         @remarks 
@@ -370,9 +369,8 @@ namespace Ogre {
         SubEntity* getSubEntity( const String& name ) const;
 
         /** Retrieves the number of SubEntity objects making up this entity.
-        * @deprecated use getSubEntities()
         */
-        size_t getNumSubEntities(void) const;
+        size_t getNumSubEntities(void) const { return mSubEntityList.size(); }
 
         /** Retrieves SubEntity objects making up this entity.
         */

--- a/OgreMain/include/OgreManualObject.h
+++ b/OgreMain/include/OgreManualObject.h
@@ -515,11 +515,9 @@ namespace Ogre
         */
         const std::vector<ManualObjectSection*>& getSections() const { return mSectionList; }
 
-        /// @deprecated use getSections()
-        OGRE_DEPRECATED ManualObjectSection* getSection(unsigned int index) const;
+        ManualObjectSection* getSection(size_t index) const { return mSectionList.at(index); }
 
-        /// @deprecated use getSections()
-        OGRE_DEPRECATED unsigned int getNumSections(void) const;
+        size_t getNumSections(void) const { return mSectionList.size(); }
 
 
         /** Sets whether or not to keep the original declaration order when 

--- a/OgreMain/include/OgreMaterial.h
+++ b/OgreMain/include/OgreMaterial.h
@@ -208,16 +208,14 @@ namespace Ogre {
             return the first one in the technique list which is supported by the hardware.
         */
         Technique* createTechnique(void);
-        /** Gets the indexed technique.
-         * @deprecated use getTechniques()  */
-        Technique* getTechnique(unsigned short index) const;
+        /** Gets the indexed technique. */
+        Technique* getTechnique(size_t index) const { return mTechniques.at(index); }
         /** searches for the named technique.
             Return 0 if technique with name is not found
         */
         Technique* getTechnique(const String& name) const;
-        /** Retrieves the number of techniques.
-         * @deprecated use getTechniques()  */
-        unsigned short getNumTechniques(void) const;
+        /** Retrieves the number of techniques.  */
+        size_t getNumTechniques(void) const { return mTechniques.size(); }
         /** Removes the technique at the given index. */        
         void removeTechnique(unsigned short index);     
         /** Removes all the techniques in this Material. */
@@ -244,12 +242,10 @@ namespace Ogre {
         /// @deprecated use getSupportedTechniques()
         OGRE_DEPRECATED TechniqueIterator getSupportedTechniqueIterator(void);
         
-        /** Gets the indexed supported technique.
-         * @deprecated use getSupportedTechniques() */
-        OGRE_DEPRECATED Technique* getSupportedTechnique(unsigned short index);
-        /** Retrieves the number of supported techniques.
-         * @deprecated use getSupportedTechniques() */
-        OGRE_DEPRECATED unsigned short getNumSupportedTechniques(void) const;
+        /** Gets the indexed supported technique. */
+        Technique* getSupportedTechnique(size_t index) const { return mSupportedTechniques.at(index); }
+        /** Retrieves the number of supported techniques. */
+        size_t getNumSupportedTechniques(void) const { return mSupportedTechniques.size(); }
         /** Gets a string explaining why any techniques are not supported. */
         const String& getUnsupportedTechniquesExplanation() const { return mUnsupportedReasons; }
 

--- a/OgreMain/include/OgreMesh.h
+++ b/OgreMain/include/OgreMesh.h
@@ -952,14 +952,12 @@ namespace Ogre {
             A new Pose ready for population.
         */
         Pose* createPose(ushort target, const String& name = BLANKSTRING);
-        /** Get the number of poses.
-         * @deprecated use getPoseList() */
-        OGRE_DEPRECATED size_t getPoseCount(void) const { return mPoseList.size(); }
-        /** Retrieve an existing Pose by index.
-         * @deprecated use getPoseList() */
-        OGRE_DEPRECATED Pose* getPose(ushort index);
+        /** Get the number of poses */
+        size_t getPoseCount(void) const { return mPoseList.size(); }
+        /** Retrieve an existing Pose by index */
+        Pose* getPose(size_t index) const { return mPoseList.at(index); }
         /** Retrieve an existing Pose by name.*/
-        Pose* getPose(const String& name);
+        Pose* getPose(const String& name) const;
         /** Destroy a pose by index.
         @note
             This will invalidate any animation tracks referring to this pose or those after it.

--- a/OgreMain/include/OgrePass.h
+++ b/OgreMain/include/OgrePass.h
@@ -556,9 +556,8 @@ namespace Ogre {
             Throws an exception if the TextureUnitState is attached to another Pass.*/
         void addTextureUnitState(TextureUnitState* state);
         /** Retrieves a const pointer to a texture unit state.
-         * @deprecated use getTextureUnitStates()
          */
-        TextureUnitState* getTextureUnitState(unsigned short index) const;
+        TextureUnitState* getTextureUnitState(size_t index) const { return mTextureUnitStates.at(index); }
         /** Retrieves the Texture Unit State matching name.
             Returns 0 if name match is not found.
         */
@@ -595,13 +594,8 @@ namespace Ogre {
          */
         void removeAllTextureUnitStates(void);
 
-        /** Returns the number of texture unit settings.
-         * @deprecated use getTextureUnitStates()
-         */
-        unsigned short getNumTextureUnitStates(void) const
-        {
-            return static_cast<unsigned short>(mTextureUnitStates.size());
-        }
+        /** Returns the number of texture unit settings */
+        size_t getNumTextureUnitStates(void) const { return mTextureUnitStates.size(); }
 
         /** Gets the 'nth' texture which references the given content type.
             @remarks

--- a/OgreMain/include/OgreRenderTexture.h
+++ b/OgreMain/include/OgreRenderTexture.h
@@ -107,12 +107,7 @@ namespace Ogre
         const BoundSufaceList& getBoundSurfaceList() const { return mBoundSurfaces; }
 
         /** Get a pointer to a bound surface */
-        RenderTexture* getBoundSurface(size_t index)
-        {
-            assert (index < mBoundSurfaces.size());
-            return mBoundSurfaces[index];
-        }
-
+        RenderTexture* getBoundSurface(size_t index) { return mBoundSurfaces.at(index); }
 
     protected:
         BoundSufaceList mBoundSurfaces;

--- a/OgreMain/include/OgreRibbonTrail.h
+++ b/OgreMain/include/OgreRibbonTrail.h
@@ -129,7 +129,7 @@ namespace Ogre {
         */
         virtual void setInitialColour(size_t chainIndex, float r, float g, float b, float a = 1.0);
         /** Get the starting ribbon colour. */
-        virtual const ColourValue& getInitialColour(size_t chainIndex) const;
+        const ColourValue& getInitialColour(size_t chainIndex) const { return mInitialColour.at(chainIndex); }
 
         /** Enables / disables fading the trail using colour. 
         @param chainIndex The index of the chain
@@ -143,7 +143,7 @@ namespace Ogre {
         */
         virtual void setInitialWidth(size_t chainIndex, Real width);
         /** Get the starting ribbon width in world units. */
-        virtual Real getInitialWidth(size_t chainIndex) const;
+        Real getInitialWidth(size_t chainIndex) const { return mInitialWidth.at(chainIndex); }
         
         /** Set the change in ribbon width per second. 
         @param chainIndex The index of the chain
@@ -151,7 +151,7 @@ namespace Ogre {
         */
         virtual void setWidthChange(size_t chainIndex, Real widthDeltaPerSecond);
         /** Get the change in ribbon width per second. */
-        virtual Real getWidthChange(size_t chainIndex) const;
+        Real getWidthChange(size_t chainIndex) const { return mDeltaWidth.at(chainIndex); }
 
         /** Enables / disables fading the trail using colour. 
         @param chainIndex The index of the chain
@@ -160,7 +160,7 @@ namespace Ogre {
         virtual void setColourChange(size_t chainIndex, float r, float g, float b, float a);
 
         /** Get the per-second fading amount */
-        virtual const ColourValue& getColourChange(size_t chainIndex) const;
+        const ColourValue& getColourChange(size_t chainIndex) const { return mDeltaColour.at(chainIndex); }
 
         /// @see Node::Listener::nodeUpdated
         void nodeUpdated(const Node* node);

--- a/OgreMain/include/OgreSceneNode.h
+++ b/OgreMain/include/OgreSceneNode.h
@@ -134,21 +134,17 @@ namespace Ogre {
         virtual void attachObject(MovableObject* obj);
 
         /** Reports the number of objects attached to this node.
-        @deprecated use getAttachedObjects()
         */
-        unsigned short numAttachedObjects(void) const;
+        size_t numAttachedObjects(void) const { return mObjectsByName.size(); }
 
-        /** Retrieves a pointer to an attached object.
-        @remarks Retrieves by index, see alternate version to retrieve by name. The index
-        of an object may change as other objects are added / removed.
-        @deprecated use getAttachedObjects()
+        /** Retrieves a pointer to an attached object by index
+        @note The index of an object may change as other objects are added / removed.
         */
-        MovableObject* getAttachedObject(unsigned short index);
+        MovableObject* getAttachedObject(size_t index) const { return mObjectsByName.at(index); }
 
-        /** Retrieves a pointer to an attached object.
-        @remarks Retrieves by object name, see alternate version to retrieve by index.
+        /** Retrieves a pointer to an attached object by name
         */
-        MovableObject* getAttachedObject(const String& name);
+        MovableObject* getAttachedObject(const String& name) const;
 
         /** Detaches the indexed object from this scene node.
         @remarks

--- a/OgreMain/include/OgreTechnique.h
+++ b/OgreMain/include/OgreTechnique.h
@@ -180,16 +180,14 @@ namespace Ogre {
             enough facilities for what you're asking for.
         */
         Pass* createPass(void);
-        /** Retrieves the Pass with the given index.
-         * @deprecated use getPasses() */
-        Pass* getPass(unsigned short index) const;
+        /** Retrieves the Pass with the given index.*/
+        Pass* getPass(size_t index) const { return mPasses.at(index); }
         /** Retrieves the Pass matching name.
             Returns 0 if name match is not found.
         */
         Pass* getPass(const String& name) const;
-        /** Retrieves the number of passes.
-         * @deprecated use getPasses() */
-        unsigned short getNumPasses(void) const;
+        /** Retrieves the number of passes. */
+        size_t getNumPasses(void) const { return mPasses.size(); }
         /** Removes the Pass with the given index. */
         void removePass(unsigned short index);
         /** Removes all Passes from this Technique. */

--- a/OgreMain/src/OgreAnimationTrack.cpp
+++ b/OgreMain/src/OgreAnimationTrack.cpp
@@ -54,19 +54,6 @@ namespace Ogre {
         removeAllKeyFrames();
     }
     //---------------------------------------------------------------------
-    unsigned short AnimationTrack::getNumKeyFrames(void) const
-    {
-        return (unsigned short)mKeyFrames.size();
-    }
-    //---------------------------------------------------------------------
-    KeyFrame* AnimationTrack::getKeyFrame(unsigned short index) const
-    {
-        // If you hit this assert, then the keyframe index is out of bounds
-        assert( index < (ushort)mKeyFrames.size() );
-
-        return mKeyFrames[index];
-    }
-    //---------------------------------------------------------------------
     Real AnimationTrack::getKeyFramesAtTime(const TimeIndex& timeIndex, KeyFrame** keyFrame1, KeyFrame** keyFrame2,
         unsigned short* firstKeyIndex) const
     {

--- a/OgreMain/src/OgreCompositionTargetPass.cpp
+++ b/OgreMain/src/OgreCompositionTargetPass.cpp
@@ -139,19 +139,6 @@ void CompositionTargetPass::removePass(size_t index)
     mPasses.erase(i);
 }
 //-----------------------------------------------------------------------
-
-CompositionPass *CompositionTargetPass::getPass(size_t index)
-{
-    assert (index < mPasses.size() && "Index out of bounds.");
-    return mPasses[index];
-}
-//-----------------------------------------------------------------------
-
-size_t CompositionTargetPass::getNumPasses()
-{
-    return mPasses.size();
-}
-//-----------------------------------------------------------------------
 void CompositionTargetPass::removeAllPasses()
 {
     Passes::iterator i, iend;

--- a/OgreMain/src/OgreCompositionTechnique.cpp
+++ b/OgreMain/src/OgreCompositionTechnique.cpp
@@ -63,19 +63,11 @@ void CompositionTechnique::removeTextureDefinition(size_t index)
     OGRE_DELETE (*i);
     mTextureDefinitions.erase(i);
 }
-//-----------------------------------------------------------------------
-
-CompositionTechnique::TextureDefinition *CompositionTechnique::getTextureDefinition(size_t index)
-{
-    assert (index < mTextureDefinitions.size() && "Index out of bounds.");
-    return mTextureDefinitions[index];
-}
 //---------------------------------------------------------------------
-CompositionTechnique::TextureDefinition *CompositionTechnique::getTextureDefinition(const String& name)
+CompositionTechnique::TextureDefinition *CompositionTechnique::getTextureDefinition(const String& name) const
 {
-    TextureDefinitions::iterator i, iend;
-    iend = mTextureDefinitions.end();
-    for (i = mTextureDefinitions.begin(); i != iend; ++i)
+    auto iend = mTextureDefinitions.end();
+    for (auto i = mTextureDefinitions.begin(); i != iend; ++i)
     {
         if ((*i)->name == name)
             return *i;
@@ -83,12 +75,6 @@ CompositionTechnique::TextureDefinition *CompositionTechnique::getTextureDefinit
 
     return 0;
 
-}
-//-----------------------------------------------------------------------
-
-size_t CompositionTechnique::getNumTextureDefinitions()
-{
-    return mTextureDefinitions.size();
 }
 //-----------------------------------------------------------------------
 void CompositionTechnique::removeAllTextureDefinitions()
@@ -124,19 +110,6 @@ void CompositionTechnique::removeTargetPass(size_t index)
     mTargetPasses.erase(i);
 }
 //-----------------------------------------------------------------------
-
-CompositionTargetPass *CompositionTechnique::getTargetPass(size_t index)
-{
-    assert (index < mTargetPasses.size() && "Index out of bounds.");
-    return mTargetPasses[index];
-}
-//-----------------------------------------------------------------------
-
-size_t CompositionTechnique::getNumTargetPasses()
-{
-    return mTargetPasses.size();
-}
-//-----------------------------------------------------------------------
 void CompositionTechnique::removeAllTargetPasses()
 {
     TargetPasses::iterator i, iend;
@@ -151,11 +124,6 @@ void CompositionTechnique::removeAllTargetPasses()
 CompositionTechnique::TargetPassIterator CompositionTechnique::getTargetPassIterator(void)
 {
     return TargetPassIterator(mTargetPasses.begin(), mTargetPasses.end());
-}
-//-----------------------------------------------------------------------
-CompositionTargetPass *CompositionTechnique::getOutputTargetPass()
-{
-    return mOutputTarget;
 }
 //-----------------------------------------------------------------------
 bool CompositionTechnique::isSupported(bool acceptTextureDegradation)

--- a/OgreMain/src/OgreCompositor.cpp
+++ b/OgreMain/src/OgreCompositor.cpp
@@ -71,19 +71,6 @@ void Compositor::removeTechnique(size_t index)
     mCompilationRequired = true;
 }
 //-----------------------------------------------------------------------
-
-CompositionTechnique *Compositor::getTechnique(size_t index)
-{
-    assert (index < mTechniques.size() && "Index out of bounds.");
-    return mTechniques[index];
-}
-//-----------------------------------------------------------------------
-
-size_t Compositor::getNumTechniques()
-{
-    return mTechniques.size();
-}
-//-----------------------------------------------------------------------
 void Compositor::removeAllTechniques()
 {
     Techniques::iterator i, iend;
@@ -100,19 +87,6 @@ void Compositor::removeAllTechniques()
 Compositor::TechniqueIterator Compositor::getTechniqueIterator(void)
 {
     return TechniqueIterator(mTechniques.begin(), mTechniques.end());
-}
-//-----------------------------------------------------------------------
-
-CompositionTechnique *Compositor::getSupportedTechnique(size_t index)
-{
-    assert (index < mSupportedTechniques.size() && "Index out of bounds.");
-    return mSupportedTechniques[index];
-}
-//-----------------------------------------------------------------------
-
-size_t Compositor::getNumSupportedTechniques()
-{
-    return mSupportedTechniques.size();
 }
 //-----------------------------------------------------------------------
 

--- a/OgreMain/src/OgreCompositorChain.cpp
+++ b/OgreMain/src/OgreCompositorChain.cpp
@@ -215,15 +215,9 @@ void CompositorChain::_queuedOperation(CompositorInstance::RenderSystemOperation
 
 }
 //-----------------------------------------------------------------------
-CompositorInstance *CompositorChain::getCompositor(size_t index)
+size_t CompositorChain::getCompositorPosition(const String& name) const
 {
-    assert (index < mInstances.size() && "Index out of bounds.");
-    return mInstances[index];
-}
-//-----------------------------------------------------------------------
-size_t CompositorChain::getCompositorPosition(const String& name)
-{
-    for (Instances::iterator it = mInstances.begin(); it != mInstances.end(); ++it) 
+    for (auto it = mInstances.begin(); it != mInstances.end(); ++it)
     {
         if ((*it)->getCompositor()->getName() == name) 
         {
@@ -232,7 +226,7 @@ size_t CompositorChain::getCompositorPosition(const String& name)
     }
     return NPOS;
 }
-CompositorInstance *CompositorChain::getCompositor(const String& name)
+CompositorInstance *CompositorChain::getCompositor(const String& name) const
 {
     size_t idx = getCompositorPosition(name);
     return idx == NPOS ? NULL : mInstances[idx];

--- a/OgreMain/src/OgreCompositorInstance.cpp
+++ b/OgreMain/src/OgreCompositorInstance.cpp
@@ -531,16 +531,6 @@ void CompositorInstance::_compileOutputOperation(TargetOperation &finalState)
     collectPasses(finalState, tpass);
 }
 //-----------------------------------------------------------------------
-Compositor *CompositorInstance::getCompositor()
-{
-    return mCompositor;
-}
-//-----------------------------------------------------------------------
-CompositionTechnique *CompositorInstance::getTechnique()
-{
-    return mTechnique;
-}
-//-----------------------------------------------------------------------
 void CompositorInstance::setTechnique(CompositionTechnique* tech, bool reuseTextures)
 {
     if (mTechnique != tech)

--- a/OgreMain/src/OgreEntity.cpp
+++ b/OgreMain/src/OgreEntity.cpp
@@ -294,24 +294,10 @@ namespace Ogre {
         return mMesh;
     }
     //-----------------------------------------------------------------------
-    SubEntity* Entity::getSubEntity(size_t index) const
-    {
-        if (index >= mSubEntityList.size())
-            OGRE_EXCEPT(Exception::ERR_INVALIDPARAMS,
-                        "Index out of bounds.",
-                        "Entity::getSubEntity");
-        return mSubEntityList[index];
-    }
-    //-----------------------------------------------------------------------
     SubEntity* Entity::getSubEntity(const String& name) const
     {
         ushort index = mMesh->_getSubMeshIndex(name);
         return getSubEntity(index);
-    }
-    //-----------------------------------------------------------------------
-    size_t Entity::getNumSubEntities(void) const
-    {
-        return mSubEntityList.size();
     }
     //-----------------------------------------------------------------------
     Entity* Entity::clone( const String& newName) const

--- a/OgreMain/src/OgreManualObject.cpp
+++ b/OgreMain/src/OgreManualObject.cpp
@@ -551,20 +551,6 @@ ManualObject::ManualObject(const String& name)
         // Save setting for future sections
         mUseIdentityView = useIdentityView;
     }
-    //-----------------------------------------------------------------------
-    ManualObject::ManualObjectSection* ManualObject::getSection(unsigned int inIndex) const
-    {
-        if (inIndex >= mSectionList.size())
-            OGRE_EXCEPT(Exception::ERR_INVALIDPARAMS,
-            "Index out of bounds.",
-            "ManualObject::getSection");
-        return mSectionList[inIndex];
-    }
-    //-----------------------------------------------------------------------
-    unsigned int ManualObject::getNumSections(void) const
-    {
-        return static_cast< unsigned int >( mSectionList.size() );
-    }
     //-----------------------------------------------------------------------------
     const String& ManualObject::getMovableType(void) const
     {

--- a/OgreMain/src/OgreMaterial.cpp
+++ b/OgreMain/src/OgreMaterial.cpp
@@ -238,12 +238,6 @@ namespace Ogre {
         return t;
     }
     //-----------------------------------------------------------------------
-    Technique* Material::getTechnique(unsigned short index) const
-    {
-        assert (index < mTechniques.size() && "Index out of bounds.");
-        return mTechniques[index];
-    }
-    //-----------------------------------------------------------------------
     Technique* Material::getTechnique(const String& name) const
     {
         Techniques::const_iterator i    = mTechniques.begin();
@@ -262,22 +256,6 @@ namespace Ogre {
         }
 
         return foundTechnique;
-    }
-    //-----------------------------------------------------------------------   
-    unsigned short Material::getNumTechniques(void) const
-    {
-        return static_cast<unsigned short>(mTechniques.size());
-    }
-    //-----------------------------------------------------------------------
-    Technique* Material::getSupportedTechnique(unsigned short index)
-    {
-        assert (index < mSupportedTechniques.size() && "Index out of bounds.");
-        return mSupportedTechniques[index];
-    }
-    //-----------------------------------------------------------------------   
-    unsigned short Material::getNumSupportedTechniques(void) const
-    {
-        return static_cast<unsigned short>(mSupportedTechniques.size());
     }
     //-----------------------------------------------------------------------
     unsigned short Material::getNumLodLevels(unsigned short schemeIndex) const

--- a/OgreMain/src/OgreMesh.cpp
+++ b/OgreMain/src/OgreMesh.cpp
@@ -2396,22 +2396,9 @@ namespace Ogre {
         return retPose;
     }
     //---------------------------------------------------------------------
-    Pose* Mesh::getPose(ushort index)
+    Pose* Mesh::getPose(const String& name) const
     {
-        if (index >= mPoseList.size())
-        {
-            OGRE_EXCEPT(Exception::ERR_INVALIDPARAMS,
-                "Index out of bounds",
-                "Mesh::getPose");
-        }
-
-        return mPoseList[index];
-
-    }
-    //---------------------------------------------------------------------
-    Pose* Mesh::getPose(const String& name)
-    {
-        for (PoseList::iterator i = mPoseList.begin(); i != mPoseList.end(); ++i)
+        for (auto i = mPoseList.begin(); i != mPoseList.end(); ++i)
         {
             if ((*i)->getName() == name)
                 return *i;

--- a/OgreMain/src/OgrePass.cpp
+++ b/OgreMain/src/OgrePass.cpp
@@ -500,13 +500,6 @@ namespace Ogre {
             mContentTypeLookupBuilt = false;
         }
     }
-    //-----------------------------------------------------------------------
-    TextureUnitState* Pass::getTextureUnitState(unsigned short index) const
-    {
-            OGRE_LOCK_MUTEX(mTexUnitChangeMutex);
-        assert (index < mTextureUnitStates.size() && "Index out of bounds");
-        return mTextureUnitStates[index];
-    }
     //-----------------------------------------------------------------------------
     TextureUnitState* Pass::getTextureUnitState(const String& name) const
     {

--- a/OgreMain/src/OgreRibbonTrail.cpp
+++ b/OgreMain/src/OgreRibbonTrail.cpp
@@ -231,16 +231,6 @@ namespace Ogre
         mInitialColour[chainIndex].a = a;
     }
     //-----------------------------------------------------------------------
-    const ColourValue& RibbonTrail::getInitialColour(size_t chainIndex) const
-    {
-        if (chainIndex >= mChainCount)
-        {
-            OGRE_EXCEPT(Exception::ERR_INVALIDPARAMS, 
-                "chainIndex out of bounds", "RibbonTrail::getInitialColour");
-        }
-        return mInitialColour[chainIndex];
-    }
-    //-----------------------------------------------------------------------
     void RibbonTrail::setInitialWidth(size_t chainIndex, Real width)
     {
         if (chainIndex >= mChainCount)
@@ -249,16 +239,6 @@ namespace Ogre
                 "chainIndex out of bounds", "RibbonTrail::setInitialWidth");
         }
         mInitialWidth[chainIndex] = width;
-    }
-    //-----------------------------------------------------------------------
-    Real RibbonTrail::getInitialWidth(size_t chainIndex) const
-    {
-        if (chainIndex >= mChainCount)
-        {
-            OGRE_EXCEPT(Exception::ERR_INVALIDPARAMS, 
-                "chainIndex out of bounds", "RibbonTrail::getInitialWidth");
-        }
-        return mInitialWidth[chainIndex];
     }
     //-----------------------------------------------------------------------
     void RibbonTrail::setColourChange(size_t chainIndex, const ColourValue& valuePerSecond)
@@ -283,16 +263,6 @@ namespace Ogre
 
     }
     //-----------------------------------------------------------------------
-    const ColourValue& RibbonTrail::getColourChange(size_t chainIndex) const
-    {
-        if (chainIndex >= mChainCount)
-        {
-            OGRE_EXCEPT(Exception::ERR_INVALIDPARAMS, 
-                "chainIndex out of bounds", "RibbonTrail::getColourChange");
-        }
-        return mDeltaColour[chainIndex];
-    }
-    //-----------------------------------------------------------------------
     void RibbonTrail::setWidthChange(size_t chainIndex, Real widthDeltaPerSecond)
     {
         if (chainIndex >= mChainCount)
@@ -302,17 +272,6 @@ namespace Ogre
         }
         mDeltaWidth[chainIndex] = widthDeltaPerSecond;
         manageController();
-    }
-    //-----------------------------------------------------------------------
-    Real RibbonTrail::getWidthChange(size_t chainIndex) const
-    {
-        if (chainIndex >= mChainCount)
-        {
-            OGRE_EXCEPT(Exception::ERR_INVALIDPARAMS, 
-                "chainIndex out of bounds", "RibbonTrail::getWidthChange");
-        }
-        return mDeltaWidth[chainIndex];
-
     }
     //-----------------------------------------------------------------------
     void RibbonTrail::manageController(void)

--- a/OgreMain/src/OgreSceneNode.cpp
+++ b/OgreMain/src/OgreSceneNode.cpp
@@ -119,28 +119,11 @@ namespace Ogre {
         needUpdate();
     }
     //-----------------------------------------------------------------------
-    unsigned short SceneNode::numAttachedObjects(void) const
-    {
-        return static_cast< unsigned short >( mObjectsByName.size() );
-    }
-    //-----------------------------------------------------------------------
-    MovableObject* SceneNode::getAttachedObject(unsigned short index)
-    {
-        if (index < mObjectsByName.size())
-        {
-            return mObjectsByName[index];
-        }
-        else
-        {
-            OGRE_EXCEPT(Exception::ERR_INVALIDPARAMS, "Object index out of bounds.", "SceneNode::getAttachedObject");
-        }
-    }
-    //-----------------------------------------------------------------------
-    MovableObject* SceneNode::getAttachedObject(const String& name)
+    MovableObject* SceneNode::getAttachedObject(const String& name) const
     {
         // Look up 
         MovableObjectNameExists pred = {name};
-        ObjectMap::iterator i = std::find_if(mObjectsByName.begin(), mObjectsByName.end(), pred);
+        auto i = std::find_if(mObjectsByName.begin(), mObjectsByName.end(), pred);
 
         if (i == mObjectsByName.end())
         {

--- a/OgreMain/src/OgreTechnique.cpp
+++ b/OgreMain/src/OgreTechnique.cpp
@@ -299,12 +299,6 @@ namespace Ogre {
         return newPass;
     }
     //-----------------------------------------------------------------------------
-    Pass* Technique::getPass(unsigned short index) const
-    {
-        assert(index < mPasses.size() && "Index out of bounds");
-        return mPasses[index];
-    }
-    //-----------------------------------------------------------------------------
     Pass* Technique::getPass(const String& name) const
     {
         Passes::const_iterator i    = mPasses.begin();
@@ -323,11 +317,6 @@ namespace Ogre {
         }
 
         return foundPass;
-    }
-    //-----------------------------------------------------------------------------
-    unsigned short Technique::getNumPasses(void) const
-    {
-        return static_cast<unsigned short>(mPasses.size());
     }
     //-----------------------------------------------------------------------------
     void Technique::removePass(unsigned short index)

--- a/Tests/OgreMain/src/MeshSerializerTests.cpp
+++ b/Tests/OgreMain/src/MeshSerializerTests.cpp
@@ -431,7 +431,7 @@ void MeshSerializerTests::assertMeshClone(Mesh* a, Mesh* b, MeshVersion version 
             EXPECT_EQ(bList.at(it->first)->getAnimationType(), it->second->getAnimationType());
             ASSERT_EQ(bList.at(it->first)->getNumKeyFrames(), it->second->getNumKeyFrames());
 
-            for (int j = 0; j < it->second->getNumKeyFrames(); j++)
+            for (size_t j = 0; j < it->second->getNumKeyFrames(); j++)
             {
                 VertexPoseKeyFrame* aKeyFrame = it->second->getVertexPoseKeyFrame(j);
                 VertexPoseKeyFrame* bKeyFrame = bList.at(it->first)->getVertexPoseKeyFrame(j);


### PR DESCRIPTION
fix declaration and un-deprecate as applicable. Also do bounds checking
for full binding support.