### PR TITLE
Fix UBSan error about member call on address not pointing to ScriptTranslatorManager

### DIFF
--- a/OgreMain/include/OgreScriptTranslator.h
+++ b/OgreMain/include/OgreScriptTranslator.h
@@ -120,7 +120,7 @@ namespace Ogre{
      *  ScriptCompilerManager tied to specific object types.
      *  Each manager may manage multiple types.
      */
-    class ScriptTranslatorManager : public ScriptTranslatorAlloc
+    class _OgreExport ScriptTranslatorManager : public ScriptTranslatorAlloc
     {
     public:
         // required - virtual destructor


### PR DESCRIPTION
The error occurred when calling getTranslator(const AbstractNodePtr&) on an RTShader::SGScriptTranslatorManager in ScriptCompilerManager::getTranslator(const AbstractNodePtr&) due to the ScriptTranslatorManager not being exported. Therefore, technically, both OgreMain and OgreRTShaderSystem contain distinct ScriptTranslatorManager types.

See https://stackoverflow.com/a/57304113 and https://bugs.llvm.org/show_bug.cgi?id=39191#c1.