### PR TITLE
Disable vptr checks for Singleton constructor

### DIFF
--- a/OgreMain/include/OgreSingleton.h
+++ b/OgreMain/include/OgreSingleton.h
@@ -80,7 +80,7 @@ protected:
     static T* msSingleton;
 
 public:
-#if defined(__GNUC__) || defined(__clang__)
+#if (defined(__has_attribute) && __has_attribute(no_sanitize)) || (defined(__GNUC__) && __GNUC__ >= 8)
     // The `static_cast` happens so early in the construction of the inheriting
     // classes that the `this` pointer is still detected as the super class
     // pointer. Therefore, disabling vptr checks.

--- a/OgreMain/include/OgreSingleton.h
+++ b/OgreMain/include/OgreSingleton.h
@@ -80,11 +80,13 @@ protected:
     static T* msSingleton;
 
 public:
-#if (defined(__has_attribute) && __has_attribute(no_sanitize)) || (defined(__GNUC__) && __GNUC__ >= 8)
+#if defined(__has_attribute)
+#  if __has_attribute(no_sanitize)
     // The `static_cast` happens so early in the construction of the inheriting
     // classes that the `this` pointer is still detected as the super class
     // pointer. Therefore, disabling vptr checks.
     __attribute__((no_sanitize("vptr")))
+#  endif
 #endif
     Singleton(void)
     {

--- a/OgreMain/include/OgreSingleton.h
+++ b/OgreMain/include/OgreSingleton.h
@@ -80,6 +80,12 @@ protected:
     static T* msSingleton;
 
 public:
+#if defined(__GNUC__) || defined(__clang__)
+    // The `static_cast` happens so early in the construction of the inheriting
+    // classes that the `this` pointer is still detected as the super class
+    // pointer. Therefore, disabling vptr checks.
+    __attribute__((no_sanitize("vptr")))
+#endif
     Singleton(void)
     {
         OgreAssert(!msSingleton, "There can be only one singleton");


### PR DESCRIPTION
UBSan complains a lot about the this pointer not being of type T* which is correct during construction, but ultimately doesn't matter. This change disables the vptr check on the Singleton constructor to avoid errors from UBSan.