### PR TITLE
fix compiling error in linux 2

### DIFF
--- a/OgreMain/include/OgreMath.h
+++ b/OgreMain/include/OgreMath.h
@@ -28,6 +28,7 @@ THE SOFTWARE.
 #ifndef __Math_H__
 #define __Math_H__
 
+#include <limits>
 #include "OgrePrerequisites.h"
 #include "OgreHeaderPrefix.h"
 


### PR DESCRIPTION
Fixing the compiling error in linux, I put include in OgreMath.h as Pavel said.