### PR TITLE
fix warnings on compiling with GCC11 in linux

### DIFF
--- a/OgreMain/src/OgreSIMDHelper.h
+++ b/OgreMain/src/OgreSIMDHelper.h
@@ -290,7 +290,7 @@ namespace Ogre {
 #if OGRE_DEBUG_MODE
 #define __OGRE_CHECK_STACK_ALIGNED_FOR_SSE()        \
     {                                               \
-        __m128 test;                                \
+        __m128 test = {};                           \
         assert(_isAlignedForSSE(&test));            \
     }
 


### PR DESCRIPTION
Fix this warning messages
[output.txt](https://github.com/OGRECave/ogre/files/6569091/output.txt)
