### PR TITLE
Fixing warning in a deprecated String::toString case

### DIFF
--- a/RenderSystems/GLES2/src/OgreGLES2HardwarePixelBuffer.cpp
+++ b/RenderSystems/GLES2/src/OgreGLES2HardwarePixelBuffer.cpp
@@ -245,8 +245,8 @@ namespace Ogre {
         LogManager::getSingleton().logMessage("GLES2TextureBuffer::upload - ID: " + StringConverter::toString(mTextureID) +
                                               " Target: " + StringConverter::toString(mTarget) +
                                               " Format: " + PixelUtil::getFormatName(data.format) +
-                                              " Origin format: " + StringConverter::toString(GLES2PixelUtil::getGLOriginFormat(data.format), 0, ' ', std::ios::hex) +
-                                              " Data type: " + StringConverter::toString(GLES2PixelUtil::getGLOriginDataType(data.format), 0, ' ', std::ios::hex));
+                                              " Origin format: " + StringUtil::format("%x", GLES2PixelUtil::getGLOriginFormat(data.format)) +
+                                              " Data type: " + StringUtil::format("%x", GLES2PixelUtil::getGLOriginDataType(data.format)));
 #endif
 #endif
 

--- a/RenderSystems/GLES2/src/OgreGLES2Texture.cpp
+++ b/RenderSystems/GLES2/src/OgreGLES2Texture.cpp
@@ -187,9 +187,9 @@ namespace Ogre {
                 LogManager::getSingleton().logMessage("GLES2Texture::create - Mip: " + StringConverter::toString(mip) +
                                                       " Width: " + StringConverter::toString(width) +
                                                       " Height: " + StringConverter::toString(height) +
-                                                      " Internal Format: " + StringConverter::toString(internalformat, 0, ' ', std::ios::hex) +
-                                                      " Format: " + StringConverter::toString(format, 0, ' ', std::ios::hex)
-                                                      );
+                                                      " Internal Format: " + StringUtil::format("%x", internalformat) +
+                                                      " Format: " + StringUtil::format("%x", format)
+                                                       );
 #endif
                 size = static_cast<GLsizei>(PixelUtil::getMemorySize(width, height, depth, mFormat));
                 
@@ -249,7 +249,7 @@ namespace Ogre {
                                                       " ID: " + StringConverter::toString(mTextureID) +
                                                       " Width: " + StringConverter::toString(width) +
                                                       " Height: " + StringConverter::toString(height) +
-                                                      " Internal Format: " + StringConverter::toString(internalformat, 0, ' ', std::ios::hex));
+                                                      " Internal Format: " + StringUtil::format("%x", internalformat));
 #endif
             switch(mTextureType)
             {


### PR DESCRIPTION
changes toString for StringUtil::format as documentation advises.