### PR TITLE
RTSS: fix use of non-unit light direction when scaling is present

### DIFF
--- a/Components/RTShaderSystem/src/OgreShaderExPerPixelLighting.cpp
+++ b/Components/RTShaderSystem/src/OgreShaderExPerPixelLighting.cpp
@@ -137,7 +137,7 @@ bool PerPixelLighting::resolvePerLightParameters(ProgramSet* programSet)
         switch (mLightParamsList[i].mType)
         {
         case Light::LT_DIRECTIONAL:
-            mLightParamsList[i].mDirection = psProgram->resolveParameter(GpuProgramParameters::ACT_LIGHT_POSITION_VIEW_SPACE, i);
+            mLightParamsList[i].mDirection = psProgram->resolveParameter(GpuProgramParameters::ACT_LIGHT_DIRECTION_VIEW_SPACE, i);
             mLightParamsList[i].mPSInDirection = mLightParamsList[i].mDirection;
             needViewPos = mSpecularEnable || needViewPos;
             break;
@@ -151,7 +151,7 @@ bool PerPixelLighting::resolvePerLightParameters(ProgramSet* programSet)
 
         case Light::LT_SPOTLIGHT:
             mLightParamsList[i].mPosition = psProgram->resolveParameter(GpuProgramParameters::ACT_LIGHT_POSITION_VIEW_SPACE, i);
-            mLightParamsList[i].mDirection = psProgram->resolveParameter(GCT_FLOAT4, -1, (uint16)GPV_LIGHTS, "light_direction_view_space");
+            mLightParamsList[i].mDirection = psProgram->resolveParameter(GpuProgramParameters::ACT_LIGHT_DIRECTION_VIEW_SPACE, i);
             mLightParamsList[i].mPSInDirection = mLightParamsList[i].mDirection;
             mLightParamsList[i].mAttenuatParams = psProgram->resolveParameter(GpuProgramParameters::ACT_LIGHT_ATTENUATION, i);
             mLightParamsList[i].mSpotParams = psProgram->resolveParameter(GpuProgramParameters::ACT_SPOTLIGHT_PARAMS, i);

--- a/Components/RTShaderSystem/src/OgreShaderFFPLighting.cpp
+++ b/Components/RTShaderSystem/src/OgreShaderFFPLighting.cpp
@@ -106,10 +106,7 @@ void FFPLighting::updateGpuProgramsParams(Renderable* rend, const Pass* pass, co
 			curParams.mPosition->updateExtraInfo(j);
             curParams.mAttenuatParams->updateExtraInfo(j);
             curParams.mSpotParams->updateExtraInfo(j);
-
-            Vector3 vec3;
-			vec3 = source->getInverseTransposeViewMatrix().linear() * source->getLightDirection(j);
-			curParams.mDirection->setGpuParameter(Vector4(-vec3.normalisedCopy(), 0));
+			curParams.mDirection->updateExtraInfo(j);
 		}
 			break;
 		}
@@ -177,7 +174,7 @@ bool FFPLighting::resolveParameters(ProgramSet* programSet)
 		switch (mLightParamsList[i].mType)
 		{
 		case Light::LT_DIRECTIONAL:
-			mLightParamsList[i].mDirection = vsProgram->resolveParameter(GpuProgramParameters::ACT_LIGHT_POSITION_VIEW_SPACE, i);
+			mLightParamsList[i].mDirection = vsProgram->resolveParameter(GpuProgramParameters::ACT_LIGHT_DIRECTION_VIEW_SPACE, i);
 			mLightParamsList[i].mPSInDirection = mLightParamsList[i].mDirection;
 			break;
 		
@@ -194,7 +191,7 @@ bool FFPLighting::resolveParameters(ProgramSet* programSet)
 			mLightParamsList[i].mPosition = vsProgram->resolveParameter(GpuProgramParameters::ACT_LIGHT_POSITION_VIEW_SPACE, i);
             mLightParamsList[i].mAttenuatParams = vsProgram->resolveParameter(GpuProgramParameters::ACT_LIGHT_ATTENUATION, i);
 
-			mLightParamsList[i].mDirection = vsProgram->resolveParameter(GCT_FLOAT4, -1, (uint16)GPV_LIGHTS, "light_direction_view_space");
+			mLightParamsList[i].mDirection = vsProgram->resolveParameter(GpuProgramParameters::ACT_LIGHT_DIRECTION_VIEW_SPACE, i);
 			mLightParamsList[i].mPSInDirection = mLightParamsList[i].mDirection;
 
 			mLightParamsList[i].mSpotParams = vsProgram->resolveParameter(GpuProgramParameters::ACT_SPOTLIGHT_PARAMS, i);

--- a/Components/Terrain/src/OgreTerrainMaterialShaderHelperGLSL.cpp
+++ b/Components/Terrain/src/OgreTerrainMaterialShaderHelperGLSL.cpp
@@ -390,7 +390,7 @@ namespace Ogre
 
         outStream <<
             "    vec3 lightDir = \n"
-            "        lightPosObjSpace.xyz - (oPosObj.xyz * lightPosObjSpace.w);\n"
+            "        -(lightPosObjSpace.xyz - (oPosObj.xyz * lightPosObjSpace.w));\n"
             "    vec3 eyeDir = eyePosObjSpace - oPosObj.xyz;\n"
 
             // set up accumulation areas

--- a/Media/RTShaderLib/GLSL/SGXLib_PerPixelLighting.glsl
+++ b/Media/RTShaderLib/GLSL/SGXLib_PerPixelLighting.glsl
@@ -48,12 +48,12 @@ void SGX_FetchNormal(in sampler2D s,
 //-----------------------------------------------------------------------------
 void SGX_Light_Directional_Diffuse(
 				   in vec3 vNormal,
-				   in vec3 vNegLightDirView,
+				   in vec3 vLightDirView,
 				   in vec3 vDiffuseColour, 
 				   inout vec3 vOut)
 {
 	vec3 vNormalView = normalize(vNormal);
-	float nDotL = dot(vNormalView, vNegLightDirView);
+	float nDotL = dot(vNormalView, -vLightDirView);
 	
 	vOut += vDiffuseColour * clamp(nDotL, 0.0, 1.0);
 	vOut = clamp(vOut, 0.0, 1.0);
@@ -63,7 +63,7 @@ void SGX_Light_Directional_Diffuse(
 void SGX_Light_Directional_DiffuseSpecular(
 					in vec3 vNormal,
 					in vec3 vViewDir,
-					in vec3 vNegLightDirView,
+					in vec3 vLightDirView,
 					in vec3 vDiffuseColour, 
 					in vec3 vSpecularColour, 
 					in float fSpecularPower,
@@ -71,9 +71,9 @@ void SGX_Light_Directional_DiffuseSpecular(
 					inout vec3 vOutSpecular)
 {
 	vec3 vNormalView = normalize(vNormal);		
-	float nDotL		   = dot(vNormalView, vNegLightDirView);			
+	float nDotL		   = dot(vNormalView, -vLightDirView);
 	vec3 vView       = normalize(vViewDir);
-	vec3 vHalfWay    = normalize(vView + vNegLightDirView);
+	vec3 vHalfWay    = normalize(vView + -vLightDirView);
 	float nDotH        = dot(vNormalView, vHalfWay);
 	
 	if (nDotL > 0.0)
@@ -150,7 +150,7 @@ void SGX_Light_Point_DiffuseSpecular(
 void SGX_Light_Spot_Diffuse(
 				    in vec3 vNormal,
 				    in vec3 vLightView,
-				    in vec3 vNegLightDirView,
+				    in vec3 vLightDirView,
 				    in vec4 vAttParams,
 				    in vec3 vSpotParams,
 				    in vec3 vDiffuseColour, 
@@ -164,7 +164,7 @@ void SGX_Light_Spot_Diffuse(
 	if (nDotL > 0.0 && fLightD <= vAttParams.x)
 	{
 		float fAtten	= 1.0 / (vAttParams.y + vAttParams.z*fLightD + vAttParams.w*fLightD*fLightD);
-		float rho		= dot(vNegLightDirView, vLightView);						
+		float rho		= dot(-vLightDirView, vLightView);
 		float fSpotE	= clamp((rho - vSpotParams.y) / (vSpotParams.x - vSpotParams.y), 0.0, 1.0);
 		float fSpotT	= pow(fSpotE, vSpotParams.z);	
 						
@@ -178,7 +178,7 @@ void SGX_Light_Spot_DiffuseSpecular(
 				    in vec3 vNormal,
 				    in vec3 vViewDir,
 				    in vec3 vLightView,
-				    in vec3 vNegLightDirView,
+				    in vec3 vLightDirView,
 				    in vec4 vAttParams,
 				    in vec3 vSpotParams,
 				    in vec3 vDiffuseColour, 
@@ -199,7 +199,7 @@ void SGX_Light_Spot_DiffuseSpecular(
 		vec3 vHalfWay    = normalize(vView + vLightView);				
 		float nDotH        = dot(vNormalView, vHalfWay);
 		float fAtten	= 1.0 / (vAttParams.y + vAttParams.z*fLightD + vAttParams.w*fLightD*fLightD);
-		float rho		= dot(vNegLightDirView, vLightView);						
+		float rho		= dot(-vLightDirView, vLightView);
 		float fSpotE	= clamp((rho - vSpotParams.y) / (vSpotParams.x - vSpotParams.y), 0.0, 1.0);
 		float fSpotT	= pow(fSpotE, vSpotParams.z);	
 						


### PR DESCRIPTION
generally use ACT variant for data retrieval