### PR TITLE
fix warning messages, changing String::toString for StringUtil::format

### DIFF
--- a/RenderSystems/GLES2/src/OgreGLES2Texture.cpp
+++ b/RenderSystems/GLES2/src/OgreGLES2Texture.cpp
@@ -280,9 +280,9 @@ namespace Ogre {
                                                   " ID: " + StringConverter::toString(mTextureID) +
                                                   " Width: " + StringConverter::toString(width) +
                                                   " Height: " + StringConverter::toString(height) +
-                                                  " Internal Format: " + StringConverter::toString(internalformat, 0, ' ', std::ios::hex) +
-                                                  " Format: " + StringConverter::toString(format, 0, ' ', std::ios::hex) +
-                                                  " Datatype: " + StringConverter::toString(datatype, 0, ' ', std::ios::hex)
+                                                  " Internal Format: " + StringUtil::format("%x", internalformat) +
+                                                  " Format: " + StringUtil::format("%x", format) +
+                                                  " Datatype: " + StringUtil::format("%x", datatype)
                                                   );
 #endif
             // Normal formats


### PR DESCRIPTION
Still lasts warnings messages from this type