### PR TITLE
fixing warning messages in android ogre3d compilation

### DIFF
--- a/CMake/Utils/AndroidMacros.cmake
+++ b/CMake/Utils/AndroidMacros.cmake
@@ -58,6 +58,7 @@ macro(create_android_proj ANDROID_PROJECT_TARGET)
 
     SET(ANDROID_SDK_API_LEVEL "${ANDROID_NATIVE_API_LEVEL}")
     SET(ANDROID_TARGET "android-${ANDROID_SDK_API_LEVEL}")
+    SET(MINIZ_X86_OR_X64_CPU "0")
 
     file(MAKE_DIRECTORY "${NDKOUT}/app/src/main/assets")
     file(MAKE_DIRECTORY "${NDKOUT}/app/src/main/res")


### PR DESCRIPTION
this fix those messages for android ogre3d compilation

In file included from /home/joilnen/ogre3d_devel/my/ogre3d-1.13.00/OgreMain/src/OgreDeflate.cpp:38:
/home/joilnen/ogre3d_devel/my/ogre3d-1.13.00/OgreMain/src/zip/miniz.h:287:5: warning: 'MINIZ_X86_OR_X64_CPU' is not defined, evaluates to 0 [-Wundef]
#if MINIZ_X86_OR_X64_CPU
    ^
/home/joilnen/ogre3d_devel/my/ogre3d-1.13.00/OgreMain/src/zip/miniz.h:1088:5: warning: 'MINIZ_HAS_64BIT_REGISTERS' is not defined, evaluates to 0 [-Wundef]
#if MINIZ_HAS_64BIT_REGISTERS
    ^
/home/joilnen/ogre3d_devel/my/ogre3d-1.13.00/OgreMain/src/zip/miniz.h:1092:5: warning: 'TINFL_USE_64BIT_BITBUF' is not defined, evaluates to 0 [-Wundef]
#if TINFL_USE_64BIT_BITBUF
    ^
