### PR TITLE
fix compile warning when passing a 32 bit type into an 8 bit type.

### DIFF
--- a/Components/RTShaderSystem/include/OgreShaderParameter.h
+++ b/Components/RTShaderSystem/include/OgreShaderParameter.h
@@ -589,7 +589,7 @@ public:
             return;
 
         mParamsPtr->_setRawAutoConstant(mPhysicalIndex, mAutoConstantType, data, mVariability,
-                                        mElementSize);
+            static_cast<uint8>(mElementSize));
     }
 
 protected:


### PR DESCRIPTION
this warning prevents my app from compiling cleanly.  did not occur on 1.12.9.