### PR TITLE
RTSS: ProgramManager - drop superfluous cast

### DIFF
--- a/Components/RTShaderSystem/src/OgreShaderProgramManager.cpp
+++ b/Components/RTShaderSystem/src/OgreShaderProgramManager.cpp
@@ -409,12 +409,7 @@ void ProgramManager::removeProgramProcessor(ProgramProcessor* processor)
 //-----------------------------------------------------------------------------
 void ProgramManager::destroyGpuProgram(GpuProgramPtr& gpuProgram)
 {       
-    HighLevelGpuProgramPtr res           = dynamic_pointer_cast<HighLevelGpuProgram>(gpuProgram);
-
-    if (res)
-    {
-        HighLevelGpuProgramManager::getSingleton().remove(res);
-    }
+    GpuProgramManager::getSingleton().remove(gpuProgram);
 }
 
 //-----------------------------------------------------------------------

--- a/Components/Terrain/src/OgreTerrainMaterialGeneratorA.cpp
+++ b/Components/Terrain/src/OgreTerrainMaterialGeneratorA.cpp
@@ -589,7 +589,10 @@ namespace Ogre
                     if(prof->isLayerNormalMappingEnabled())
                         params->setNamedConstant("normtex" + StringConverter::toString(i), (int)numSamplers++);
                 }
+            }
 
+            if (prof->isShadowingEnabled(tt, terrain))
+            {
                 uint numShadowTextures = 1;
                 if (prof->getReceiveDynamicShadowsPSSM())
                     numShadowTextures = (uint)prof->getReceiveDynamicShadowsPSSM()->getSplitCount();


### PR DESCRIPTION
seems VS2019 does not like it

fixes #2134