### PR TITLE
Fix compiling issues regarding mismatch and ambiguous between float and double.

### DIFF
--- a/Components/Overlay/src/OgreFont.cpp
+++ b/Components/Overlay/src/OgreFont.cpp
@@ -540,7 +540,7 @@ namespace Ogre
                            (Real)m / (Real)finalHeight,                  // v1
                            (Real)(l + width) / (Real)finalWidth,         // u2
                            (m + max_height) / (Real)finalHeight); // v2
-                this->setGlyphInfo({cp, uvs, textureAspect * uvs.width() / uvs.height(),
+                this->setGlyphInfo({cp, uvs, float(textureAspect * uvs.width() / uvs.height()),
                                     float(x_bearing) / max_height, float(advance) / max_height});
 
                 // Advance a column

--- a/Components/RTShaderSystem/src/OgreShaderProgram.cpp
+++ b/Components/RTShaderSystem/src/OgreShaderProgram.cpp
@@ -167,7 +167,7 @@ UniformParameterPtr Program::resolveAutoParameterReal(GpuProgramParameters::Auto
     }
     
     // Create new parameter.
-    param = UniformParameterPtr(OGRE_NEW UniformParameter(autoType, data, size));
+    param = UniformParameterPtr(OGRE_NEW UniformParameter(autoType, float(data), size));
     addParameter(param);
 
     return param;


### PR DESCRIPTION
Compiling errors when using the double precision.
Overlay: Non-constant-expression cannot be narrowed from type 'double' to 'float' in initializer list.
RTS: Call to constructor of 'Ogre::RTShader::UniformParameter' is ambiguous.