### PR TITLE
🐛 Fixed missing include in FindOpenGLES2.cmake

### DIFF
--- a/CMake/Packages/FindOpenGLES2.cmake
+++ b/CMake/Packages/FindOpenGLES2.cmake
@@ -23,6 +23,8 @@
 #  EGL_INCLUDE_DIR  - the EGL include directory
 #  EGL_LIBRARIES    - Link these to use EGL
 
+include(FindPkgMacros)
+
 IF(APPLE)
   create_search_paths(/Developer/Platforms)
   findpkg_framework(OpenGLES2)


### PR DESCRIPTION
Fixed a missing `include(FindPkgMacros)` in `FindOpenGLES2.cmake`