### PR TITLE
Enable OBJC and OBJCXX for apple build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,11 @@ if (APPLE AND NOT ANDROID)
   set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++11")
   set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++")
 
+  if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.16.0")
+    enable_language(OBJC)
+    enable_language(OBJCXX)
+  endif()
+
   if(POLICY CMP0068)
     cmake_policy(SET CMP0068 NEW)  # CMake 3.9+: `RPATH` settings on macOS do not affect `install_name`.
   endif()


### PR DESCRIPTION
Without this small changes build on macOS fails with error like:
```
error: Objective-C was disabled in PCH file but is currently enabled
```

Here a two small changes:
 - increase minimal version of cmake to 3.16.0.
 - enable languages `OBJC` and `OBJCXX`;

CMake-3.16.0 was the first one which is supported `OBJC` and `OBJCXX`: https://discourse.cmake.org/t/cmake-3-16-0-available-for-download/262