### PR TITLE
Fix this crash in linux(arch linux/intel(mesa21.2.1-1)

### DIFF
--- a/Media/RTShaderLib/GLSL/SGXLib_PerPixelLighting.glsl
+++ b/Media/RTShaderLib/GLSL/SGXLib_PerPixelLighting.glsl
@@ -50,7 +50,7 @@ void SGX_Flip_Backface_Normal(in float triArea, in float targetFlipped, inout ve
 #else
 void SGX_Flip_Backface_Normal(in bool frontFacing, in float targetFlipped, inout vec3 normal)
 {
-	if(targetFlipped < 0)
+	if(targetFlipped < 0.0)
 		frontFacing = !frontFacing;
 	if(!frontFacing)
 		normal *= -1.0;


### PR DESCRIPTION
Error: RTSS - creating GpuPrograms for pass 0 of 'RTSS/OffsetMapping' failed
An exception has occurred: RuntimeAssertionException: gpuProgram failed. gpu program could not be created in createGpuPrograms at /home/joilnen/ogre3d_devel/my/ogre3d-13.2.c4039/Components/RTShaderSystem/src/OgreShaderProgramManager.cpp (line 250)