### PR TITLE
fix warning message in android ndk23

### DIFF
--- a/Components/Bites/include/OgreInput.h
+++ b/Components/Bites/include/OgreInput.h
@@ -202,7 +202,7 @@ public:
     InputListenerChain() {}
     InputListenerChain(std::vector<InputListener*> chain) : mListenerChain(chain) {}
 
-    InputListenerChain& operator=(InputListenerChain o)
+    InputListenerChain& operator=(const InputListenerChain &o)
     {
         mListenerChain = o.mListenerChain;
         return *this;

--- a/OgreMain/src/Android/OgreAPKFileSystemArchive.cpp
+++ b/OgreMain/src/Android/OgreAPKFileSystemArchive.cpp
@@ -50,187 +50,187 @@ namespace {
         time_t getModifiedTime(const String& filename) const;
     };
 
-	std::map<String, std::vector< String > > mFiles;
+    std::map<String, std::vector< String > > mFiles;
 
-	bool IsFolderParsed( const String& Folder ) {
-		bool parsed = false;
-		std::map<String, std::vector< String > >::iterator iter = mFiles.find( Folder );
-		if(iter != mFiles.end()) parsed = true;
-		return parsed;
-	}
+    bool IsFolderParsed( const String& Folder ) {
+        bool parsed = false;
+        std::map<String, std::vector< String > >::iterator iter = mFiles.find( Folder );
+        if(iter != mFiles.end()) parsed = true;
+        return parsed;
+    }
 
-	void ParseFolder( AAssetManager* AssetMgr, const String& Folder ) {
-		std::vector<String> mFilenames;
-		AAssetDir* dir = AAssetManager_openDir(AssetMgr, Folder.c_str());
-		const char* fileName = NULL;
-		while((fileName = AAssetDir_getNextFileName(dir)) != NULL) {
-			mFilenames.push_back( String( fileName ) );
-		}
-		mFiles.insert( std::make_pair( Folder, mFilenames ) );
-	}
+    void ParseFolder( AAssetManager* AssetMgr, const String& Folder ) {
+        std::vector<String> mFilenames;
+        AAssetDir* dir = AAssetManager_openDir(AssetMgr, Folder.c_str());
+        const char* fileName = NULL;
+        while((fileName = AAssetDir_getNextFileName(dir)) != NULL) {
+            mFilenames.push_back( String( fileName ) );
+        }
+        mFiles.insert( std::make_pair( Folder, mFilenames ) );
+    }
 }
-	APKFileSystemArchive::APKFileSystemArchive(const String& name, const String& archType, AAssetManager* assetMgr)
-		:Archive(name, archType), mAssetMgr(assetMgr)
-	{
+    APKFileSystemArchive::APKFileSystemArchive(const String& name, const String& archType, AAssetManager* assetMgr)
+        :Archive(name, archType), mAssetMgr(assetMgr)
+    {
         if (mName.size() > 0 && mName[0] == '/')
-        	mName.erase(mName.begin());
+            mName.erase(mName.begin());
 
         mPathPreFix = mName;
         if (mPathPreFix.size() > 0)
-        	mPathPreFix += "/";
-			
-		if(!IsFolderParsed( mName )) {
-			ParseFolder( mAssetMgr, mName );
-		}			
-	}
+            mPathPreFix += "/";
+            
+        if(!IsFolderParsed( mName )) {
+            ParseFolder( mAssetMgr, mName );
+        }           
+    }
 
-	APKFileSystemArchive::~APKFileSystemArchive()
-	{
-		std::map<String, std::vector< String > >::iterator iter = mFiles.find( mName );
-		if (iter != mFiles.end()) {
-			iter->second.clear();
-			mFiles.erase( iter );
-		}
-		unload();
-	}
+    APKFileSystemArchive::~APKFileSystemArchive()
+    {
+        std::map<String, std::vector< String > >::iterator iter = mFiles.find( mName );
+        if (iter != mFiles.end()) {
+            iter->second.clear();
+            mFiles.erase( iter );
+        }
+        unload();
+    }
 
-	bool APKFileSystemArchive::isCaseSensitive() const
-	{
-		return true;
-	}
+    bool APKFileSystemArchive::isCaseSensitive() const
+    {
+        return true;
+    }
 
-	void APKFileSystemArchive::load()
-	{
+    void APKFileSystemArchive::load()
+    {
 
-	}
+    }
 
-	void APKFileSystemArchive::unload()
-	{
+    void APKFileSystemArchive::unload()
+    {
 
-	}
+    }
 
-	DataStreamPtr APKFileSystemArchive::open(const Ogre::String &filename, bool readOnly) const
-	{
-	    MemoryDataStreamPtr stream;
-		AAsset* asset = AAssetManager_open(mAssetMgr, (mPathPreFix + filename).c_str(), AASSET_MODE_BUFFER);
-		if(asset)
-		{
-			off_t length = AAsset_getLength(asset);
+    DataStreamPtr APKFileSystemArchive::open(const Ogre::String &filename, bool readOnly) const
+    {
+        MemoryDataStreamPtr stream;
+        AAsset* asset = AAssetManager_open(mAssetMgr, (mPathPreFix + filename).c_str(), AASSET_MODE_BUFFER);
+        if(asset)
+        {
+            off_t length = AAsset_getLength(asset);
             stream = std::make_shared<MemoryDataStream>(filename, length, true, true);
-			memcpy(stream->getPtr(), AAsset_getBuffer(asset), length);
-			AAsset_close(asset);
-		}
-		return stream;
-	}
+            memcpy(stream->getPtr(), AAsset_getBuffer(asset), length);
+            AAsset_close(asset);
+        }
+        return stream;
+    }
 
-	DataStreamPtr APKFileSystemArchive::create(const Ogre::String &filename)
-	{
-		return DataStreamPtr();
-	}
+    DataStreamPtr APKFileSystemArchive::create(const Ogre::String &filename)
+    {
+        return DataStreamPtr();
+    }
 
-	void APKFileSystemArchive::remove(const String &filename)
-	{
+    void APKFileSystemArchive::remove(const String &filename)
+    {
 
-	}
+    }
 
-	StringVectorPtr APKFileSystemArchive::list(bool recursive, bool dirs) const
-	{
-		StringVectorPtr files(new StringVector);
-		std::map<String, std::vector< String > >::iterator iter = mFiles.find( mName );
-		std::vector< String > fileList = iter->second;
-		for( size_t i = 0; i < fileList.size(); i++ )
-		{
-			files->push_back(fileList[i]);
-		}
-		return files;
-	}
+    StringVectorPtr APKFileSystemArchive::list(bool recursive, bool dirs) const
+    {
+        StringVectorPtr files(new StringVector);
+        std::map<String, std::vector< String > >::iterator iter = mFiles.find( mName );
+        std::vector< String > fileList = iter->second;
+        for( size_t i = 0; i < fileList.size(); i++ )
+        {
+            files->push_back(fileList[i]);
+        }
+        return files;
+    }
 
-	FileInfoListPtr APKFileSystemArchive::listFileInfo(bool recursive, bool dirs) const
-	{
-		FileInfoListPtr files(new FileInfoList);
-		std::map<String, std::vector< String > >::iterator iter = mFiles.find( mName );
-		std::vector< String > fileList = iter->second;
-		for( size_t i = 0; i < fileList.size(); i++ )
-		{
-			AAsset* asset = AAssetManager_open(mAssetMgr, (mPathPreFix + fileList[i]).c_str(), AASSET_MODE_UNKNOWN);
-			if(asset)
-			{
-				FileInfo info;
-				info.archive = this;
-				info.filename = fileList[i];
-				info.path = mName;
-				info.basename = fileList[i];
-				info.compressedSize = AAsset_getLength(asset);
-				info.uncompressedSize = info.compressedSize;
-				files->push_back(info);
-				AAsset_close(asset);
-			}
-		}
-		return files;
-	}
+    FileInfoListPtr APKFileSystemArchive::listFileInfo(bool recursive, bool dirs) const
+    {
+        FileInfoListPtr files(new FileInfoList);
+        std::map<String, std::vector< String > >::iterator iter = mFiles.find( mName );
+        std::vector< String > fileList = iter->second;
+        for( size_t i = 0; i < fileList.size(); i++ )
+        {
+            AAsset* asset = AAssetManager_open(mAssetMgr, (mPathPreFix + fileList[i]).c_str(), AASSET_MODE_UNKNOWN);
+            if(asset)
+            {
+                FileInfo info;
+                info.archive = this;
+                info.filename = fileList[i];
+                info.path = mName;
+                info.basename = fileList[i];
+                info.compressedSize = AAsset_getLength(asset);
+                info.uncompressedSize = info.compressedSize;
+                files->push_back(info);
+                AAsset_close(asset);
+            }
+        }
+        return files;
+    }
 
-	StringVectorPtr APKFileSystemArchive::find(const String& pattern, bool recursive, bool dirs) const
-	{
-		StringVectorPtr files(new StringVector);
-		std::map<String, std::vector< String > >::iterator iter = mFiles.find( mName );
-		std::vector< String > fileList = iter->second;
-		for( size_t i = 0; i < fileList.size(); i++ ) 
-		{
-			if(StringUtil::match(fileList[i], pattern))
-				files->push_back(fileList[i]);
-		}
-		return files;
-	}
+    StringVectorPtr APKFileSystemArchive::find(const String& pattern, bool recursive, bool dirs) const
+    {
+        StringVectorPtr files(new StringVector);
+        std::map<String, std::vector< String > >::iterator iter = mFiles.find( mName );
+        std::vector< String > fileList = iter->second;
+        for( size_t i = 0; i < fileList.size(); i++ ) 
+        {
+            if(StringUtil::match(fileList[i], pattern))
+                files->push_back(fileList[i]);
+        }
+        return files;
+    }
 
-	FileInfoListPtr APKFileSystemArchive::findFileInfo(const String& pattern, bool recursive, bool dirs) const
-	{
-		FileInfoListPtr files(new FileInfoList);
-		std::map<String, std::vector< String > >::iterator iter = mFiles.find( mName );
-		std::vector< String > fileList = iter->second;
-		for( size_t i = 0; i < fileList.size(); i++ ) 
-		{
-			if(StringUtil::match(fileList[i], pattern)) 
-			{
-				AAsset* asset = AAssetManager_open(mAssetMgr, (mPathPreFix + fileList[i]).c_str(), AASSET_MODE_UNKNOWN);
-				if(asset) {
-					FileInfo info;
-					info.archive = this;
-					info.filename = fileList[i];
-					info.path = mName;
-					info.basename = fileList[i];
-					info.compressedSize = AAsset_getLength(asset);
-					info.uncompressedSize = info.compressedSize;
-					files->push_back(info);
-					AAsset_close(asset);
-				}
-			}
-		}
-		return files;
-	}
+    FileInfoListPtr APKFileSystemArchive::findFileInfo(const String& pattern, bool recursive, bool dirs) const
+    {
+        FileInfoListPtr files(new FileInfoList);
+        std::map<String, std::vector< String > >::iterator iter = mFiles.find( mName );
+        std::vector< String > fileList = iter->second;
+        for( size_t i = 0; i < fileList.size(); i++ ) 
+        {
+            if(StringUtil::match(fileList[i], pattern)) 
+            {
+                AAsset* asset = AAssetManager_open(mAssetMgr, (mPathPreFix + fileList[i]).c_str(), AASSET_MODE_UNKNOWN);
+                if(asset) {
+                    FileInfo info;
+                    info.archive = this;
+                    info.filename = fileList[i];
+                    info.path = mName;
+                    info.basename = fileList[i];
+                    info.compressedSize = AAsset_getLength(asset);
+                    info.uncompressedSize = info.compressedSize;
+                    files->push_back(info);
+                    AAsset_close(asset);
+                }
+            }
+        }
+        return files;
+    }
 
-	bool APKFileSystemArchive::exists(const String& filename) const
-	{
-		AAsset* asset = AAssetManager_open(mAssetMgr, (mPathPreFix + filename).c_str(), AASSET_MODE_UNKNOWN);
-		if(asset)
-		{
-			AAsset_close(asset);
-			return true;
-		}
-		return false;
-	}
+    bool APKFileSystemArchive::exists(const String& filename) const
+    {
+        AAsset* asset = AAssetManager_open(mAssetMgr, (mPathPreFix + filename).c_str(), AASSET_MODE_UNKNOWN);
+        if(asset)
+        {
+            AAsset_close(asset);
+            return true;
+        }
+        return false;
+    }
 
-	time_t APKFileSystemArchive::getModifiedTime(const Ogre::String &filename) const
-	{
-		return 0;
-	}
+    time_t APKFileSystemArchive::getModifiedTime(const Ogre::String &filename) const
+    {
+        return 0;
+    }
 
-	//////////////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////////////
 
-	const String &APKFileSystemArchiveFactory::getType() const
-	{
-		static String type = "APKFileSystem";
-		return type;
-	}
+    const String &APKFileSystemArchiveFactory::getType() const
+    {
+        static String type = "APKFileSystem";
+        return type;
+    }
 
     Archive *APKFileSystemArchiveFactory::createInstance( const String& name, bool readOnly )
     {


### PR DESCRIPTION
Clean this kind of warning message in ndk23 

In file included from /home/joilnen/ogre3d_devel/my/ogre3d-13.0.x/Samples/Common/include/SamplePlugin.h:32:
454 In file included from /home/joilnen/ogre3d_devel/my/ogre3d-13.0.x/Samples/Common/include/Sample.h:42:
455 /home/joilnen/ogre3d_devel/my/ogre3d-13.0.x/Components/Bites/include/OgreInput.h:205:25: warning: definition of implicit copy constr    ↳ uctor for 'InputListenerChain' is deprecated because it has a user-declared copy assignment operator [-Wdeprecated-copy]
456     InputListenerChain& operator=(InputListenerChain o)
457                         ^                                                                                                      
458 /home/joilnen/ogre3d_devel/my/ogre3d-13.0.x/Samples/Simple/include/ImGuiDemo.h:59:26: note: in implicit copy constructor for 'OgreBi    ↳ tes::InputListenerChain' first required here
459         mListenerChain = InputListenerChain({mTrayMgr.get(), mImguiListener.get(), mCameraMan.get()});                         
460                          ^
461 [ 91%] Building CXX object Samples/CMakeFiles/DefaultSamples.dir/Compositor/src/HelperLogics.cpp.o  
462 [ 91%] Building CXX object Samples/CMakeFiles/DefaultSamples.dir/DeferredShading/src/AmbientLight.cpp.o