### PR TITLE
fix warning message in android ndk23

### DIFF
--- a/OgreMain/src/Android/OgreAPKFileSystemArchive.cpp
+++ b/OgreMain/src/Android/OgreAPKFileSystemArchive.cpp
@@ -72,14 +72,16 @@ namespace {
 	APKFileSystemArchive::APKFileSystemArchive(const String& name, const String& archType, AAssetManager* assetMgr)
 		:Archive(name, archType), mAssetMgr(assetMgr)
 	{
-        if (mName.size() > 0 && mName[0] == '/')
+        if (mName.size() > 0 && mName[0] == '/') {
         	mName.erase(mName.begin());
+        }
 
         mPathPreFix = mName;
-        if (mPathPreFix.size() > 0)
+        if (mPathPreFix.size() > 0) {
         	mPathPreFix += "/";
+        }
 			
-		if(!IsFolderParsed( mName )) {
+		if (!IsFolderParsed( mName )) {
 			ParseFolder( mAssetMgr, mName );
 		}			
 	}


### PR DESCRIPTION
Clean this kind of warning message in ndk23
[ 40%] Building CXX object OgreMain/CMakeFiles/OgreMain.dir/src/OgreETCCodec.cpp.o
193 [ 40%] Building CXX object OgreMain/CMakeFiles/OgreMain.dir/src/OgreZip.cpp.o
194 [ 40%] Building CXX object OgreMain/CMakeFiles/OgreMain.dir/src/Android/OgreAPKFileSystemArchive.cpp.o
195 /home/joilnen/ogre3d_devel/my/ogre3d-13.0.x/OgreMain/src/Android/OgreAPKFileSystemArchive.cpp:82:3: warning: misleading indentation;    ↳  statement is not part of the previous 'if' [-Wmisleading-indentation]
196                 if(!IsFolderParsed( mName )) {
197                 ^
198 /home/joilnen/ogre3d_devel/my/ogre3d-13.0.x/OgreMain/src/Android/OgreAPKFileSystemArchive.cpp:79:9: note: previous statement is here
199         if (mPathPreFix.size() > 0)
200         ^
201 [ 41%] Building CXX object OgreMain/CMakeFiles/OgreMain.dir/src/Android/OgreAndroidLogListener.cpp.o
202 [ 41%] Building CXX object OgreMain/CMakeFiles/OgreMain.dir/src/Android/OgreFileSystemLayer.cpp.o
203 [ 41%] Building CXX object OgreMain/CMakeFiles/OgreMain.dir/src/OgreSearchOps.cpp.o                                            
204 [ 41%] Building CXX object OgreMain/CMakeFiles/OgreMain.dir/src/Android/OgreAPKZipArchive.cpp.o