### PR TITLE
Use Qt 6 for OgreBitesQt if present

### DIFF
--- a/CMake/Dependencies.cmake
+++ b/CMake/Dependencies.cmake
@@ -285,8 +285,11 @@ if(NOT ANDROID AND NOT EMSCRIPTEN)
     )
   endif()
 
-  find_package(Qt5 COMPONENTS Core Gui QUIET)
-  macro_log_feature(Qt5_FOUND "Qt" "optional integration with the Qt Library for window creation and input" "http://www.qt.io/" FALSE "" "")
+  find_package(QT NAMES Qt6 Qt5 COMPONENTS Core Gui QUIET)
+  find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core Gui QUIET)
+
+  macro_log_feature(Qt5_FOUND "Qt" "optional integration with the Qt5 Library for window creation and input" "http://www.qt.io/" FALSE "" "")
+  macro_log_feature(Qt6_FOUND "Qt" "optional integration with the Qt6 Library for window creation and input" "http://www.qt.io/" FALSE "" "")
 endif()
 
 #######################################################################

--- a/Components/Bites/CMakeLists.txt
+++ b/Components/Bites/CMakeLists.txt
@@ -172,11 +172,16 @@ generate_export_header(OgreBites
     EXPORT_MACRO_NAME _OgreBitesExport
     EXPORT_FILE_NAME ${PROJECT_BINARY_DIR}/include/OgreBitesPrerequisites.h)
 
-if(Qt5_FOUND)
-  qt5_wrap_cpp(MOC_SRC "${CMAKE_CURRENT_SOURCE_DIR}/include/OgreApplicationContextQt.h")
+if(Qt6_FOUND OR Qt5_FOUND)
+  if(Qt6_FOUND)
+    qt6_wrap_cpp(MOC_SRC "${CMAKE_CURRENT_SOURCE_DIR}/include/OgreApplicationContextQt.h")
+  else()
+    qt5_wrap_cpp(MOC_SRC "${CMAKE_CURRENT_SOURCE_DIR}/include/OgreApplicationContextQt.h")
+  endif()
+
   add_library(OgreBitesQt ${OGRE_COMP_LIB_TYPE} ${MOC_SRC} "${CMAKE_CURRENT_SOURCE_DIR}/src/OgreApplicationContextQt.cpp")
   set_target_properties(OgreBitesQt PROPERTIES VERSION ${OGRE_SOVERSION} SOVERSION ${OGRE_SOVERSION})
-  target_link_libraries(OgreBitesQt PUBLIC Qt5::Gui OgreBites)
+  target_link_libraries(OgreBitesQt PUBLIC Qt${QT_VERSION_MAJOR}::Gui OgreBites)
   ogre_config_component(OgreBitesQt)
 endif()
 


### PR DESCRIPTION
Use the cmake commands of
https://doc-snapshots.qt.io/qt6-dev/cmake-qt5-and-qt6-compatibility.html#supporting-older-qt-5-versions
to support both Qt 5 and Qt 6.