### PR TITLE
fix warnings in ndk23 copy constructor issues

### DIFF
--- a/Components/Bites/include/OgreInput.h
+++ b/Components/Bites/include/OgreInput.h
@@ -202,7 +202,7 @@ public:
     InputListenerChain() {}
     InputListenerChain(std::vector<InputListener*> chain) : mListenerChain(chain) {}
 
-    InputListenerChain& operator=(InputListenerChain o)
+    InputListenerChain& operator=(const InputListenerChain& o)
     {
         mListenerChain = o.mListenerChain;
         return *this;


### PR DESCRIPTION
Compiler from ndk23 complaint from this copy constructor, changed to a most common form
---
452 In file included from /home/joilnen/ogre3d_devel/my/ogre3d-13.0.x/Samples/Common/include/DefaultSamplesPlugin.h:31:
453 In file included from /home/joilnen/ogre3d_devel/my/ogre3d-13.0.x/Samples/Common/include/SamplePlugin.h:32:
454 In file included from /home/joilnen/ogre3d_devel/my/ogre3d-13.0.x/Samples/Common/include/Sample.h:42:
455 /home/joilnen/ogre3d_devel/my/ogre3d-13.0.x/Components/Bites/include/OgreInput.h:205:25: warning: definition of implicit     ↳ copy constructor for 'InputListenerChain' is deprecated because it has a user-declared copy assignment operator [-Wdepr    ↳ ecated-copy]
456     InputListenerChain& operator=(InputListenerChain o)
457                         ^                                                                                     
458 /home/joilnen/ogre3d_devel/my/ogre3d-13.0.x/Samples/Simple/include/ImGuiDemo.h:59:26: note: in implicit copy constructor     ↳ for 'OgreBites::InputListenerChain' first required here
459         mListenerChain = InputListenerChain({mTrayMgr.get(), mImguiListener.get(), mCameraMan.get()});
460                          ^
461 [ 91%] Building CXX object Samples/CMakeFiles/DefaultSamples.dir/Compositor/src/HelperLogics.cpp.o              
462 [ 91%] Building CXX object Samples/CMakeFiles/DefaultSamples.dir/DeferredShading/src/AmbientLight.cpp.o
463 [ 91%] Building CXX object Samples/CMakeFiles/DefaultSamples.dir/DeferredShading/src/DLight.cpp.o
464 [ 91%] Building CXX object Samples/CMakeFiles/DefaultSamples.dir/DeferredShading/src/DeferredLightCP.cpp.o