### PR TITLE
Use safe idiom for math constants.

### DIFF
--- a/OgreMain/include/OgreMath.h
+++ b/OgreMain/include/OgreMath.h
@@ -358,7 +358,7 @@ namespace Ogre
         static inline Real Log (Real fValue) { return std::log(fValue); }
 
         /// Stored value of log(2) for frequent use
-        static const Real LOG2;
+        static constexpr Real LOG2 = 0.69314718055994530942;
 
         static inline Real Log2 (Real fValue) { return std::log(fValue)/LOG2; }
 
@@ -738,13 +738,13 @@ namespace Ogre
         static Real boundingRadiusFromAABBCentered(const AxisAlignedBox &aabb);
 
 
-        static const Real POS_INFINITY;
-        static const Real NEG_INFINITY;
-        static const Real PI;
-        static const Real TWO_PI;
-        static const Real HALF_PI;
-        static const float fDeg2Rad;
-        static const float fRad2Deg;
+        static constexpr Real POS_INFINITY = std::numeric_limits<Real>::infinity();
+        static constexpr Real NEG_INFINITY = -std::numeric_limits<Real>::infinity();
+        static constexpr Real PI = 3.14159265358979323846;
+        static constexpr Real TWO_PI = Real( 2.0 * PI );
+        static constexpr Real HALF_PI = Real( 0.5 * PI );
+        static constexpr float fDeg2Rad = PI / Real(180.0);
+        static constexpr float fRad2Deg = Real(180.0) / PI;
 
     };
 

--- a/OgreMain/src/OgreMath.cpp
+++ b/OgreMain/src/OgreMath.cpp
@@ -30,14 +30,14 @@ THE SOFTWARE.
 namespace Ogre
 {
 
-    const Real Math::POS_INFINITY = std::numeric_limits<Real>::infinity();
-    const Real Math::NEG_INFINITY = -std::numeric_limits<Real>::infinity();
-    const Real Math::PI = Real( 4.0 * atan( 1.0 ) );
-    const Real Math::TWO_PI = Real( 2.0 * PI );
-    const Real Math::HALF_PI = Real( 0.5 * PI );
-    const float Math::fDeg2Rad = PI / float(180.0);
-    const float Math::fRad2Deg = float(180.0) / PI;
-    const Real Math::LOG2 = std::log(Real(2.0));
+    constexpr Real Math::POS_INFINITY;
+    constexpr Real Math::NEG_INFINITY;
+    constexpr Real Math::PI;
+    constexpr Real Math::TWO_PI;
+    constexpr Real Math::HALF_PI;
+    constexpr float Math::fDeg2Rad;
+    constexpr float Math::fRad2Deg;
+    constexpr Real Math::LOG2;
 
     int Math::mTrigTableSize;
    Math::AngleUnit Math::msAngleUnit;


### PR DESCRIPTION
Constexpr is used to ensure that the constants are initialized in the "constant initialization" phase.

Reference:
- https://abseil.io/tips/140
- https://en.cppreference.com/w/cpp/language/initialization