### PR TITLE
GLSLang: SPIRV-Tools dependancy is superfluous

### DIFF
--- a/CMake/Dependencies.cmake
+++ b/CMake/Dependencies.cmake
@@ -226,12 +226,8 @@ if (NOT (APPLE_IOS OR WINDOWS_STORE OR WINDOWS_PHONE OR ANDROID OR EMSCRIPTEN))
   macro_log_feature(Cg_FOUND "cg" "C for graphics shader language" "http://developer.nvidia.com/object/cg_toolkit.html" FALSE "" "")
 endif ()
 
-# Find glslang
-find_package(SPIRV-Tools QUIET) # glslangs own cmake is broken
-if(DEFINED ENV{VULKAN_SDK})
-    set(SPIRV-Tools_FOUND TRUE)
-endif()
-macro_log_feature(SPIRV-Tools_FOUND "glslang" "GLSL to SPIRV reference compiler" "https://github.com/KhronosGroup/glslang" FALSE "" "")
+# Find Vulkan SDK
+macro_log_feature(ENV{VULKAN_SDK} "Vulkan SDK" "Vulkan RenderSystem, glslang Plugin. Alternatively use system packages" "https://vulkan.lunarg.com/" FALSE "" "")
 
 # OpenEXR
 find_package(OpenEXR)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -331,7 +331,7 @@ cmake_dependent_option(OGRE_BUILD_COMPONENT_TERRAIN "Build Terrain component" TR
 cmake_dependent_option(OGRE_BUILD_COMPONENT_VOLUME "Build Volume component" TRUE "" FALSE)
 cmake_dependent_option(OGRE_BUILD_COMPONENT_PROPERTY "Build Property component" TRUE "" FALSE)
 cmake_dependent_option(OGRE_BUILD_PLUGIN_CG "Build Cg plugin" TRUE "Cg_FOUND;NOT APPLE_IOS;NOT WINDOWS_STORE;NOT WINDOWS_PHONE" FALSE)
-cmake_dependent_option(OGRE_BUILD_PLUGIN_GLSLANG "Build glslang plugin" TRUE "SPIRV-Tools_FOUND OR OGRE_BUILD_RENDERSYSTEM_VULKAN" FALSE) # no way to determine whether glslang is present
+option(OGRE_BUILD_PLUGIN_GLSLANG "Build glslang plugin" ${OGRE_BUILD_RENDERSYSTEM_VULKAN}) # no way to determine whether glslang is present
 option(OGRE_BUILD_COMPONENT_OVERLAY "Build Overlay component" TRUE)
 
 cmake_dependent_option(OGRE_BUILD_COMPONENT_OVERLAY_IMGUI "Include dear imgui in Overlays" TRUE "OGRE_BUILD_COMPONENT_OVERLAY" FALSE)

--- a/PlugIns/GLSLang/CMakeLists.txt
+++ b/PlugIns/GLSLang/CMakeLists.txt
@@ -17,7 +17,7 @@ elseif(WIN32)
     target_link_directories(Plugin_GLSLangProgramManager PRIVATE $ENV{VULKAN_SDK}/lib)
     target_link_libraries(Plugin_GLSLangProgramManager PUBLIC OgreMain shaderc_combined)
 else()
-    target_link_libraries(Plugin_GLSLangProgramManager PUBLIC OgreMain glslang HLSL OSDependent OGLCompiler SPIRV SPIRV-Tools)
+    target_link_libraries(Plugin_GLSLangProgramManager PUBLIC OgreMain glslang HLSL OSDependent OGLCompiler SPIRV)
 endif()
 
 ogre_config_framework(Plugin_GLSLangProgramManager)


### PR DESCRIPTION
give up on detecting Vulkan besides Vulkan SDK.
The CMake state of this is a mess.