### PR TITLE
Fix FTBFS on GCC 11

### DIFF
--- a/OgreMain/include/OgreGpuProgramParams.h
+++ b/OgreMain/include/OgreGpuProgramParams.h
@@ -28,6 +28,8 @@ Copyright (c) 2000-2014 Torus Knot Software Ltd
 #ifndef __GpuProgramParams_H_
 #define __GpuProgramParams_H_
 
+#include <limits>
+
 // Precompiler options
 #include "OgrePrerequisites.h"
 #include "OgreSharedPtr.h"


### PR DESCRIPTION
<details>
<summary>Full build output</summary>

```
[ 35%] Building CXX object RenderSystems/GLSupport/CMakeFiles/OgreGLSupport.dir/src/GLSL/OgreGLSLProgramManagerCommon.cpp.o
In file included from /tmp/git/ogre/RenderSystems/GLSupport/include/GLSL/OgreGLSLProgramManagerCommon.h:33,
                 from /tmp/git/ogre/RenderSystems/GLSupport/src/GLSL/OgreGLSLProgramManagerCommon.cpp:29:
/tmp/git/ogre/OgreMain/include/OgreGpuProgramParams.h: In constructor 'Ogre::GpuConstantDefinition::GpuConstantDefinition()':
/tmp/git/ogre/OgreMain/include/OgreGpuProgramParams.h:298:31: error: 'numeric_limits' is not a member of 'std'
  298 |         : physicalIndex((std::numeric_limits<size_t>::max)())
      |                               ^~~~~~~~~~~~~~
/tmp/git/ogre/OgreMain/include/OgreGpuProgramParams.h:298:52: error: expected primary-expression before '>' token
  298 |         : physicalIndex((std::numeric_limits<size_t>::max)())
      |                                                    ^
/tmp/git/ogre/OgreMain/include/OgreGpuProgramParams.h:298:55: error: '::max' has not been declared; did you mean 'std::max'?
  298 |         : physicalIndex((std::numeric_limits<size_t>::max)())
      |                                                       ^~~
      |                                                       std::max
In file included from /usr/include/c++/11.2.0/algorithm:62,
                 from /tmp/git/ogre/OgreMain/include/OgreStdHeaders.h:21,
                 from /tmp/git/ogre/OgreMain/include/OgrePrerequisites.h:307,
                 from /tmp/git/ogre/OgreMain/include/OgreString.h:31,
                 from /tmp/git/ogre/RenderSystems/GLSupport/include/GLSL/OgreGLSLProgramManagerCommon.h:32,
                 from /tmp/git/ogre/RenderSystems/GLSupport/src/GLSL/OgreGLSLProgramManagerCommon.cpp:29:
/usr/include/c++/11.2.0/bits/stl_algo.h:3467:5: note: 'std::max' declared here
 3467 |     max(initializer_list<_Tp> __l, _Compare __comp)
      |     ^~~
In file included from /tmp/git/ogre/RenderSystems/GLSupport/include/GLSL/OgreGLSLProgramManagerCommon.h:33,
                 from /tmp/git/ogre/RenderSystems/GLSupport/src/GLSL/OgreGLSLProgramManagerCommon.cpp:29:
/tmp/git/ogre/OgreMain/include/OgreGpuProgramParams.h: In member function 'bool Ogre::GpuProgramParameters::hasPassIterationNumber() const':
/tmp/git/ogre/OgreMain/include/OgreGpuProgramParams.h:1795:53: error: 'numeric_limits' is not a member of 'std'
 1795 |         { return mActivePassIterationIndex != (std::numeric_limits<size_t>::max)(); }
      |                                                     ^~~~~~~~~~~~~~
/tmp/git/ogre/OgreMain/include/OgreGpuProgramParams.h:1795:74: error: expected primary-expression before '>' token
 1795 |         { return mActivePassIterationIndex != (std::numeric_limits<size_t>::max)(); }
      |                                                                          ^
/tmp/git/ogre/OgreMain/include/OgreGpuProgramParams.h:1795:77: error: '::max' has not been declared; did you mean 'std::max'?
 1795 |         { return mActivePassIterationIndex != (std::numeric_limits<size_t>::max)(); }
      |                                                                             ^~~
      |                                                                             std::max
In file included from /usr/include/c++/11.2.0/algorithm:62,
                 from /tmp/git/ogre/OgreMain/include/OgreStdHeaders.h:21,
                 from /tmp/git/ogre/OgreMain/include/OgrePrerequisites.h:307,
                 from /tmp/git/ogre/OgreMain/include/OgreString.h:31,
                 from /tmp/git/ogre/RenderSystems/GLSupport/include/GLSL/OgreGLSLProgramManagerCommon.h:32,
                 from /tmp/git/ogre/RenderSystems/GLSupport/src/GLSL/OgreGLSLProgramManagerCommon.cpp:29:
/usr/include/c++/11.2.0/bits/stl_algo.h:3467:5: note: 'std::max' declared here
 3467 |     max(initializer_list<_Tp> __l, _Compare __comp)
      |     ^~~
make[2]: *** [RenderSystems/GLSupport/CMakeFiles/OgreGLSupport.dir/build.make:188: RenderSystems/GLSupport/CMakeFiles/OgreGLSupport.dir/src/GLSL/OgreGLSLProgramManagerCommon.cpp.o] Error 1
make[2]: Leaving directory '/usr/src/git/ogre/_build'
make[1]: *** [CMakeFiles/Makefile2:690: RenderSystems/GLSupport/CMakeFiles/OgreGLSupport.dir/all] Error 2
make[1]: Leaving directory '/usr/src/git/ogre/_build'
make: *** [Makefile:156: all] Error 2
make: Leaving directory '/usr/src/git/ogre/_build'
```

</details>