### PR TITLE
Main: RenderSystemCapabilities - deprecate int&bool programConstantCount

### DIFF
--- a/OgreMain/include/OgreRenderSystemCapabilities.h
+++ b/OgreMain/include/OgreRenderSystemCapabilities.h
@@ -278,24 +278,12 @@ namespace Ogre
         /// The identifier associated with the render system for which these capabilities are valid
         String mRenderSystemName;
 
-        /// The number of floating-point constants vertex programs support
-        ushort mVertexProgramConstantFloatCount;           
-        /// The number of integer constants vertex programs support
-        ushort mVertexProgramConstantIntCount;           
-        /// The number of boolean constants vertex programs support
-        ushort mVertexProgramConstantBoolCount;           
-        /// The number of floating-point constants geometry programs support
-        ushort mGeometryProgramConstantFloatCount;           
-        /// The number of integer constants vertex geometry support
-        ushort mGeometryProgramConstantIntCount;           
-        /// The number of boolean constants vertex geometry support
-        ushort mGeometryProgramConstantBoolCount;           
-        /// The number of floating-point constants fragment programs support
-        ushort mFragmentProgramConstantFloatCount;           
-        /// The number of integer constants fragment programs support
-        ushort mFragmentProgramConstantIntCount;           
-        /// The number of boolean constants fragment programs support
-        ushort mFragmentProgramConstantBoolCount;
+        /// The number of floating-point 4-vector constants vertex programs support
+        ushort mVertexProgramConstantFloatCount;
+        /// The number of floating-point 4-vector constants geometry programs support
+        ushort mGeometryProgramConstantFloatCount;
+        /// The number of floating-point 4-vector constants fragment programs support
+        ushort mFragmentProgramConstantFloatCount;
         /// The number of simultaneous render targets supported
         ushort mNumMultiRenderTargets;
         /// The maximum point size
@@ -315,25 +303,12 @@ namespace Ogre
         /// The list of supported shader profiles
         ShaderProfiles mSupportedShaderProfiles;
 
-        // Support for new shader stages in shader model 5.0
-        /// The number of floating-point constants tessellation Hull programs support
-        ushort mTessellationHullProgramConstantFloatCount;           
-        /// The number of integer constants tessellation Hull programs support
-        ushort mTessellationHullProgramConstantIntCount;           
-        /// The number of boolean constants tessellation Hull programs support
-        ushort mTessellationHullProgramConstantBoolCount;
-        /// The number of floating-point constants tessellation Domain programs support
-        ushort mTessellationDomainProgramConstantFloatCount;           
-        /// The number of integer constants tessellation Domain programs support
-        ushort mTessellationDomainProgramConstantIntCount;           
-        /// The number of boolean constants tessellation Domain programs support
-        ushort mTessellationDomainProgramConstantBoolCount;
-        /// The number of floating-point constants compute programs support
-        ushort mComputeProgramConstantFloatCount;           
-        /// The number of integer constants compute programs support
-        ushort mComputeProgramConstantIntCount;           
-        /// The number of boolean constants compute programs support
-        ushort mComputeProgramConstantBoolCount;
+        /// The number of floating-point 4-vector constants tessellation Hull programs support
+        ushort mTessellationHullProgramConstantFloatCount;
+        /// The number of floating-point 4-vector constants tessellation Domain programs support
+        ushort mTessellationDomainProgramConstantFloatCount;
+        /// The number of floating-point 4-vector constants compute programs support
+        ushort mComputeProgramConstantFloatCount;
 
         /// The number of vertex attributes available
         ushort mNumVertexAttributes;
@@ -523,50 +498,20 @@ namespace Ogre
         }
 
 
-        /// The number of floating-point constants vertex programs support
+        /// The number of floating-point 4-vector constants vertex programs support
         ushort getVertexProgramConstantFloatCount(void) const
         {
-            return mVertexProgramConstantFloatCount;           
+            return mVertexProgramConstantFloatCount;
         }
-        /// The number of integer constants vertex programs support
-        ushort getVertexProgramConstantIntCount(void) const
-        {
-            return mVertexProgramConstantIntCount;           
-        }
-        /// The number of boolean constants vertex programs support
-        ushort getVertexProgramConstantBoolCount(void) const
-        {
-            return mVertexProgramConstantBoolCount;           
-        }
-        /// The number of floating-point constants geometry programs support
+        /// The number of floating-point 4-vector constants geometry programs support
         ushort getGeometryProgramConstantFloatCount(void) const
         {
-            return mGeometryProgramConstantFloatCount;           
+            return mGeometryProgramConstantFloatCount;
         }
-        /// The number of integer constants geometry programs support
-        ushort getGeometryProgramConstantIntCount(void) const
-        {
-            return mGeometryProgramConstantIntCount;           
-        }
-        /// The number of boolean constants geometry programs support
-        ushort getGeometryProgramConstantBoolCount(void) const
-        {
-            return mGeometryProgramConstantBoolCount;           
-        }
-        /// The number of floating-point constants fragment programs support
+        /// The number of floating-point 4-vector constants fragment programs support
         ushort getFragmentProgramConstantFloatCount(void) const
         {
-            return mFragmentProgramConstantFloatCount;           
-        }
-        /// The number of integer constants fragment programs support
-        ushort getFragmentProgramConstantIntCount(void) const
-        {
-            return mFragmentProgramConstantIntCount;           
-        }
-        /// The number of boolean constants fragment programs support
-        ushort getFragmentProgramConstantBoolCount(void) const
-        {
-            return mFragmentProgramConstantBoolCount;           
+            return mFragmentProgramConstantFloatCount;
         }
 
         /// sets the device name for Render system
@@ -581,51 +526,22 @@ namespace Ogre
             return mDeviceName;
         }
 
-        /// The number of floating-point constants vertex programs support
+        /// The number of floating-point 4-vector constants vertex programs support
         void setVertexProgramConstantFloatCount(ushort c)
         {
-            mVertexProgramConstantFloatCount = c;           
+            mVertexProgramConstantFloatCount = c;
         }
-        /// The number of integer constants vertex programs support
-        void setVertexProgramConstantIntCount(ushort c)
-        {
-            mVertexProgramConstantIntCount = c;           
-        }
-        /// The number of boolean constants vertex programs support
-        void setVertexProgramConstantBoolCount(ushort c)
-        {
-            mVertexProgramConstantBoolCount = c;           
-        }
-        /// The number of floating-point constants geometry programs support
+        /// The number of floating-point 4-vector constants geometry programs support
         void setGeometryProgramConstantFloatCount(ushort c)
         {
-            mGeometryProgramConstantFloatCount = c;           
+            mGeometryProgramConstantFloatCount = c;
         }
-        /// The number of integer constants geometry programs support
-        void setGeometryProgramConstantIntCount(ushort c)
-        {
-            mGeometryProgramConstantIntCount = c;           
-        }
-        /// The number of boolean constants geometry programs support
-        void setGeometryProgramConstantBoolCount(ushort c)
-        {
-            mGeometryProgramConstantBoolCount = c;           
-        }
-        /// The number of floating-point constants fragment programs support
+        /// The number of floating-point 4-vector constants fragment programs support
         void setFragmentProgramConstantFloatCount(ushort c)
         {
-            mFragmentProgramConstantFloatCount = c;           
+            mFragmentProgramConstantFloatCount = c;
         }
-        /// The number of integer constants fragment programs support
-        void setFragmentProgramConstantIntCount(ushort c)
-        {
-            mFragmentProgramConstantIntCount = c;           
-        }
-        /// The number of boolean constants fragment programs support
-        void setFragmentProgramConstantBoolCount(ushort c)
-        {
-            mFragmentProgramConstantBoolCount = c;           
-        }
+
         /// Maximum point screen size in pixels
         void setMaxPointSize(Real s)
         {
@@ -725,98 +641,157 @@ namespace Ogre
         /** Write the capabilities to the pass in Log */
         void log(Log* pLog) const;
 
-        // Support for new shader stages in shader model 5.0
-        /// The number of floating-point constants tessellation Hull programs support
-        void setTessellationHullProgramConstantFloatCount(ushort c)
-        {
-            mTessellationHullProgramConstantFloatCount = c;           
-        }
-        /// The number of integer constants tessellation Domain programs support
-        void setTessellationHullProgramConstantIntCount(ushort c)
-        {
-            mTessellationHullProgramConstantIntCount = c;           
-        }
-        /// The number of boolean constants tessellation Domain programs support
-        void setTessellationHullProgramConstantBoolCount(ushort c)
-        {
-            mTessellationHullProgramConstantBoolCount = c;           
-        }
-        /// The number of floating-point constants fragment programs support
-        ushort getTessellationHullProgramConstantFloatCount(void) const
-        {
-            return mTessellationHullProgramConstantFloatCount;           
-        }
-        /// The number of integer constants fragment programs support
-        ushort getTessellationHullProgramConstantIntCount(void) const
-        {
-            return mTessellationHullProgramConstantIntCount;           
-        }
-        /// The number of boolean constants fragment programs support
-        ushort getTessellationHullProgramConstantBoolCount(void) const
-        {
-            return mTessellationHullProgramConstantBoolCount;           
-        }
-
-        /// The number of floating-point constants tessellation Domain programs support
-        void setTessellationDomainProgramConstantFloatCount(ushort c)
-        {
-            mTessellationDomainProgramConstantFloatCount = c;           
-        }
-        /// The number of integer constants tessellation Domain programs support
-        void setTessellationDomainProgramConstantIntCount(ushort c)
-        {
-            mTessellationDomainProgramConstantIntCount = c;           
-        }
-        /// The number of boolean constants tessellation Domain programs support
-        void setTessellationDomainProgramConstantBoolCount(ushort c)
-        {
-            mTessellationDomainProgramConstantBoolCount = c;           
-        }
-        /// The number of floating-point constants fragment programs support
-        ushort getTessellationDomainProgramConstantFloatCount(void) const
-        {
-            return mTessellationDomainProgramConstantFloatCount;           
-        }
-        /// The number of integer constants fragment programs support
-        ushort getTessellationDomainProgramConstantIntCount(void) const
-        {
-            return mTessellationDomainProgramConstantIntCount;           
-        }
-        /// The number of boolean constants fragment programs support
-        ushort getTessellationDomainProgramConstantBoolCount(void) const
-        {
-            return mTessellationDomainProgramConstantBoolCount;           
-        }
-
-        /// The number of floating-point constants compute programs support
+        /// The number of floating-point 4-vector constants compute programs support
         void setComputeProgramConstantFloatCount(ushort c)
         {
-            mComputeProgramConstantFloatCount = c;           
+            mComputeProgramConstantFloatCount = c;
         }
-        /// The number of integer constants compute programs support
-        void setComputeProgramConstantIntCount(ushort c)
-        {
-            mComputeProgramConstantIntCount = c;           
-        }
-        /// The number of boolean constants compute programs support
-        void setComputeProgramConstantBoolCount(ushort c)
-        {
-            mComputeProgramConstantBoolCount = c;           
-        }
-        /// The number of floating-point constants fragment programs support
+        /// The number of floating-point 4-vector constants fragment programs support
         ushort getComputeProgramConstantFloatCount(void) const
         {
-            return mComputeProgramConstantFloatCount;           
+            return mComputeProgramConstantFloatCount;
         }
-        /// The number of integer constants fragment programs support
-        ushort getComputeProgramConstantIntCount(void) const
+        /// The number of floating-point 4-vector constants fragment programs support
+        ushort getTessellationDomainProgramConstantFloatCount(void) const
         {
-            return mComputeProgramConstantIntCount;           
+            return mTessellationDomainProgramConstantFloatCount;
         }
-        /// The number of boolean constants fragment programs support
-        ushort getComputeProgramConstantBoolCount(void) const
+        /// The number of floating-point 4-vector constants tessellation Domain programs support
+        void setTessellationDomainProgramConstantFloatCount(ushort c)
         {
-            return mComputeProgramConstantBoolCount;           
+            mTessellationDomainProgramConstantFloatCount = c;
+        }
+        /// The number of floating-point 4-vector constants fragment programs support
+        ushort getTessellationHullProgramConstantFloatCount(void) const
+        {
+            return mTessellationHullProgramConstantFloatCount;
+        }
+        /// The number of floating-point 4-vector constants tessellation Hull programs support
+        void setTessellationHullProgramConstantFloatCount(ushort c)
+        {
+            mTessellationHullProgramConstantFloatCount = c;
+        }
+
+
+        /// @deprecated use getVertexProgramConstantFloatCount instead
+        OGRE_DEPRECATED ushort getVertexProgramConstantIntCount(void) const
+        {
+            return mVertexProgramConstantFloatCount;
+        }
+        /// @deprecated use getVertexProgramConstantFloatCount instead
+        OGRE_DEPRECATED ushort getVertexProgramConstantBoolCount(void) const
+        {
+            return mVertexProgramConstantFloatCount;
+        }
+        /// @deprecated use getGeometryProgramConstantFloatCount instead
+        OGRE_DEPRECATED ushort getGeometryProgramConstantIntCount(void) const
+        {
+            return mGeometryProgramConstantFloatCount;
+        }
+        /// @deprecated use getGeometryProgramConstantFloatCount instead
+        OGRE_DEPRECATED ushort getGeometryProgramConstantBoolCount(void) const
+        {
+            return mGeometryProgramConstantFloatCount;
+        }
+        /// @deprecated use getFragmentProgramConstantFloatCount instead
+        OGRE_DEPRECATED ushort getFragmentProgramConstantIntCount(void) const
+        {
+            return mFragmentProgramConstantFloatCount;
+        }
+        /// @deprecated use getFragmentProgramConstantFloatCount instead
+        OGRE_DEPRECATED ushort getFragmentProgramConstantBoolCount(void) const
+        {
+            return mFragmentProgramConstantFloatCount;
+        }
+        /// @deprecated use setVertexProgramConstantFloatCount instead
+        OGRE_DEPRECATED void setVertexProgramConstantIntCount(ushort c)
+        {
+            mVertexProgramConstantFloatCount = c;
+        }
+        /// @deprecated use setVertexProgramConstantFloatCount instead
+        OGRE_DEPRECATED void setVertexProgramConstantBoolCount(ushort c)
+        {
+            mVertexProgramConstantFloatCount = c;
+        }
+        /// @deprecated use setGeometryProgramConstantFloatCount instead
+        OGRE_DEPRECATED void setGeometryProgramConstantIntCount(ushort c)
+        {
+            mGeometryProgramConstantFloatCount = c;
+        }
+        /// @deprecated use setGeometryProgramConstantFloatCount instead
+        OGRE_DEPRECATED void setGeometryProgramConstantBoolCount(ushort c)
+        {
+            mGeometryProgramConstantFloatCount = c;
+        }
+        /// @deprecated use setFragmentProgramConstantFloatCount instead
+        OGRE_DEPRECATED void setFragmentProgramConstantIntCount(ushort c)
+        {
+            mFragmentProgramConstantFloatCount = c;
+        }
+        /// @deprecated use setFragmentProgramConstantFloatCount instead
+        OGRE_DEPRECATED void setFragmentProgramConstantBoolCount(ushort c)
+        {
+            mFragmentProgramConstantFloatCount = c;
+        }
+        /// @deprecated use setTessellationHullProgramConstantFloatCount instead
+        OGRE_DEPRECATED void setTessellationHullProgramConstantIntCount(ushort c)
+        {
+            mTessellationHullProgramConstantFloatCount = c;
+        }
+        /// @deprecated use setTessellationHullProgramConstantFloatCount instead
+        OGRE_DEPRECATED void setTessellationHullProgramConstantBoolCount(ushort c)
+        {
+            mTessellationHullProgramConstantFloatCount = c;
+        }
+        /// @deprecated use getTessellationHullProgramConstantFloatCount instead
+        OGRE_DEPRECATED ushort getTessellationHullProgramConstantIntCount(void) const
+        {
+            return mTessellationHullProgramConstantFloatCount;
+        }
+        /// @deprecated use getTessellationHullProgramConstantFloatCount instead
+        OGRE_DEPRECATED ushort getTessellationHullProgramConstantBoolCount(void) const
+        {
+            return mTessellationHullProgramConstantFloatCount;
+        }
+        /// @deprecated use setTessellationDomainProgramConstantFloatCount instead
+        OGRE_DEPRECATED void setTessellationDomainProgramConstantIntCount(ushort c)
+        {
+            mTessellationDomainProgramConstantFloatCount = c;
+        }
+        /// @deprecated use setTessellationDomainProgramConstantFloatCount instead
+        OGRE_DEPRECATED void setTessellationDomainProgramConstantBoolCount(ushort c)
+        {
+            mTessellationDomainProgramConstantFloatCount = c;
+        }
+        /// @deprecated use getTessellationDomainProgramConstantFloatCount instead
+        OGRE_DEPRECATED ushort getTessellationDomainProgramConstantIntCount(void) const
+        {
+            return mTessellationDomainProgramConstantFloatCount;
+        }
+        /// @deprecated use getTessellationDomainProgramConstantFloatCount instead
+        OGRE_DEPRECATED ushort getTessellationDomainProgramConstantBoolCount(void) const
+        {
+            return mTessellationDomainProgramConstantFloatCount;
+        }
+        /// @deprecated use setComputeProgramConstantFloatCount instead
+        OGRE_DEPRECATED void setComputeProgramConstantIntCount(ushort c)
+        {
+            mComputeProgramConstantFloatCount = c;
+        }
+        /// @deprecated use setComputeProgramConstantFloatCount instead
+        OGRE_DEPRECATED void setComputeProgramConstantBoolCount(ushort c)
+        {
+            mComputeProgramConstantFloatCount = c;
+        }
+        /// @deprecated use getComputeProgramConstantFloatCount instead
+        OGRE_DEPRECATED ushort getComputeProgramConstantIntCount(void) const
+        {
+            return mComputeProgramConstantFloatCount;
+        }
+        /// @deprecated use getComputeProgramConstantFloatCount instead
+        OGRE_DEPRECATED ushort getComputeProgramConstantBoolCount(void) const
+        {
+            return mComputeProgramConstantFloatCount;
         }
 
     };

--- a/OgreMain/src/OgreRenderSystemCapabilities.cpp
+++ b/OgreMain/src/OgreRenderSystemCapabilities.cpp
@@ -111,61 +111,37 @@ namespace Ogre {
                              StringConverter::toString(hasCapability(RSC_STENCIL_WRAP), true));
         }
         pLog->logMessage(" * Vertex programs: yes");
-        pLog->logMessage("   - Number of floating-point constants: " +
+        pLog->logMessage("   - Number of constant 4-vectors: " +
                          StringConverter::toString(mVertexProgramConstantFloatCount));
-        pLog->logMessage("   - Number of integer constants: " +
-                         StringConverter::toString(mVertexProgramConstantIntCount));
-        pLog->logMessage("   - Number of boolean constants: " +
-                         StringConverter::toString(mVertexProgramConstantBoolCount));
         pLog->logMessage(" * Fragment programs: yes");
-        pLog->logMessage("   - Number of floating-point constants: " +
+        pLog->logMessage("   - Number of constant 4-vectors: " +
                          StringConverter::toString(mFragmentProgramConstantFloatCount));
-        pLog->logMessage("   - Number of integer constants: " +
-                         StringConverter::toString(mFragmentProgramConstantIntCount));
-        pLog->logMessage("   - Number of boolean constants: " +
-                         StringConverter::toString(mFragmentProgramConstantBoolCount));
         pLog->logMessage(" * Geometry programs: " +
                          StringConverter::toString(hasCapability(RSC_GEOMETRY_PROGRAM), true));
         if (hasCapability(RSC_GEOMETRY_PROGRAM))
         {
-            pLog->logMessage("   - Number of floating-point constants: " +
+            pLog->logMessage("   - Number of constant 4-vectors: " +
                              StringConverter::toString(mGeometryProgramConstantFloatCount));
-            pLog->logMessage("   - Number of integer constants: " +
-                             StringConverter::toString(mGeometryProgramConstantIntCount));
-            pLog->logMessage("   - Number of boolean constants: " +
-                             StringConverter::toString(mGeometryProgramConstantBoolCount));
         }
         pLog->logMessage(" * Tessellation Hull programs: " +
                          StringConverter::toString(hasCapability(RSC_TESSELLATION_HULL_PROGRAM), true));
         if (hasCapability(RSC_TESSELLATION_HULL_PROGRAM))
         {
-            pLog->logMessage("   - Number of floating-point constants: " +
+            pLog->logMessage("   - Number of constant 4-vectors: " +
                              StringConverter::toString(mTessellationHullProgramConstantFloatCount));
-            pLog->logMessage("   - Number of integer constants: " +
-                             StringConverter::toString(mTessellationHullProgramConstantIntCount));
-            pLog->logMessage("   - Number of boolean constants: " +
-                             StringConverter::toString(mTessellationHullProgramConstantBoolCount));
         }
         pLog->logMessage(" * Tessellation Domain programs: " +
                          StringConverter::toString(hasCapability(RSC_TESSELLATION_DOMAIN_PROGRAM), true));
         if (hasCapability(RSC_TESSELLATION_DOMAIN_PROGRAM))
         {
-            pLog->logMessage("   - Number of floating-point constants: " +
+            pLog->logMessage("   - Number of constant 4-vectors: " +
                              StringConverter::toString(mTessellationDomainProgramConstantFloatCount));
-            pLog->logMessage("   - Number of integer constants: " +
-                             StringConverter::toString(mTessellationDomainProgramConstantIntCount));
-            pLog->logMessage("   - Number of boolean constants: " +
-                             StringConverter::toString(mTessellationDomainProgramConstantBoolCount));
         }
         pLog->logMessage(" * Compute programs: " + StringConverter::toString(hasCapability(RSC_COMPUTE_PROGRAM), true));
         if (hasCapability(RSC_COMPUTE_PROGRAM))
         {
-            pLog->logMessage("   - Number of floating-point constants: " +
+            pLog->logMessage("   - Number of constant 4-vectors: " +
                              StringConverter::toString(mComputeProgramConstantFloatCount));
-            pLog->logMessage("   - Number of integer constants: " +
-                             StringConverter::toString(mComputeProgramConstantIntCount));
-            pLog->logMessage("   - Number of boolean constants: " +
-                             StringConverter::toString(mComputeProgramConstantBoolCount));
         }
         pLog->logMessage(
             " * Supported Shader Profiles: " +

--- a/OgreMain/src/OgreRenderSystemCapabilitiesSerializer.cpp
+++ b/OgreMain/src/OgreRenderSystemCapabilitiesSerializer.cpp
@@ -86,23 +86,11 @@ namespace Ogre
         file << "\t" << "stencil_buffer_bit_depth " << StringConverter::toString(caps->getStencilBufferBitDepth()) << endl;
         file << "\t" << "num_multi_render_targets " << StringConverter::toString(caps->getNumMultiRenderTargets()) << endl;
         file << "\t" << "vertex_program_constant_float_count " << StringConverter::toString(caps->getVertexProgramConstantFloatCount()) << endl;
-        file << "\t" << "vertex_program_constant_int_count " << StringConverter::toString(caps->getVertexProgramConstantIntCount()) << endl;
-        file << "\t" << "vertex_program_constant_bool_count " << StringConverter::toString(caps->getVertexProgramConstantBoolCount()) << endl;
         file << "\t" << "fragment_program_constant_float_count " << StringConverter::toString(caps->getFragmentProgramConstantFloatCount()) << endl;
-        file << "\t" << "fragment_program_constant_int_count " << StringConverter::toString(caps->getFragmentProgramConstantIntCount()) << endl;
-        file << "\t" << "fragment_program_constant_bool_count " << StringConverter::toString(caps->getFragmentProgramConstantBoolCount()) << endl;
         file << "\t" << "geometry_program_constant_float_count " << StringConverter::toString(caps->getGeometryProgramConstantFloatCount()) << endl;
-        file << "\t" << "geometry_program_constant_int_count " << StringConverter::toString(caps->getGeometryProgramConstantIntCount()) << endl;
-        file << "\t" << "geometry_program_constant_bool_count " << StringConverter::toString(caps->getGeometryProgramConstantBoolCount()) << endl;
         file << "\t" << "tessellation_hull_program_constant_float_count " << StringConverter::toString(caps->getTessellationHullProgramConstantFloatCount()) << endl;
-        file << "\t" << "tessellation_hull_program_constant_int_count " << StringConverter::toString(caps->getTessellationHullProgramConstantIntCount()) << endl;
-        file << "\t" << "tessellation_hull_program_constant_bool_count " << StringConverter::toString(caps->getTessellationHullProgramConstantBoolCount()) << endl;
         file << "\t" << "tessellation_domain_program_constant_float_count " << StringConverter::toString(caps->getTessellationDomainProgramConstantFloatCount()) << endl;
-        file << "\t" << "tessellation_domain_program_constant_int_count " << StringConverter::toString(caps->getTessellationDomainProgramConstantIntCount()) << endl;
-        file << "\t" << "tessellation_domain_program_constant_bool_count " << StringConverter::toString(caps->getTessellationDomainProgramConstantBoolCount()) << endl;
         file << "\t" << "compute_program_constant_float_count " << StringConverter::toString(caps->getComputeProgramConstantFloatCount()) << endl;
-        file << "\t" << "compute_program_constant_int_count " << StringConverter::toString(caps->getComputeProgramConstantIntCount()) << endl;
-        file << "\t" << "compute_program_constant_bool_count " << StringConverter::toString(caps->getComputeProgramConstantBoolCount()) << endl;
         file << "\t" << "num_vertex_texture_units " << StringConverter::toString(caps->getNumVertexTextureUnits()) << endl;
         file << "\t" << "num_vertex_attributes " << StringConverter::toString(caps->getNumVertexAttributes()) << endl;
 
@@ -327,23 +315,11 @@ namespace Ogre
         addSetIntMethod("stencil_buffer_bit_depth", &RenderSystemCapabilities::setStencilBufferBitDepth);
         addSetIntMethod("num_multi_render_targets", &RenderSystemCapabilities::setNumMultiRenderTargets);
         addSetIntMethod("vertex_program_constant_float_count", &RenderSystemCapabilities::setVertexProgramConstantFloatCount);
-        addSetIntMethod("vertex_program_constant_int_count", &RenderSystemCapabilities::setVertexProgramConstantIntCount);
-        addSetIntMethod("vertex_program_constant_bool_count", &RenderSystemCapabilities::setVertexProgramConstantBoolCount);
         addSetIntMethod("fragment_program_constant_float_count", &RenderSystemCapabilities::setFragmentProgramConstantFloatCount);
-        addSetIntMethod("fragment_program_constant_int_count", &RenderSystemCapabilities::setFragmentProgramConstantIntCount);
-        addSetIntMethod("fragment_program_constant_bool_count", &RenderSystemCapabilities::setFragmentProgramConstantBoolCount);
         addSetIntMethod("geometry_program_constant_float_count", &RenderSystemCapabilities::setGeometryProgramConstantFloatCount);
-        addSetIntMethod("geometry_program_constant_int_count", &RenderSystemCapabilities::setGeometryProgramConstantIntCount);
-        addSetIntMethod("geometry_program_constant_bool_count", &RenderSystemCapabilities::setGeometryProgramConstantBoolCount);
         addSetIntMethod("tessellation_hull_program_constant_float_count", &RenderSystemCapabilities::setTessellationHullProgramConstantFloatCount);
-        addSetIntMethod("tessellation_hull_program_constant_int_count", &RenderSystemCapabilities::setTessellationHullProgramConstantIntCount);
-        addSetIntMethod("tessellation_hull_program_constant_bool_count", &RenderSystemCapabilities::setTessellationHullProgramConstantBoolCount);
         addSetIntMethod("tessellation_domain_program_constant_float_count", &RenderSystemCapabilities::setTessellationDomainProgramConstantFloatCount);
-        addSetIntMethod("tessellation_domain_program_constant_int_count", &RenderSystemCapabilities::setTessellationDomainProgramConstantIntCount);
-        addSetIntMethod("tessellation_domain_program_constant_bool_count", &RenderSystemCapabilities::setTessellationDomainProgramConstantBoolCount);
         addSetIntMethod("compute_program_constant_float_count", &RenderSystemCapabilities::setComputeProgramConstantFloatCount);
-        addSetIntMethod("compute_program_constant_int_count", &RenderSystemCapabilities::setComputeProgramConstantIntCount);
-        addSetIntMethod("compute_program_constant_bool_count", &RenderSystemCapabilities::setComputeProgramConstantBoolCount);
         addSetIntMethod("num_vertex_texture_units", &RenderSystemCapabilities::setNumVertexTextureUnits);
 
         // initialize bool types

--- a/RenderSystems/Direct3D11/src/OgreD3D11RenderSystem.cpp
+++ b/RenderSystems/Direct3D11/src/OgreD3D11RenderSystem.cpp
@@ -956,13 +956,8 @@ namespace Ogre
 
         rsc->setCapability(RSC_VERTEX_PROGRAM);
 
-        // TODO: constant buffers have no limits but lower models do
-        // 16 boolean params allowed
-        rsc->setVertexProgramConstantBoolCount(16);
-        // 16 integer params allowed, 4D
-        rsc->setVertexProgramConstantIntCount(16);
         // float params, always 4D
-        rsc->setVertexProgramConstantFloatCount(512);
+        rsc->setVertexProgramConstantFloatCount(D3D11_REQ_CONSTANT_BUFFER_ELEMENT_COUNT);
 
     }
     //---------------------------------------------------------------------
@@ -999,13 +994,8 @@ namespace Ogre
             rsc->addShaderProfile("ps_5_0");
         }
 
-        // TODO: constant buffers have no limits but lower models do
-        // 16 boolean params allowed
-        rsc->setFragmentProgramConstantBoolCount(16);
-        // 16 integer params allowed, 4D
-        rsc->setFragmentProgramConstantIntCount(16);
         // float params, always 4D
-        rsc->setFragmentProgramConstantFloatCount(512);
+        rsc->setFragmentProgramConstantFloatCount(D3D11_REQ_CONSTANT_BUFFER_ELEMENT_COUNT);
 
     }
     //---------------------------------------------------------------------
@@ -1018,13 +1008,8 @@ namespace Ogre
             
             rsc->setCapability(RSC_TESSELLATION_HULL_PROGRAM);
 
-            // TODO: constant buffers have no limits but lower models do
-            // 16 boolean params allowed
-            rsc->setTessellationHullProgramConstantBoolCount(16);
-            // 16 integer params allowed, 4D
-            rsc->setTessellationHullProgramConstantIntCount(16);
             // float params, always 4D
-            rsc->setTessellationHullProgramConstantFloatCount(512);
+            rsc->setTessellationHullProgramConstantFloatCount(D3D11_REQ_CONSTANT_BUFFER_ELEMENT_COUNT);
         }
 
     }
@@ -1038,14 +1023,8 @@ namespace Ogre
 
             rsc->setCapability(RSC_TESSELLATION_DOMAIN_PROGRAM);
 
-
-            // TODO: constant buffers have no limits but lower models do
-            // 16 boolean params allowed
-            rsc->setTessellationDomainProgramConstantBoolCount(16);
-            // 16 integer params allowed, 4D
-            rsc->setTessellationDomainProgramConstantIntCount(16);
             // float params, always 4D
-            rsc->setTessellationDomainProgramConstantFloatCount(512);
+            rsc->setTessellationDomainProgramConstantFloatCount(D3D11_REQ_CONSTANT_BUFFER_ELEMENT_COUNT);
         }
 
     }
@@ -1067,16 +1046,8 @@ namespace Ogre
             rsc->addShaderProfile("cs_5_0");
         }
 
-
-
-        // TODO: constant buffers have no limits but lower models do
-        // 16 boolean params allowed
-        rsc->setComputeProgramConstantBoolCount(16);
-        // 16 integer params allowed, 4D
-        rsc->setComputeProgramConstantIntCount(16);
         // float params, always 4D
-        rsc->setComputeProgramConstantFloatCount(512);
-
+        rsc->setComputeProgramConstantFloatCount(D3D11_REQ_CONSTANT_BUFFER_ELEMENT_COUNT);
     }
     //---------------------------------------------------------------------
     void D3D11RenderSystem::convertGeometryShaderCaps(RenderSystemCapabilities* rsc) const
@@ -1096,9 +1067,7 @@ namespace Ogre
             rsc->addShaderProfile("gs_5_0");
         }
 
-        rsc->setGeometryProgramConstantFloatCount(512);
-        rsc->setGeometryProgramConstantIntCount(16);
-        rsc->setGeometryProgramConstantBoolCount(16);
+        rsc->setGeometryProgramConstantFloatCount(D3D11_REQ_CONSTANT_BUFFER_ELEMENT_COUNT);
         rsc->setGeometryProgramNumOutputVertices(1024);
     }
     //-----------------------------------------------------------------------

--- a/RenderSystems/Direct3D9/src/OgreD3D9RenderSystem.cpp
+++ b/RenderSystems/Direct3D9/src/OgreD3D9RenderSystem.cpp
@@ -1188,26 +1188,20 @@ namespace Ogre
         {
         case 1:
             // No boolean params allowed
-            rsc->setVertexProgramConstantBoolCount(0);
             // No integer params allowed
-            rsc->setVertexProgramConstantIntCount(0);
             // float params, always 4D
             rsc->setVertexProgramConstantFloatCount(static_cast<ushort>(minVSCaps.MaxVertexShaderConst));
 
             break;
         case 2:
             // 16 boolean params allowed
-            rsc->setVertexProgramConstantBoolCount(16);
             // 16 integer params allowed, 4D
-            rsc->setVertexProgramConstantIntCount(16);
             // float params, always 4D
             rsc->setVertexProgramConstantFloatCount(static_cast<ushort>(minVSCaps.MaxVertexShaderConst));
             break;
         case 3:
             // 16 boolean params allowed
-            rsc->setVertexProgramConstantBoolCount(16);
             // 16 integer params allowed, 4D
-            rsc->setVertexProgramConstantIntCount(16);
             // float params, always 4D
             rsc->setVertexProgramConstantFloatCount(static_cast<ushort>(minVSCaps.MaxVertexShaderConst));
             break;
@@ -1285,9 +1279,7 @@ namespace Ogre
         {
         case 1:
             // no boolean params allowed
-            rsc->setFragmentProgramConstantBoolCount(0);
             // no integer params allowed
-            rsc->setFragmentProgramConstantIntCount(0);
             // float params, always 4D
             // NB in ps_1_x these are actually stored as fixed point values,
             // but they are entered as floats
@@ -1295,17 +1287,13 @@ namespace Ogre
             break;
         case 2:
             // 16 boolean params allowed
-            rsc->setFragmentProgramConstantBoolCount(16);
             // 16 integer params allowed, 4D
-            rsc->setFragmentProgramConstantIntCount(16);
             // float params, always 4D
             rsc->setFragmentProgramConstantFloatCount(32);
             break;
         case 3:
             // 16 boolean params allowed
-            rsc->setFragmentProgramConstantBoolCount(16);
             // 16 integer params allowed, 4D
-            rsc->setFragmentProgramConstantIntCount(16);
             // float params, always 4D
             rsc->setFragmentProgramConstantFloatCount(224);
             break;

--- a/RenderSystems/GL/src/OgreGLRenderSystem.cpp
+++ b/RenderSystems/GL/src/OgreGLRenderSystem.cpp
@@ -452,9 +452,6 @@ namespace Ogre {
             rsc->setCapability(RSC_VERTEX_PROGRAM);
 
             // Vertex Program Properties
-            rsc->setVertexProgramConstantBoolCount(0);
-            rsc->setVertexProgramConstantIntCount(0);
-
             GLint floatConstantCount;
             glGetProgramivARB(GL_VERTEX_PROGRAM_ARB, GL_MAX_PROGRAM_LOCAL_PARAMETERS_ARB, &floatConstantCount);
             rsc->setVertexProgramConstantFloatCount(floatConstantCount);
@@ -490,11 +487,6 @@ namespace Ogre {
         // NFZ - check for ATI fragment shader support
         if (GLEW_ATI_fragment_shader)
         {
-            // no boolean params allowed
-            rsc->setFragmentProgramConstantBoolCount(0);
-            // no integer params allowed
-            rsc->setFragmentProgramConstantIntCount(0);
-
             // only 8 Vector4 constant floats supported
             rsc->setFragmentProgramConstantFloatCount(8);
 
@@ -507,9 +499,6 @@ namespace Ogre {
         if (GLEW_ARB_fragment_program)
         {
             // Fragment Program Properties
-            rsc->setFragmentProgramConstantBoolCount(0);
-            rsc->setFragmentProgramConstantIntCount(0);
-
             GLint floatConstantCount;
             glGetProgramivARB(GL_FRAGMENT_PROGRAM_ARB, GL_MAX_PROGRAM_LOCAL_PARAMETERS_ARB, &floatConstantCount);
             rsc->setFragmentProgramConstantFloatCount(floatConstantCount);
@@ -553,12 +542,9 @@ namespace Ogre {
             GLEW_EXT_geometry_shader4)
         {
             rsc->setCapability(RSC_GEOMETRY_PROGRAM);
-            rsc->setGeometryProgramConstantBoolCount(0);
-            rsc->setGeometryProgramConstantIntCount(0);
-
             GLint floatConstantCount = 0;
             glGetIntegerv(GL_MAX_GEOMETRY_UNIFORM_COMPONENTS_EXT, &floatConstantCount);
-            rsc->setGeometryProgramConstantFloatCount(floatConstantCount);
+            rsc->setGeometryProgramConstantFloatCount(floatConstantCount/4);
 
             GLint maxOutputVertices;
             glGetIntegerv(GL_MAX_GEOMETRY_OUTPUT_VERTICES_EXT,&maxOutputVertices);

--- a/RenderSystems/GL3Plus/src/OgreGL3PlusRenderSystem.cpp
+++ b/RenderSystems/GL3Plus/src/OgreGL3PlusRenderSystem.cpp
@@ -383,31 +383,21 @@ namespace Ogre {
 
         GLint constantCount = 0;
         OGRE_CHECK_GL_ERROR(glGetIntegerv(GL_MAX_VERTEX_UNIFORM_COMPONENTS, &constantCount));
-        rsc->setVertexProgramConstantFloatCount((Ogre::ushort)constantCount);
-        rsc->setVertexProgramConstantBoolCount((Ogre::ushort)constantCount);
-        rsc->setVertexProgramConstantIntCount((Ogre::ushort)constantCount);
+        rsc->setVertexProgramConstantFloatCount((Ogre::ushort)constantCount/4);
 
         // Fragment Program Properties
         constantCount = 0;
         OGRE_CHECK_GL_ERROR(glGetIntegerv(GL_MAX_FRAGMENT_UNIFORM_COMPONENTS, &constantCount));
-        rsc->setFragmentProgramConstantFloatCount((Ogre::ushort)constantCount);
-        rsc->setFragmentProgramConstantBoolCount((Ogre::ushort)constantCount);
-        rsc->setFragmentProgramConstantIntCount((Ogre::ushort)constantCount);
+        rsc->setFragmentProgramConstantFloatCount((Ogre::ushort)constantCount/4);
 
         // Geometry Program Properties
         rsc->setCapability(RSC_GEOMETRY_PROGRAM);
 
         OGRE_CHECK_GL_ERROR(glGetIntegerv(GL_MAX_GEOMETRY_UNIFORM_COMPONENTS, &constantCount));
-        rsc->setGeometryProgramConstantFloatCount(constantCount);
+        rsc->setGeometryProgramConstantFloatCount(constantCount/4);
 
         OGRE_CHECK_GL_ERROR(glGetIntegerv(GL_MAX_GEOMETRY_OUTPUT_VERTICES, &constantCount));
-        rsc->setGeometryProgramNumOutputVertices(constantCount);
-
-        //FIXME Is this correct?
-        OGRE_CHECK_GL_ERROR(glGetIntegerv(GL_MAX_GEOMETRY_UNIFORM_COMPONENTS, &constantCount));
-        rsc->setGeometryProgramConstantFloatCount(constantCount);
-        rsc->setGeometryProgramConstantBoolCount(constantCount);
-        rsc->setGeometryProgramConstantIntCount(constantCount);
+        rsc->setGeometryProgramNumOutputVertices(constantCount/4);
 
         // Tessellation Program Properties
         if (hasMinGLVersion(4, 0) || checkExtension("GL_ARB_tessellation_shader"))
@@ -416,20 +406,12 @@ namespace Ogre {
             rsc->setCapability(RSC_TESSELLATION_DOMAIN_PROGRAM);
 
             OGRE_CHECK_GL_ERROR(glGetIntegerv(GL_MAX_TESS_CONTROL_UNIFORM_COMPONENTS, &constantCount));
-            // 16 boolean params allowed
-            rsc->setTessellationHullProgramConstantBoolCount(constantCount);
-            // 16 integer params allowed, 4D
-            rsc->setTessellationHullProgramConstantIntCount(constantCount);
-            // float params, always 4D
-            rsc->setTessellationHullProgramConstantFloatCount(constantCount);
+            // float params
+            rsc->setTessellationHullProgramConstantFloatCount(constantCount/4);
 
             OGRE_CHECK_GL_ERROR(glGetIntegerv(GL_MAX_TESS_EVALUATION_UNIFORM_COMPONENTS, &constantCount));
-            // 16 boolean params allowed
-            rsc->setTessellationDomainProgramConstantBoolCount(constantCount);
-            // 16 integer params allowed, 4D
-            rsc->setTessellationDomainProgramConstantIntCount(constantCount);
-            // float params, always 4D
-            rsc->setTessellationDomainProgramConstantFloatCount(constantCount);
+            // float params
+            rsc->setTessellationDomainProgramConstantFloatCount(constantCount/4);
         }
 
         // Compute Program Properties
@@ -437,11 +419,8 @@ namespace Ogre {
         {
             rsc->setCapability(RSC_COMPUTE_PROGRAM);
 
-            //FIXME Is this correct?
             OGRE_CHECK_GL_ERROR(glGetIntegerv(GL_MAX_COMPUTE_UNIFORM_COMPONENTS, &constantCount));
             rsc->setComputeProgramConstantFloatCount(constantCount);
-            rsc->setComputeProgramConstantBoolCount(constantCount);
-            rsc->setComputeProgramConstantIntCount(constantCount);
 
             //TODO we should also check max workgroup count & size
             // OGRE_CHECK_GL_ERROR(glGetIntegerv(GL_MAX_COMPUTE_WORK_GROUP_SIZE, &workgroupCount));

--- a/RenderSystems/GLES2/src/OgreGLES2RenderSystem.cpp
+++ b/RenderSystems/GLES2/src/OgreGLES2RenderSystem.cpp
@@ -401,25 +401,13 @@ namespace Ogre {
         }
 
         GLfloat floatConstantCount = 0;
-#if OGRE_NO_GLES3_SUPPORT == 0
-        glGetFloatv(GL_MAX_VERTEX_UNIFORM_COMPONENTS, &floatConstantCount);
-#else
         glGetFloatv(GL_MAX_VERTEX_UNIFORM_VECTORS, &floatConstantCount);
-#endif
         rsc->setVertexProgramConstantFloatCount((Ogre::ushort)floatConstantCount);
-        rsc->setVertexProgramConstantBoolCount((Ogre::ushort)floatConstantCount);
-        rsc->setVertexProgramConstantIntCount((Ogre::ushort)floatConstantCount);
 
         // Fragment Program Properties
         floatConstantCount = 0;
-#if OGRE_NO_GLES3_SUPPORT == 0
-        glGetFloatv(GL_MAX_FRAGMENT_UNIFORM_COMPONENTS, &floatConstantCount);
-#else
         glGetFloatv(GL_MAX_FRAGMENT_UNIFORM_VECTORS, &floatConstantCount);
-#endif
         rsc->setFragmentProgramConstantFloatCount((Ogre::ushort)floatConstantCount);
-        rsc->setFragmentProgramConstantBoolCount((Ogre::ushort)floatConstantCount);
-        rsc->setFragmentProgramConstantIntCount((Ogre::ushort)floatConstantCount);
 
         // Check for Float textures
         if(hasMinGLVersion(3, 0) || checkExtension("GL_OES_texture_float") || checkExtension("GL_OES_texture_half_float"))

--- a/RenderSystems/Metal/src/OgreMetalRenderSystem.mm
+++ b/RenderSystems/Metal/src/OgreMetalRenderSystem.mm
@@ -192,14 +192,8 @@ namespace Ogre
 
         //These don't make sense on Metal, so just use flexible defaults.
         rsc->setVertexProgramConstantFloatCount( 16384 );
-        rsc->setVertexProgramConstantBoolCount( 16384 );
-        rsc->setVertexProgramConstantIntCount( 16384 );
         rsc->setFragmentProgramConstantFloatCount( 16384 );
-        rsc->setFragmentProgramConstantBoolCount( 16384 );
-        rsc->setFragmentProgramConstantIntCount( 16384 );
         rsc->setComputeProgramConstantFloatCount( 16384 );
-        rsc->setComputeProgramConstantBoolCount( 16384 );
-        rsc->setComputeProgramConstantIntCount( 16384 );
 
 #if OGRE_PLATFORM != OGRE_PLATFORM_APPLE_IOS
         uint8 mrtCount = 8u;

--- a/RenderSystems/Vulkan/src/OgreVulkanRenderSystem.cpp
+++ b/RenderSystems/Vulkan/src/OgreVulkanRenderSystem.cpp
@@ -577,25 +577,13 @@ namespace Ogre
         rsc->setMaxPointSize( 256 );
 
         //rsc->setMaximumResolutions( 16384, 4096, 16384 );
-
-        rsc->setVertexProgramConstantFloatCount( 256u );
-        rsc->setVertexProgramConstantIntCount( 256u );
-        rsc->setVertexProgramConstantBoolCount( 256u );
-        rsc->setGeometryProgramConstantFloatCount( 256u );
-        rsc->setGeometryProgramConstantIntCount( 256u );
-        rsc->setGeometryProgramConstantBoolCount( 256u );
-        rsc->setFragmentProgramConstantFloatCount( 256u );
-        rsc->setFragmentProgramConstantIntCount( 256u );
-        rsc->setFragmentProgramConstantBoolCount( 256u );
-        rsc->setTessellationHullProgramConstantFloatCount( 256u );
-        rsc->setTessellationHullProgramConstantIntCount( 256u );
-        rsc->setTessellationHullProgramConstantBoolCount( 256u );
-        rsc->setTessellationDomainProgramConstantFloatCount( 256u );
-        rsc->setTessellationDomainProgramConstantIntCount( 256u );
-        rsc->setTessellationDomainProgramConstantBoolCount( 256u );
-        rsc->setComputeProgramConstantFloatCount( 256u );
-        rsc->setComputeProgramConstantIntCount( 256u );
-        rsc->setComputeProgramConstantBoolCount( 256u );
+        auto maxFloatVectors = deviceLimits.maxUniformBufferRange / (4 * sizeof(float));
+        rsc->setVertexProgramConstantFloatCount(maxFloatVectors);
+        rsc->setGeometryProgramConstantFloatCount(maxFloatVectors);
+        rsc->setFragmentProgramConstantFloatCount(maxFloatVectors);
+        rsc->setTessellationHullProgramConstantFloatCount(maxFloatVectors);
+        rsc->setTessellationDomainProgramConstantFloatCount(maxFloatVectors);
+        rsc->setComputeProgramConstantFloatCount(maxFloatVectors);
 
         rsc->addShaderProfile( "spirv" );
 

--- a/Tests/OgreMain/src/RenderSystemCapabilitiesTests.cpp
+++ b/Tests/OgreMain/src/RenderSystemCapabilitiesTests.cpp
@@ -482,12 +482,7 @@ TEST_F(RenderSystemCapabilitiesTests,WriteAndReadComplexCapabilities)
     caps.addShaderProfile("..f(_)specialsymbolextravaganza!@#$%^&*_but_no_spaces");
 
     caps.setVertexProgramConstantFloatCount(1111);
-    caps.setVertexProgramConstantIntCount(2222);
-    caps.setVertexProgramConstantBoolCount(3333);
-
     caps.setFragmentProgramConstantFloatCount(4444);
-    caps.setFragmentProgramConstantIntCount(5555);
-    caps.setFragmentProgramConstantBoolCount(64000);
 
     caps.setMaxPointSize(123.75);
     caps.setNonPOW2TexturesLimited(true);
@@ -558,12 +553,7 @@ TEST_F(RenderSystemCapabilitiesTests,WriteAndReadComplexCapabilities)
     EXPECT_EQ(caps.getNumMultiRenderTargets(), caps2.getNumMultiRenderTargets());
 
     EXPECT_EQ(caps.getVertexProgramConstantFloatCount(), caps2.getVertexProgramConstantFloatCount());
-    EXPECT_EQ(caps.getVertexProgramConstantIntCount(), caps2.getVertexProgramConstantIntCount());
-    EXPECT_EQ(caps.getVertexProgramConstantBoolCount(), caps2.getVertexProgramConstantBoolCount());
-
     EXPECT_EQ(caps.getFragmentProgramConstantFloatCount(), caps2.getFragmentProgramConstantFloatCount());
-    EXPECT_EQ(caps.getFragmentProgramConstantIntCount(), caps2.getFragmentProgramConstantIntCount());
-    EXPECT_EQ(caps.getFragmentProgramConstantBoolCount(), caps2.getFragmentProgramConstantBoolCount());
 
     EXPECT_EQ(caps.getMaxPointSize(), caps2.getMaxPointSize());
     EXPECT_EQ(caps.getNonPOW2TexturesLimited(), caps2.getNonPOW2TexturesLimited());

--- a/Tests/OgreMain/src/UseCustomCapabilitiesTests.cpp
+++ b/Tests/OgreMain/src/UseCustomCapabilitiesTests.cpp
@@ -107,12 +107,7 @@ static void checkCaps(const Ogre::RenderSystemCapabilities* caps)
     EXPECT_EQ(caps->getNumMultiRenderTargets(), (Ogre::ushort)4);
 
     EXPECT_EQ(caps->getVertexProgramConstantFloatCount(), (Ogre::ushort)256);
-    EXPECT_EQ(caps->getVertexProgramConstantIntCount(), (Ogre::ushort)0);
-    EXPECT_EQ(caps->getVertexProgramConstantBoolCount(), (Ogre::ushort)0);
-
     EXPECT_EQ(caps->getFragmentProgramConstantFloatCount(), (Ogre::ushort)64);
-    EXPECT_EQ(caps->getFragmentProgramConstantIntCount(), (Ogre::ushort)0);
-    EXPECT_EQ(caps->getFragmentProgramConstantBoolCount(), (Ogre::ushort)0);
 
     EXPECT_EQ(caps->getNumVertexTextureUnits(), (Ogre::ushort)0);
     EXPECT_TRUE(caps->isShaderProfileSupported("arbvp1"));


### PR DESCRIPTION
and clarify the unit. The type separation only made sense on D3D9.