### PR TITLE
fixed build on old macOS

### DIFF
--- a/OgreMain/src/OSX/OgreFileSystemLayer.cpp
+++ b/OgreMain/src/OSX/OgreFileSystemLayer.cpp
@@ -30,6 +30,8 @@
 #include <pwd.h>
 #include <dlfcn.h>
 #include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 namespace Ogre
 {

--- a/RenderSystems/GLSupport/src/OSX/OgreOSXCocoaWindow.mm
+++ b/RenderSystems/GLSupport/src/OSX/OgreOSXCocoaWindow.mm
@@ -33,6 +33,7 @@ THE SOFTWARE.
 
 #import "OgreGLRenderSystemCommon.h"
 #import "OgreGLNativeSupport.h"
+#import <AppKit/AppKit.h>
 #import <AppKit/NSScreen.h>
 #import <AppKit/NSOpenGLView.h>
 #import <QuartzCore/CVDisplayLink.h>


### PR DESCRIPTION
It allows to build on macOS up to 10.10.

Anyway, it is uses `NSOpenGLContext.pixelFormat` which was added at 10.10 and removing it seems like as a huge and meanless job.