### PR TITLE
Assimp: Fix detection of assimp 5.1, upgrade bundled assimp, remove cmake workaround for CI

### DIFF
--- a/CMake/Dependencies.cmake
+++ b/CMake/Dependencies.cmake
@@ -251,11 +251,11 @@ find_package(ZLIB)
 macro_log_feature(ZLIB_FOUND "zlib" "Simple data compression library" "http://www.zlib.net" FALSE "" "")
 
 # Assimp
-find_package(ASSIMP QUIET)
-macro_log_feature(ASSIMP_FOUND "Assimp" "Needed for the AssimpLoader Plugin" "https://www.assimp.org/" FALSE "" "")
+find_package(assimp QUIET)
+macro_log_feature(assimp_FOUND "Assimp" "Needed for the AssimpLoader Plugin" "https://www.assimp.org/" FALSE "" "")
 
-if(ASSIMP_FOUND)
-  # workaround horribly broken assimp cmake
+if(assimp_FOUND)
+  # workaround horribly broken assimp cmake, fixed with assimp 5.1
   add_library(fix::assimp INTERFACE IMPORTED)
   set_target_properties(fix::assimp PROPERTIES
       INTERFACE_LINK_LIBRARIES "${ASSIMP_LIBRARIES}"

--- a/CMake/Dependencies.cmake
+++ b/CMake/Dependencies.cmake
@@ -142,10 +142,10 @@ if(OGRE_BUILD_DEPENDENCIES AND NOT EXISTS ${OGREDEPS_PATH})
 
       message(STATUS "Building Assimp")
       file(DOWNLOAD
-          https://github.com/assimp/assimp/archive/v5.0.1.tar.gz
-          ${PROJECT_BINARY_DIR}/v5.0.1.tar.gz)
+          https://github.com/assimp/assimp/archive/v5.1.3.tar.gz
+          ${PROJECT_BINARY_DIR}/v5.1.3.tar.gz)
       execute_process(COMMAND ${CMAKE_COMMAND}
-          -E tar xf v5.0.1.tar.gz WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
+          -E tar xf v5.1.3.tar.gz WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
       execute_process(COMMAND ${BUILD_COMMAND_COMMON}
           -DZLIB_ROOT=${OGREDEPS_PATH}
           -DBUILD_SHARED_LIBS=OFF
@@ -153,13 +153,13 @@ if(OGRE_BUILD_DEPENDENCIES AND NOT EXISTS ${OGREDEPS_PATH})
           -DASSIMP_NO_EXPORT=TRUE
           -DASSIMP_BUILD_OGRE_IMPORTER=OFF
           -DASSIMP_BUILD_ASSIMP_TOOLS=OFF
-          ${PROJECT_BINARY_DIR}/assimp-5.0.1
-          WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/assimp-5.0.1)
+          ${PROJECT_BINARY_DIR}/assimp-5.1.3
+          WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/assimp-5.1.3)
       execute_process(COMMAND ${CMAKE_COMMAND}
-        --build ${PROJECT_BINARY_DIR}/assimp-5.0.1 ${BUILD_COMMAND_OPTS})
+        --build ${PROJECT_BINARY_DIR}/assimp-5.1.3 ${BUILD_COMMAND_OPTS})
       # RelWithDebInfo has Release ABI
       if(NOT OGRE_DEBUG_MODE)
-        file(REMOVE ${OGREDEPS_PATH}/lib/cmake/assimp-5.0/assimpTargets-debug.cmake)
+        file(REMOVE ${OGREDEPS_PATH}/lib/cmake/assimp-5.1/assimpTargets-debug.cmake)
       endif()
     endif()
 endif()
@@ -258,7 +258,7 @@ if(assimp_FOUND)
   # workaround horribly broken assimp cmake, fixed with assimp 5.1
   add_library(fix::assimp INTERFACE IMPORTED)
   set_target_properties(fix::assimp PROPERTIES
-      INTERFACE_LINK_LIBRARIES "${ASSIMP_LIBRARIES}"
+      INTERFACE_LINK_LIBRARIES "${ASSIMP_LIBRARIES};pugixml"
       INTERFACE_LINK_DIRECTORIES "${ASSIMP_LIBRARY_DIRS}"
   )
   if(EXISTS "${ASSIMP_INCLUDE_DIRS}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,7 +322,7 @@ cmake_dependent_option(OGRE_BUILD_RENDERSYSTEM_GL "Build OpenGL RenderSystem" TR
 cmake_dependent_option(OGRE_BUILD_RENDERSYSTEM_GLES2 "Build OpenGL ES 2.x RenderSystem" TRUE "OPENGLES2_FOUND;NOT WINDOWS_STORE;NOT WINDOWS_PHONE" FALSE)
 cmake_dependent_option(OGRE_BUILD_RENDERSYSTEM_METAL "Build Metal RenderSystem" FALSE "APPLE" FALSE)
 option(OGRE_BUILD_RENDERSYSTEM_VULKAN "Build Vulkan RenderSystem" FALSE)
-cmake_dependent_option(OGRE_BUILD_PLUGIN_ASSIMP "Build Open Asset Import plugin" TRUE "ASSIMP_FOUND" FALSE)
+cmake_dependent_option(OGRE_BUILD_PLUGIN_ASSIMP "Build Open Asset Import plugin" TRUE "assimp_FOUND" FALSE)
 cmake_dependent_option(OGRE_BUILD_RENDERSYSTEM_TINY "Build Tiny RenderSystem (software-rendering)" FALSE "NOT ANDROID" FALSE)
 option(OGRE_BUILD_PLUGIN_BSP "Build BSP SceneManager plugin" TRUE)
 option(OGRE_BUILD_PLUGIN_OCTREE "Build Octree SceneManager plugin" TRUE)

--- a/PlugIns/Assimp/CMakeLists.txt
+++ b/PlugIns/Assimp/CMakeLists.txt
@@ -6,14 +6,6 @@ target_include_directories(Codec_Assimp PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     $<INSTALL_INTERFACE:include/OGRE/Plugins/Assimp>)
 target_link_libraries(Codec_Assimp PUBLIC OgreMain PRIVATE fix::assimp)
-if(OGRE_BUILD_DEPENDENCIES)
-    # hack to get our CI build going, despite horribly broken assimp cmake
-    if(UNIX)
-        target_link_libraries(Codec_Assimp PUBLIC ZLIB::ZLIB ${OGREDEPS_PATH}/lib/libIrrXML.a)
-    else()
-        target_link_libraries(Codec_Assimp PRIVATE ZLIB::ZLIB ${OGREDEPS_PATH}/lib/IrrXML.lib)
-    endif()
-endif()
 
 ogre_config_framework(Codec_Assimp)
 ogre_config_plugin(Codec_Assimp)


### PR DESCRIPTION
This solve an issue where assimp >= 5.1 is not found by cmake, as the `package_name` is `assimp` not `ASSIMP`.

But this also updates the assimp version used for msvc builds and drops the cmake workaround for assimp 5.0, as this is fixed with 5.1.

This should be of cause discussed if dropping 5.0 support is ok, did this because then also the workaround can be dropped, but only changing the `package_name` and keep the workaround should work if 5.0 support should stay.