### PR TITLE
GLSupport: GLX - fix selecting maximal supported context version

### DIFF
--- a/RenderSystems/GLSupport/src/GLX/OgreGLXGLSupport.cpp
+++ b/RenderSystems/GLSupport/src/GLX/OgreGLXGLSupport.cpp
@@ -539,7 +539,9 @@ namespace Ogre
             // find maximal supported context version
             context_attribs[1] = 4;
             context_attribs[3] = 6;
-            while(!glxContext && (context_attribs[1] >= majorVersion && context_attribs[3] >= minorVersion))
+            while(!glxContext &&
+                  ((context_attribs[1] > majorVersion) ||
+                   (context_attribs[1] == majorVersion && context_attribs[3] >= minorVersion)))
             {
                 ctxErrorOccurred = false;
                 glxContext = _glXCreateContextAttribsARB(mGLDisplay, fbConfig, shareList, direct, context_attribs);


### PR DESCRIPTION
As long as context_attrib[1] is larger than majorVersion, the minor Version must not be checked.

Fixes commit 680150caaf16632578e5e294df5dfc43eacd30fe