### PR TITLE
Main: clarified WorkQueue request type values.

### DIFF
--- a/OgreMain/include/OgreWorkQueue.h
+++ b/OgreMain/include/OgreWorkQueue.h
@@ -258,7 +258,7 @@ namespace Ogre
         /** Add a new request to the queue.
         @param channel The channel this request will go into = 0; the channel is the top-level
             categorisation of the request
-        @param requestType An identifier that's unique within this queue which
+        @param requestType An identifier that's unique within this channel which
             identifies the type of the request (user decides the actual value)
         @param rData The data required by the request process. 
         @param retryCount The number of times the request should be retried


### PR DESCRIPTION
The single word in the docs startled me enough to research in the codebase.

```
WORKQUEUE_CHANGECOLLECTION_REQUEST = 3 (unused?)
WORKQUEUE_DERIVED_DATA_REQUEST = 1 ("Ogre/Terrain")
WORKQUEUE_GENERATE_MATERIAL_REQUEST = 2 ("Ogre/Terrain")
WORKQUEUE_LOAD_LOD_DATA_REQUEST = 1 ("Ogre/TerrainLodManager")
WORKQUEUE_LOAD_REQUEST = 1 ("Ogre/VolumeRendering", "Ogre/TerrainGroup")
WORKQUEUE_LOAD_TERRAIN_PAGE_REQUEST = 1 ("Ogre/TerrainPagedWorldSection")
WORKQUEUE_PREPARE_REQUEST = 1 (""Ogre/Page"")
```

Although it wouldn't make sense, it was technically possible that request types must be unique per WorkQueue instance and defining user values would need to start with some "minimum user value" constant.