### PR TITLE
UnifiedShader: use forward compatible precision declarations

### DIFF
--- a/Components/Terrain/src/OgreTerrainMaterialShaderHelperGLSL.cpp
+++ b/Components/Terrain/src/OgreTerrainMaterialShaderHelperGLSL.cpp
@@ -327,7 +327,7 @@ namespace Ogre
         outStream << "MAIN_PARAMETERS\n"
                      "IN(vec4 oPosObj, TEXCOORD0)\n";
         uint texCoordSet = 1;
-        outStream << "IN(highp vec4 oUVMisc, TEXCOORD" << texCoordSet++ << ")\n";
+        outStream << "IN(f32vec4 oUVMisc, TEXCOORD" << texCoordSet++ << ")\n";
 
         if (prof->getParent()->getDebugLevel() && tt != RENDER_COMPOSITE_MAP)
         {
@@ -345,7 +345,7 @@ namespace Ogre
         outStream << "MAIN_DECLARATION\n"
             "{\n"
             "    float shadow = 1.0;\n"
-            "    highp vec2 uv = oUVMisc.xy;\n"
+            "    f32vec2 uv = oUVMisc.xy;\n"
             // base colour
             "    gl_FragColor = vec4(0,0,0,1);\n";
 

--- a/Media/Main/OgreUnifiedShader.h
+++ b/Media/Main/OgreUnifiedShader.h
@@ -163,8 +163,15 @@ mat3 mtxFromCols(vec3 a, vec3 b, vec3 c)
 
 #define OGRE_UNIFORMS(params) OGRE_UNIFORMS_BEGIN params OGRE_UNIFORMS_END
 
-#ifndef OGRE_GLSLES
-#define highp
-#define mediump
-#define lowp
+// GL_EXT_shader_explicit_arithmetic_types polyfill
+#ifdef OGRE_GLSLES
+#define float32_t highp float
+#define f32vec2 highp vec2
+#define f32vec3 highp vec3
+#define f32vec4 highp vec4
+#else
+#define float32_t float
+#define f32vec2 vec2
+#define f32vec3 vec3
+#define f32vec4 vec4
 #endif


### PR DESCRIPTION
stemming from GL_EXT_shader_explicit_arithmetic_types