### PR TITLE
Fixed Invalid memory usage when cloning material

### DIFF
--- a/OgreMain/src/OgreMaterial.cpp
+++ b/OgreMain/src/OgreMaterial.cpp
@@ -193,6 +193,14 @@ namespace Ogre {
         newMat->mName = newName;
         newMat->mHandle = newHandle;
 
+        //if we're cloning from a loaded material, notify the creator or otherwise size won't be right
+        if (newMat->getLoadingState() == LOADSTATE_LOADED)
+        {
+            // Notify manager
+            if (mCreator)
+                mCreator->_notifyResourceLoaded(newMat.get());
+        }
+
         return newMat;
     }
     //-----------------------------------------------------------------------


### PR DESCRIPTION
if a loaded material is cloned, the memory size of the cloned material isn't tracked.

Quick example pseudo code:

```
matA = MaterialManager::getSingleton().create(...);
matA->load(); //adds xxx bytes to the ResourceManager::mMemoryUsage
matB = matA.clone(...); //adds nothing
matB->unload(); //removes xxx bytes from the ResourceManager::mMemoryUsage
matA->unload(); //removes xxx bytes from the ResourceManager::mMemoryUsage
```

If you do something like that, the ResourceManager::mMemoryUsage will be "negative", but it's an unsigned value so..
After that, every time ResourceManager::checkUsage(void) is called, it'll say the memory budget is exceeded.
