### PR TITLE
Samples: Fixed compilation error.

### DIFF
--- a/Samples/Simple/include/Fresnel.h
+++ b/Samples/Simple/include/Fresnel.h
@@ -213,7 +213,7 @@ protected:
         mFishSplines.clear();
 
         MeshManager::getSingleton().remove("water", ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-        MaterialManager::getSingleton().unload("Examples/FresnelReflectionRefraction");
+        MaterialManager::getSingleton().unload("Examples/FresnelReflectionRefraction", RGN_DEFAULT);
     }
 
     const unsigned int NUM_FISH;


### PR DESCRIPTION
Fixed ```Fresnel.h:216:48: error: invalid conversion from 'const char*' to 'Ogre::ResourceHandle' {aka 'unsigned int'} [-fpermissive]```

Also appears on the 13.3.4 tag.