### PR TITLE
Main: fixed incorrect handling of samplers as constants

### DIFF
--- a/OgreMain/include/OgreMaterialSerializer.h
+++ b/OgreMain/include/OgreMaterialSerializer.h
@@ -173,7 +173,7 @@ namespace Ogre {
             const String& commandName, const String& identifier, 
             const GpuProgramParameters::AutoConstantEntry* autoEntry, 
             const GpuProgramParameters::AutoConstantEntry* defaultAutoEntry, 
-            bool isFloat, bool isDouble, bool isInt, bool isUnsignedInt, 
+            bool isFloat, bool isDouble, bool isInt, bool isUnsignedInt, bool isRegister,
             size_t physicalIndex, size_t physicalSize,
             const GpuProgramParametersSharedPtr& params, GpuProgramParameters* defaultParams,
             const unsigned short level, const bool useMainBuffer);


### PR DESCRIPTION
There was a refactor where samplers were moved out of mConstants
and into mRegisters. However, the serializer still tried to access
them from mConstants, which results in either invalid data or segfaults.

This should also be backported to the 13.3.4 tag (couldn't find a branch).