### PR TITLE
Main: fixed regression with shadow caster material

### DIFF
--- a/OgreMain/src/OgreTechnique.cpp
+++ b/OgreMain/src/OgreTechnique.cpp
@@ -1032,8 +1032,13 @@ namespace Ogre {
     }
     //-----------------------------------------------------------------------
     void  Technique::setShadowCasterMaterial(const Ogre::String &name) 
-    { 
-        setShadowCasterMaterial(MaterialManager::getSingleton().getByName(name));
+    {
+        mShadowCasterMaterialName = name;
+        mShadowCasterMaterial = MaterialManager::getSingleton().getByName(name);
+        if (mShadowCasterMaterial) {
+            // shadow caster material should never receive shadows
+            mShadowCasterMaterial->setReceiveShadows(false); // should we warn if this is not set?
+        }
     }
     //-----------------------------------------------------------------------
     Ogre::MaterialPtr  Technique::getShadowReceiverMaterial() const 


### PR DESCRIPTION
Because a shadow caster material might reference a material that's no
yet loaded we need to set the mShadowCasterMaterialName even if the material
wasn't found.
This fixes a regression where this didn't happen.