### PR TITLE
Main: Bump GTest because of issues with gcc 11.

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -10,20 +10,20 @@
 # Configure Tests build
 if (OGRE_BUILD_TESTS)
 
-  if(NOT EXISTS ${PROJECT_BINARY_DIR}/googletest-1.10.x)
+  if(NOT EXISTS ${PROJECT_BINARY_DIR}/googletest-1.11.0)
     message(STATUS "Building gtest")
     file(DOWNLOAD
-        https://github.com/google/googletest/archive/refs/heads/v1.10.x.tar.gz
-        ${PROJECT_BINARY_DIR}/v1.10.x.tar.gz)
+        https://github.com/google/googletest/archive/refs/tags/release-1.11.0.tar.gz
+        ${PROJECT_BINARY_DIR}/release-1.11.0.tar.gz)
     execute_process(COMMAND ${CMAKE_COMMAND}
-        -E tar xf v1.10.x.tar.gz WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
+        -E tar xf release-1.11.0.tar.gz WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
     execute_process(COMMAND ${BUILD_COMMAND_COMMON}
-        ${PROJECT_BINARY_DIR}/googletest-1.10.x
+        ${PROJECT_BINARY_DIR}/googletest-release-1.11.0
         -Dgtest_force_shared_crt=TRUE
         -DBUILD_GMOCK=FALSE
-        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/googletest-1.10.x)
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/googletest-release-1.11.0)
     execute_process(COMMAND ${CMAKE_COMMAND}
-        --build ${PROJECT_BINARY_DIR}/googletest-1.10.x ${BUILD_COMMAND_OPTS})
+        --build ${PROJECT_BINARY_DIR}/googletest-release-1.11.0 ${BUILD_COMMAND_OPTS})
   endif()
   find_package(GTest REQUIRED CONFIG)
   include_directories(${CMAKE_CURRENT_SOURCE_DIR}/Common/include)


### PR DESCRIPTION
See https://github.com/google/googletest/issues/3219

I got the error that's mentioned in the above issue when running with GCC 11.2.1.
Bumping gtest fixed it, but I haven't tried with any other compilers. I'm hoping the CI system will handle that.