### PR TITLE
Main: fix StaticGeometry::setRenderingDistance

### DIFF
--- a/OgreMain/src/OgreStaticGeometry.cpp
+++ b/OgreMain/src/OgreStaticGeometry.cpp
@@ -813,6 +813,21 @@ namespace Ogre {
         if (mLodStrategy == 0)
             return;
 
+        // Determine whether to still render
+        mBeyondFarDistance = false;
+
+        Real renderingDist = mParent->getRenderingDistance();
+        if (renderingDist > 0 && cam->getUseRenderingDistance())
+        {
+            // Max distance to still render
+            Real maxDist = renderingDist + mBoundingRadius;
+            if (mSquaredViewDepth > Math::Sqr(maxDist))
+            {
+                mBeyondFarDistance = true;
+                return;
+            }
+        }
+
         // Sanity check
         assert(!mLodValues.empty());
 


### PR DESCRIPTION
Setting the rendering distance on a static geometry had
no influence whether batches were skipped while rendering.

Fixes #2427

Broken since commit 060f9705c35b7278a89e03d5daf47b50e36cc319