### PR TITLE
Don't use sse on non-x86 architectures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,7 +123,7 @@ endif ()
 
 # Set compiler specific build flags
 if (NOT ANDROID AND NOT EMSCRIPTEN AND UNIX OR MINGW)
-  if (CMAKE_SYSTEM_PROCESSOR MATCHES "x86|X86|amd64|AMD64") 
+  if (CMAKE_SYSTEM_PROCESSOR MATCHES "x86|X86|amd64|AMD64")
     include(CheckCXXCompilerFlag)
     check_cxx_compiler_flag(-msse OGRE_GCC_HAS_SSE)
     if (OGRE_GCC_HAS_SSE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,11 +123,13 @@ endif ()
 
 # Set compiler specific build flags
 if (NOT ANDROID AND NOT EMSCRIPTEN AND UNIX OR MINGW)
-  include(CheckCXXCompilerFlag)
-  check_cxx_compiler_flag(-msse OGRE_GCC_HAS_SSE)
-  if (OGRE_GCC_HAS_SSE)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse")
-  endif ()
+  if (CMAKE_SYSTEM_PROCESSOR MATCHES "x86|X86|amd64|AMD64") 
+    include(CheckCXXCompilerFlag)
+    check_cxx_compiler_flag(-msse OGRE_GCC_HAS_SSE)
+    if (OGRE_GCC_HAS_SSE)
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse")
+    endif ()
+  endif()
 endif()
 
 if(UNIX)


### PR DESCRIPTION
This is [currently breaking]( https://buildd.debian.org/status/fetch.php?pkg=mygui&arch=mipsel&ver=3.2.0-1&stamp=1365373881&raw=0 ) the Debian build on MIPSLE