### PR TITLE
Main: InstanceBatchHW - use correct HBU_CPU_TO_GPU

### DIFF
--- a/OgreMain/src/OgreInstanceBatchHW.cpp
+++ b/OgreMain/src/OgreInstanceBatchHW.cpp
@@ -74,11 +74,8 @@ namespace Ogre
         mRemoveOwnVertexData = true;
         VertexData *thisVertexData      = mRenderOperation.vertexData;
         const unsigned short lastSource = thisVertexData->vertexDeclaration->getMaxSource();
-        HardwareVertexBufferSharedPtr vertexBuffer =
-                                        HardwareBufferManager::getSingleton().createVertexBuffer(
-                                        thisVertexData->vertexDeclaration->getVertexSize(lastSource),
-                                        mInstancesPerBatch,
-                                        HardwareBuffer::HBU_STATIC_WRITE_ONLY );
+        auto vertexBuffer = HardwareBufferManager::getSingleton().createVertexBuffer(
+            thisVertexData->vertexDeclaration->getVertexSize(lastSource), mInstancesPerBatch, HBU_CPU_TO_GPU);
         thisVertexData->vertexBufferBinding->setBinding( lastSource, vertexBuffer );
         vertexBuffer->setIsInstanceData( true );
         vertexBuffer->setInstanceDataStepRate( 1 );
@@ -104,11 +101,8 @@ namespace Ogre
         }
 
         //Create the vertex buffer containing per instance data
-        HardwareVertexBufferSharedPtr vertexBuffer =
-                                        HardwareBufferManager::getSingleton().createVertexBuffer(
-                                        thisVertexData->vertexDeclaration->getVertexSize(newSource),
-                                        mInstancesPerBatch,
-                                        HardwareBuffer::HBU_STATIC_WRITE_ONLY );
+        auto vertexBuffer = HardwareBufferManager::getSingleton().createVertexBuffer(
+            thisVertexData->vertexDeclaration->getVertexSize(newSource), mInstancesPerBatch, HBU_CPU_TO_GPU);
         thisVertexData->vertexBufferBinding->setBinding( newSource, vertexBuffer );
         vertexBuffer->setIsInstanceData( true );
         vertexBuffer->setInstanceDataStepRate( 1 );


### PR DESCRIPTION
essential to get DISCARD on D3D9. About 5% benefit for the others.

before/ after (fps at 10k instances)

-    D3D9: 158/270
-    GL3+: 260/280
-    D3D11: 290/305