### PR TITLE
Example illustrating #2482

### DIFF
--- a/Samples/Common/src/DefaultSamplesPlugin.cpp
+++ b/Samples/Common/src/DefaultSamplesPlugin.cpp
@@ -31,6 +31,7 @@
 
 #include "AtomicCounters.h"
 #include "BezierPatch.h"
+#include "BillboardChain.h"
 #include "BSP.h"
 #ifdef OGRE_BUILD_COMPONENT_BULLET
 #include "Bullet.h"
@@ -100,6 +101,7 @@ DefaultSamplesPlugin::DefaultSamplesPlugin() : SamplePlugin("DefaultSamplesPlugi
 {
     addSample(new Sample_AtomicCounters);
     addSample(new Sample_BezierPatch);
+    addSample(new Sample_BillboardChain);
 #ifdef OGRE_BUILD_COMPONENT_BULLET
     addSample(new Sample_Bullet);
 #endif

--- a/Samples/Simple/include/BillboardChain.h
+++ b/Samples/Simple/include/BillboardChain.h
@@ -3,6 +3,7 @@
 
 #include "SdkSample.h"
 #include "OgreBillboardChain.h"
+#include "OgreBillboardSet.h"
 #include <iostream>
 
 using namespace Ogre;
@@ -48,6 +49,14 @@ protected:
         chain->addChainElement(0, e);
         e.position = Vector3(1.0, 1.0, 1.0);
         chain->addChainElement(0, e);
+
+        auto set = mSceneMgr->createBillboardSet("set");
+        set->setMaterialName(mat->getName(), mat->getGroup());
+        mSceneMgr->getRootSceneNode()->attachObject(set);
+        set->setDefaultWidth(0.1);
+        set->setDefaultHeight(0.1);
+        set->createBillboard (-1, 0, 0, ColourValue::Green);
+        set->createBillboard (1, 0, 0, ColourValue::Blue);
 
         // use an orbit style camera
         mCameraMan->setStyle(CS_ORBIT);

--- a/Samples/Simple/include/BillboardChain.h
+++ b/Samples/Simple/include/BillboardChain.h
@@ -1,0 +1,65 @@
+#ifndef __BillboardChain_H__
+#define __BillboardChain_H__
+
+#include "SdkSample.h"
+#include "OgreBillboardChain.h"
+#include <iostream>
+
+using namespace Ogre;
+using namespace OgreBites;
+
+class _OgreSampleClassExport Sample_BillboardChain : public SdkSample
+{
+public:
+
+    Sample_BillboardChain()
+    {
+        std::cerr << "*** Created ***" << std::endl;
+        mInfo["Title"] = "Billboard Chain";
+        mInfo["Description"] = "Illustrate BillboardChain bug";
+        mInfo["Category"] = "Geometry";
+    }
+
+protected:
+
+    void setupContent()
+    {
+        // setup some basic lighting for our scene
+        mSceneMgr->setAmbientLight(ColourValue(0.5, 0.5, 0.5));
+        mSceneMgr->getRootSceneNode()
+            ->createChildSceneNode(Vector3(100, 100, 100))
+            ->attachObject(mSceneMgr->createLight());
+
+        auto mat = Ogre::MaterialManager::getSingleton().create("BillboardChainMaterial", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+        mat->setReceiveShadows(false);
+        auto t = mat->getTechnique(0);
+        t->setLightingEnabled(false);
+        t->setSceneBlending(Ogre::SBT_REPLACE);
+        t->setDepthWriteEnabled(true);
+
+        auto chain = mSceneMgr->createBillboardChain("chain");
+        chain->setMaterialName(mat->getName(), mat->getGroup());
+        mSceneMgr->getRootSceneNode()->attachObject(chain);
+
+        BillboardChain::Element e;
+        e.position = Vector3(0.0, 0.0, 0.0);
+        e.width = 0.1;
+        e.colour = ColourValue::Red;
+        chain->addChainElement(0, e);
+        e.position = Vector3(1.0, 1.0, 1.0);
+        chain->addChainElement(0, e);
+
+        // use an orbit style camera
+        mCameraMan->setStyle(CS_ORBIT);
+        mCameraMan->setYawPitchDist(Degree(0), Degree(30), 10);
+
+        mTrayMgr->showCursor();
+    }
+
+    void cleanupContent()
+    {
+    }
+
+};
+
+#endif


### PR DESCRIPTION
This is a minimal example illustrating issue #2482. Not intended for merging.
As you expected, @paroj, `BillboardChain` and `BillboardSet` act differently when moving the camera: While the set is always facing the cam as expected, the chain essentially ignores camera updates.