### PR TITLE
PCZSceneManager: fix scaling of portal radius

### DIFF
--- a/PlugIns/OctreeZone/src/OgreOctreeZone.cpp
+++ b/PlugIns/OctreeZone/src/OgreOctreeZone.cpp
@@ -343,7 +343,7 @@ namespace Ogre
             Portal * p = *it;
             bool portalNeedUpdate = p->needUpdate();
 
-            Real pRadius = p->getRadius();
+            Real pRadius = p->getDerivedRadius();
 
             // First we check against portals in the SAME zone (and only if they have a 
             // target zone different from the home zone)
@@ -367,7 +367,7 @@ namespace Ogre
                 // Skip portal if it's pointing to the same target zone as this portal points to
                 if (p2->getTargetZone() == p->getTargetZone()) continue;
 
-                if (pRadius > p2->getRadius())
+                if (pRadius > p2->getDerivedRadius())
                 {
                     // Portal#1 is bigger than Portal#2, check for crossing
                     if (p2->getCurrentHomeZone() != p->getTargetZone() && p2->crossedPortal(p))
@@ -377,7 +377,7 @@ namespace Ogre
                         transferPortalList.push_back(p2);
                     }
                 }
-                else if (pRadius < p2->getRadius())
+                else if (pRadius < p2->getDerivedRadius())
                 {
                     // Portal #2 is bigger than Portal #1, check for crossing
                     if (p->getCurrentHomeZone() != p2->getTargetZone() && p->crossedPortal(p2))
@@ -400,7 +400,7 @@ namespace Ogre
                 if (!portalNeedUpdate && !ap->needUpdate()) continue;
 
                 // only check for crossing if AntiPortal smaller than portal.
-                if (pRadius > ap->getRadius())
+                if (pRadius > ap->getDerivedRadius())
                 {
                     // Portal#1 is bigger than AntiPortal, check for crossing
                     if (ap->crossedPortal(p))
@@ -424,7 +424,7 @@ namespace Ogre
                 {
                     Portal * p3 = (*it3);
                     // only check against bigger regular portals
-                    if (pRadius < p3->getRadius())
+                    if (pRadius < p3->getDerivedRadius())
                     {
                         // Portal#3 is bigger than Portal#1, check for crossing
                         if (p->getCurrentHomeZone() != p3->getTargetZone() && p->crossedPortal(p3))

--- a/PlugIns/PCZSceneManager/include/OgrePortalBase.h
+++ b/PlugIns/PCZSceneManager/include/OgrePortalBase.h
@@ -106,8 +106,9 @@ namespace Ogre
 
         /** Get the type of portal */
         PORTAL_TYPE getType() const {return mType;}
-        /** Retrieve the radius of the portal (calculates if necessary for quad portals) */
-        Real getRadius() const;
+        /** Retrieve the radius of the portal in world coordinates */
+        Real getDerivedRadius() const
+        { return mDerivedRadius; }
 
         /** Get the Zone the Portal is currently "in" */
         PCZone* getCurrentHomeZone()
@@ -190,8 +191,7 @@ namespace Ogre
         const AxisAlignedBox& getBoundingBox() const;
 
         /** @copydoc MovableObject::getBoundingRadius */
-        Real getBoundingRadius() const
-        { return getRadius(); }
+        Real getBoundingRadius() const;
 
         /** @copydoc MovableObject::_updateRenderQueue */
         void _updateRenderQueue(RenderQueue* queue)
@@ -255,6 +255,8 @@ namespace Ogre
         /// Derived (world coordinates) direction of the portal
         // NOTE: Only applicable for a Quad portal
         mutable Vector3 mDerivedDirection;
+        /// Derived (world coordinates) radius of the sphere enclosing the portal
+        mutable Real mDerivedRadius;
         /// Derived (world coordinates) of portal (center point)
         mutable Vector3 mDerivedCP;
         /// Sphere of the portal centered on the derived CP

--- a/PlugIns/PCZSceneManager/src/OgreDefaultZone.cpp
+++ b/PlugIns/PCZSceneManager/src/OgreDefaultZone.cpp
@@ -279,7 +279,7 @@ namespace Ogre
             Portal * p = *it;
             bool portalNeedUpdate = p->needUpdate();
 
-            Real pRadius = p->getRadius();
+            Real pRadius = p->getDerivedRadius();
 
             // First we check against portals in the SAME zone (and only if they have a 
             // target zone different from the home zone)
@@ -303,7 +303,7 @@ namespace Ogre
                 // Skip portal if it's pointing to the same target zone as this portal points to
                 if (p2->getTargetZone() == p->getTargetZone()) continue;
 
-                if (pRadius > p2->getRadius())
+                if (pRadius > p2->getDerivedRadius())
                 {
                     // Portal#1 is bigger than Portal#2, check for crossing
                     if (p2->getCurrentHomeZone() != p->getTargetZone() && p2->crossedPortal(p))
@@ -313,7 +313,7 @@ namespace Ogre
                         transferPortalList.push_back(p2);
                     }
                 }
-                else if (pRadius < p2->getRadius())
+                else if (pRadius < p2->getDerivedRadius())
                 {
                     // Portal #2 is bigger than Portal #1, check for crossing
                     if (p->getCurrentHomeZone() != p2->getTargetZone() && p->crossedPortal(p2))
@@ -336,7 +336,7 @@ namespace Ogre
                 if (!portalNeedUpdate && !ap->needUpdate()) continue;
 
                 // only check for crossing if AntiPortal smaller than portal.
-                if (pRadius > ap->getRadius())
+                if (pRadius > ap->getDerivedRadius())
                 {
                     // Portal#1 is bigger than AntiPortal, check for crossing
                     if (ap->crossedPortal(p))
@@ -360,7 +360,7 @@ namespace Ogre
                 {
                     Portal * p3 = (*it3);
                     // only check against bigger regular portals
-                    if (pRadius < p3->getRadius())
+                    if (pRadius < p3->getDerivedRadius())
                     {
                         // Portal#3 is bigger than Portal#1, check for crossing
                         if (p->getCurrentHomeZone() != p3->getTargetZone() && p->crossedPortal(p3))

--- a/PlugIns/PCZSceneManager/src/OgrePortalBase.cpp
+++ b/PlugIns/PCZSceneManager/src/OgrePortalBase.cpp
@@ -216,18 +216,17 @@ void PortalBase::calcDirectionAndRadius(void) const
         radiusVector = mCorners[1] - mLocalCP;
         mRadius = radiusVector.length();
 
-        min = mDerivedCP - mRadius;
-        max = mDerivedCP + mRadius;
+        min = mLocalCP - mRadius;
+        max = mLocalCP + mRadius;
         break;
     }
-    mDerivedSphere.setRadius(mRadius);
     mLocalPortalAAB.setExtents(min, max);
     // locals are now up to date
     mLocalsUpToDate = true;
 }
 
 // Calculate the local bounding sphere of the portal from the corner points
-Real PortalBase::getRadius( void ) const
+Real PortalBase::getBoundingRadius( void ) const
 {
     if (!mLocalsUpToDate)
     {
@@ -263,6 +262,9 @@ void PortalBase::updateDerivedValues(void) const
         mPrevDerivedCP = mDerivedCP;
         mDerivedCP = transform * mLocalCP;
         mDerivedSphere.setCenter(mDerivedCP);
+        mDerivedRadius = getBoundingRadiusScaled();
+        mDerivedSphere.setRadius(mDerivedRadius);
+
         switch(mType)
         {
         case PORTAL_TYPE_QUAD:
@@ -326,6 +328,8 @@ void PortalBase::updateDerivedValues(void) const
             mPrevDerivedCP = mDerivedCP;
             mDerivedCP = mLocalCP;
             mDerivedSphere.setCenter(mDerivedCP);
+            mDerivedRadius = mRadius;
+            mDerivedSphere.setRadius(mDerivedRadius);
             for (int i=0;i<numCorners;i++)
             {
                 mDerivedCorners[i] = mCorners[i];
@@ -348,6 +352,8 @@ void PortalBase::updateDerivedValues(void) const
             mDerivedCP = mLocalCP;
             mPrevDerivedCP = mDerivedCP;
             mDerivedSphere.setCenter(mDerivedCP);
+            mDerivedRadius = mRadius;
+            mDerivedSphere.setRadius(mDerivedRadius);
             for (int i=0;i<numCorners;i++)
             {
                 mDerivedCorners[i] = mCorners[i];
@@ -367,7 +373,7 @@ void PortalBase::updateDerivedValues(void) const
     mPortalAAB.merge(mPrevPortalAAB);
     mPrevPortalAAB = mWorldAABB;
 
-    mPortalCapsule.set(mPrevDerivedCP, mDerivedCP, mRadius);
+    mPortalCapsule.set(mPrevDerivedCP, mDerivedCP, mDerivedRadius);
     mDerivedUpToDate = true;
 }
 
@@ -658,9 +664,9 @@ PortalBase::PortalIntersectResult PortalBase::intersects(PCZSceneNode* pczsn)
                     // small enough to fit through the portal! (avoid the "elephant fitting 
                     // through a mouse hole" case)
                     Vector3 nodeHalfVector = pczsn->_getWorldAABB().getHalfSize();
-                    Vector3 portalBox = Vector3(mRadius, mRadius, mRadius);
+                    Vector3 portalBox = Vector3(mDerivedRadius, mDerivedRadius, mDerivedRadius);
                     portalBox.makeFloor(nodeHalfVector);
-                    if (portalBox.x < mRadius)
+                    if (portalBox.x < mDerivedRadius)
                     {
                         // crossing occurred!
                         return PortalBase::INTERSECT_CROSS;
@@ -740,12 +746,12 @@ PortalBase::PortalIntersectResult PortalBase::intersects(PCZSceneNode* pczsn)
             // the sphere surface (or vice versa) for crossing.  
             //Real previousDistance2 = mPrevDerivedCP.squaredDistance(pczsn->getPrevPosition());
             Real currentDistance2 = mDerivedCP.squaredDistance(pczsn->_getDerivedPosition());
-            Real mRadius2 = mRadius * mRadius;
+            Real mDerivedRadius2 = mDerivedRadius * mDerivedRadius;
             if (mDirection == Vector3::UNIT_Z)
             {
                 // portal norm is "outward" pointing, look for going from outside to inside 
-                //if (previousDistance2 >= mRadius2 &&
-                if (currentDistance2 < mRadius2)
+                //if (previousDistance2 >= mDerivedRadius2 &&
+                if (currentDistance2 < mDerivedRadius2)
                 {
                     return PortalBase::INTERSECT_CROSS;
                 }
@@ -753,14 +759,14 @@ PortalBase::PortalIntersectResult PortalBase::intersects(PCZSceneNode* pczsn)
             else
             {
                 // portal norm is "inward" pointing, look for going from inside to outside
-                //if (previousDistance2 < mRadius2 &&
-                if (currentDistance2 >= mRadius2)
+                //if (previousDistance2 < mDerivedRadius2 &&
+                if (currentDistance2 >= mDerivedRadius2)
                 {
                     return PortalBase::INTERSECT_CROSS;
                 }
             }
             // no crossing, but might be touching - check distance 
-            if (Math::Sqrt(Math::Abs(mRadius2 - currentDistance2)) <= mRadius)
+            if (Math::Sqrt(Math::Abs(mDerivedRadius2 - currentDistance2)) <= mDerivedRadius)
             {
                 return PortalBase::INTERSECT_NO_CROSS;
             }
@@ -835,12 +841,12 @@ bool PortalBase::crossedPortal(const PortalBase* otherPortal)
                     // the sphere surface (or vice versa) for crossing.  
                     //Real previousDistance2 = mPrevDerivedCP.squaredDistance(otherPortal->getPrevDerivedCP());
                     Real currentDistance2 = mDerivedCP.squaredDistance(otherPortal->getDerivedCP());
-                    Real mRadius2 = Math::Sqr(otherPortal->getRadius());
+                    Real mDerivedRadius2 = Math::Sqr(otherPortal->getDerivedRadius());
                     if (otherPortal->getDerivedDirection() == Vector3::UNIT_Z)
                     {
                         // portal norm is "outward" pointing, look for going from outside to inside 
-                        //if (previousDistance2 >= mRadius2 &&
-                        if (currentDistance2 < mRadius2)
+                        //if (previousDistance2 >= mDerivedRadius2 &&
+                        if (currentDistance2 < mDerivedRadius2)
                         {
                             return true;
                         }
@@ -848,8 +854,8 @@ bool PortalBase::crossedPortal(const PortalBase* otherPortal)
                     else
                     {
                         // portal norm is "inward" pointing, look for going from inside to outside
-                        //if (previousDistance2 < mRadius2 &&
-                        if (currentDistance2 >= mRadius2)
+                        //if (previousDistance2 < mDerivedRadius2 &&
+                        if (currentDistance2 >= mDerivedRadius2)
                         {
                             return true;
                         }
@@ -900,7 +906,7 @@ bool PortalBase::closeTo(const PortalBase* otherPortal)
     case PORTAL_TYPE_SPHERE:
         // NOTE: Spheres must match perfectly
         if (mDerivedCP == otherPortal->getDerivedCP() &&
-            mRadius == otherPortal->getRadius())
+            mDerivedRadius == otherPortal->getDerivedRadius())
         {
             close = true;
         }


### PR DESCRIPTION
On the PCZSceneManager docs (https://github.com/OGRECave/ogre/tree/master/PlugIns/PCZSceneManager) it says: "NOTE: Scaling of a portal is not yet tested. Scaling a node should scale the portal (but don't cry to me if it doesn't work right yet...)"

I have scaling in my PCZ Scene. Culling works correctly through scaled portals. However, Nodes passing through Portals (and other intersections) were tested against unscaled radii. This PR fixes that.