### PR TITLE
Main: Root - run destructor on MaterialManager before GpuProgramManager

### DIFF
--- a/OgreMain/src/OgreRoot.cpp
+++ b/OgreMain/src/OgreRoot.cpp
@@ -255,6 +255,7 @@ namespace Ogre {
 #endif
 		mCompositorManager.reset(); // needs rendersystem
         mParticleManager.reset(); // may use plugins
+        mMaterialManager.reset(); // may use GPU program manager
         mGpuProgramManager.reset(); // may use plugins
         unloadPlugins();
 


### PR DESCRIPTION
See #2506 for a detailed explanation.