### PR TITLE
Bug: One extra mipmap being generated in Ogre::Texture::convertToImage

### DIFF
--- a/OgreMain/src/OgreTexture.cpp
+++ b/OgreMain/src/OgreTexture.cpp
@@ -415,7 +415,7 @@ namespace Ogre {
     //---------------------------------------------------------------------
     void Texture::convertToImage(Image& destImage, bool includeMipMaps)
     {
-        uint32 numMips = includeMipMaps? getNumMipmaps() + 1 : 1;
+        uint32 numMips = includeMipMaps? getNumMipmaps() : 0;
         destImage.create(getFormat(), getWidth(), getHeight(), getDepth(), getNumFaces(), numMips);
 
         for (uint32 face = 0; face < getNumFaces(); ++face)


### PR DESCRIPTION
We're currently trying to [upgrade from Ogre1.12.1 to Ogre1.12.10](https://github.com/ros2/rviz/pull/878) and have encounterered some tests failing, which I believe is due to a bug introduced in #1755.

Before the changes in #1755 of refactoring the ``Texture::convertToImage(Image& destImage, bool includeMipMaps)`` method, no mipmaps were generated with the example below, but since 1.12.10 onwards, one extra mipmap gets generated.

Here is a minimal example to reproduce the issue on 1.12.10 and beyond:

**main.cpp**

```cpp
#include <OgreImage.h>
#include <OgreResourceGroupManager.h>
#include <OgreTextureManager.h>
#include <OgreTexture.h>
#include <OgreApplicationContext.h>
#include <OgreRoot.h>
#include <iostream>

class MyTestApp : public OgreBites::ApplicationContext
{

public:
  MyTestApp()
  : OgreBites::ApplicationContext("OgreTutorialApp")
  {
  }

  void setup(void)
  {
    OgreBites::ApplicationContext::setup();

    Ogre::ResourceGroupManager::getSingleton().addResourceLocation(
      "/home/ijnek/tmp_workspaces/ogre_reproduce_bug/resource", "FileSystem");

    Ogre::Image originalImage;
    originalImage.load("test_20x20.png", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);

    Ogre::TexturePtr texture = Ogre::TextureManager::getSingleton().loadImage(
          "bla", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME, originalImage,
          Ogre::TEX_TYPE_2D, 0);

    Ogre::Image convertedImage;
    texture->convertToImage(convertedImage);

    std::cout << "numMipMaps (should all be the same): " << std::endl;
    std::cout << "  originalImage:  " << originalImage.getNumMipmaps() << std::endl;
    std::cout << "  texture:        " << texture->getNumMipmaps() << std::endl;
    std::cout << "  convertedImage: " << convertedImage.getNumMipmaps() << std::endl;
  }
};

int main(int argc, char * argv[])
{
  MyTestApp app;
  app.initApp();
  app.getRoot()->startRendering();
  app.closeApp();
  return 0;
}

```

**CMakeLists.txt**
```cmake
cmake_minimum_required(VERSION 3.22)
project(ogre_reproduce_bug)

find_package(OGRE REQUIRED COMPONENTS Bites CONFIG)
add_executable(${PROJECT_NAME} main.cpp)
target_link_libraries(${PROJECT_NAME} OgreBites)
```

**Output**

v1.12.9
```
numMipMaps (should all be the same):
  originalImage:  0
  texture:        0
  convertedImage: 0
```

v1.12.10
```
numMipMaps (should all be the same):
  originalImage:  0
  texture:        0
  convertedImage: 1
```
I'm unfamiliar with whether ogre backports bug fixes, but I am wondering if it is possible to get the bug fixes into the [ubuntu package](https://packages.ubuntu.com/jammy/arm64/libogre-1.12-dev) rather than having to build the newest version from source or having to manually apply the patch?