### PR TITLE
prototype to support local space bone arrays for hardware skinning.  …

### DIFF
--- a/OgreMain/include/OgreAutoParamDataSource.h
+++ b/OgreMain/include/OgreAutoParamDataSource.h
@@ -61,8 +61,11 @@ namespace Ogre {
     private:
         const Light& getLight(size_t index) const;
         mutable Affine3 mWorldMatrix[256];
+        mutable Affine3 mLocalMatrix[256];
         mutable size_t mWorldMatrixCount;
         mutable const Affine3* mWorldMatrixArray;
+        mutable size_t mLocalMatrixCount;
+        mutable const Affine3* mLocalMatrixArray;
         mutable Affine3 mWorldViewMatrix;
         mutable Matrix4 mViewProjMatrix;
         mutable Matrix4 mWorldViewProjMatrix;
@@ -85,6 +88,7 @@ namespace Ogre {
         mutable Vector4 mLodCameraPosition;
         mutable Vector4 mLodCameraPositionObjectSpace;
 
+        mutable bool mLocalMatrixDirty;
         mutable bool mWorldMatrixDirty;
         mutable bool mViewMatrixDirty;
         mutable bool mProjMatrixDirty;
@@ -157,8 +161,11 @@ namespace Ogre {
 		/** Returns the current bounded camera */
 		const Camera* getCurrentCamera() const;
 
+        const Affine3& getLocalMatrix (void) const;
         const Affine3& getWorldMatrix(void) const;
+        const Affine3* getLocalMatrixArray (void) const;
         const Affine3* getWorldMatrixArray(void) const;
+        size_t getLocalMatrixCount (void) const;
         size_t getWorldMatrixCount(void) const;
         const Affine3& getViewMatrix(void) const;
         const Matrix4& getViewProjectionMatrix(void) const;

--- a/OgreMain/include/OgreGpuProgramParams.h
+++ b/OgreMain/include/OgreGpuProgramParams.h
@@ -640,6 +640,7 @@ namespace Ogre {
             /// 4columns) usually for doing hardware skinning.
             /// You should make enough entries available in your vertex program for the number of
             /// bones in use, i.e. an array of numBones*3 float4’s.
+            ACT_LOCAL_MATRIX_ARRAY_3x4,
             ACT_WORLD_MATRIX_ARRAY_3x4,
             /// The current array of world matrices, used for blending
             ACT_WORLD_MATRIX_ARRAY,

--- a/OgreMain/include/OgreRenderable.h
+++ b/OgreMain/include/OgreRenderable.h
@@ -132,6 +132,7 @@ namespace Ogre {
             the behavior is undefined if returns non-affine matrix here.
         */
         virtual void getWorldTransforms(Matrix4* xform) const = 0;
+        virtual void getLocalTransforms (Matrix4* xform) const {};
 
         /** Returns the number of world transform matrices this renderable requires.
 
@@ -141,6 +142,7 @@ namespace Ogre {
             If a renderable does not use vertex blending this method returns 1, which is the default for 
             simplicity.
         */
+        virtual unsigned short getNumLocalTransforms (void) const { return 1; }
         virtual unsigned short getNumWorldTransforms(void) const { return 1; }
 
         /** Sets whether or not to use an 'identity' projection.

--- a/OgreMain/src/OgreAutoParamDataSource.cpp
+++ b/OgreMain/src/OgreAutoParamDataSource.cpp
@@ -38,6 +38,7 @@ namespace Ogre {
     AutoParamDataSource::AutoParamDataSource()
         : mWorldMatrixCount(0),
          mWorldMatrixArray(0),
+         mLocalMatrixDirty (true),
          mWorldMatrixDirty(true),
          mViewMatrixDirty(true),
          mProjMatrixDirty(true),
@@ -104,6 +105,7 @@ namespace Ogre {
     void AutoParamDataSource::setCurrentRenderable(const Renderable* rend)
     {
         mCurrentRenderable = rend;
+        mLocalMatrixDirty = true;
         mWorldMatrixDirty = true;
         mViewMatrixDirty = true;
         mProjMatrixDirty = true;
@@ -262,6 +264,18 @@ namespace Ogre {
         mWorldMatrixDirty = false;
     }
     //-----------------------------------------------------------------------------
+    const Affine3& AutoParamDataSource::getLocalMatrix (void) const
+    {
+        if (mLocalMatrixDirty)
+        {
+            mLocalMatrixArray = mLocalMatrix;
+            mCurrentRenderable->getLocalTransforms (reinterpret_cast<Matrix4*>(mLocalMatrix));
+            mLocalMatrixCount = mCurrentRenderable->getNumLocalTransforms ();
+            mLocalMatrixDirty = false;
+        }
+        return mLocalMatrixArray[0];
+    }
+    //-----------------------------------------------------------------------------
     const Affine3& AutoParamDataSource::getWorldMatrix(void) const
     {
         if (mWorldMatrixDirty)
@@ -281,11 +295,25 @@ namespace Ogre {
         return mWorldMatrixArray[0];
     }
     //-----------------------------------------------------------------------------
+    size_t AutoParamDataSource::getLocalMatrixCount (void) const
+    {
+        // trigger derivation
+        getLocalMatrix ();
+        return mLocalMatrixCount;
+    }
+    //-----------------------------------------------------------------------------
     size_t AutoParamDataSource::getWorldMatrixCount(void) const
     {
         // trigger derivation
         getWorldMatrix();
         return mWorldMatrixCount;
+    }
+    //-----------------------------------------------------------------------------
+    const Affine3* AutoParamDataSource::getLocalMatrixArray (void) const
+    {
+        // trigger derivation
+        getLocalMatrix ();
+        return mLocalMatrixArray;
     }
     //-----------------------------------------------------------------------------
     const Affine3* AutoParamDataSource::getWorldMatrixArray(void) const

--- a/OgreMain/src/OgreGpuProgramParams.cpp
+++ b/OgreMain/src/OgreGpuProgramParams.cpp
@@ -40,6 +40,7 @@ namespace Ogre
         AutoConstantDefinition(ACT_TRANSPOSE_WORLD_MATRIX,             "transpose_world_matrix",            16, ET_REAL, ACDT_NONE),
         AutoConstantDefinition(ACT_INVERSE_TRANSPOSE_WORLD_MATRIX, "inverse_transpose_world_matrix", 16, ET_REAL, ACDT_NONE),
 
+        AutoConstantDefinition(ACT_LOCAL_MATRIX_ARRAY_3x4,        "local_matrix_array_3x4",      12, ET_REAL, ACDT_NONE),
         AutoConstantDefinition(ACT_WORLD_MATRIX_ARRAY_3x4,        "world_matrix_array_3x4",      12, ET_REAL, ACDT_NONE),
         AutoConstantDefinition(ACT_WORLD_MATRIX_ARRAY,            "world_matrix_array",          16, ET_REAL, ACDT_NONE),
         AutoConstantDefinition(ACT_WORLD_DUALQUATERNION_ARRAY_2x4, "world_dualquaternion_array_2x4",      8, ET_REAL, ACDT_NONE),
@@ -1101,6 +1102,7 @@ namespace Ogre
         case ACT_INVERSE_WORLD_MATRIX:
         case ACT_TRANSPOSE_WORLD_MATRIX:
         case ACT_INVERSE_TRANSPOSE_WORLD_MATRIX:
+        case ACT_LOCAL_MATRIX_ARRAY_3x4:
         case ACT_WORLD_MATRIX_ARRAY_3x4:
         case ACT_WORLD_MATRIX_ARRAY:
         case ACT_WORLD_DUALQUATERNION_ARRAY_2x4:
@@ -1862,6 +1864,19 @@ namespace Ogre
                     break;
                 case ACT_INVERSE_TRANSPOSE_WORLD_MATRIX:
                     _writeRawConstant(ac.physicalIndex, source->getInverseTransposeWorldMatrix(),ac.elementCount);
+                    break;
+
+                case ACT_LOCAL_MATRIX_ARRAY_3x4:
+                    // Loop over matrices
+                    pMatrix = source->getLocalMatrixArray ();
+                    numMatrices = source->getLocalMatrixCount ();
+                    index = i->physicalIndex;
+                    for (m = 0; m < numMatrices; ++m)
+                    {
+                        _writeRawConstants (index, (*pMatrix)[0], 12);
+                        index += 12 * sizeof (Real);
+                        ++pMatrix;
+                    }
                     break;
 
                 case ACT_WORLD_MATRIX_ARRAY_3x4:


### PR DESCRIPTION
…i don't like how there are now 2 large (mostly unused) matrix arrays in the AutoParamDataSource variables.  also, are there other existing mechanisms to accomplish the same idea?

this does, however, allow me to support local space skinning.