### PR TITLE
Main: fix compilation for Real=double and affected tests

### DIFF
--- a/OgreMain/src/OgreLight.cpp
+++ b/OgreMain/src/OgreLight.cpp
@@ -592,7 +592,8 @@ namespace Ogre {
         }
         void applyDeltaValue(const Vector4& val) override
         {
-            setValue(mLight->getAttenuation() + val);
+            const auto& attenuation = mLight->getAttenuation();
+            setValue(Vector4(attenuation[0], attenuation[1], attenuation[2], attenuation[3]) + val);
         }
         void setCurrentStateAsBaseValue(void) override
         {

--- a/Tests/OgreMain/src/General.cpp
+++ b/Tests/OgreMain/src/General.cpp
@@ -64,10 +64,27 @@ TEST_F(CameraTests,customProjectionMatrix)
     std::vector<Vector3> corners(cam.getWorldSpaceCorners(), cam.getWorldSpaceCorners() + 8);
     RealRect extents = cam.getFrustumExtents();
     cam.setCustomProjectionMatrix(true, cam.getProjectionMatrix());
-    for(int j = 0; j < 8; j++)
-        EXPECT_EQ(corners[j], cam.getWorldSpaceCorners()[j]);
+    for(int j = 0; j < 8; j++) {
+        for(int k = 0; k < 3; k++) {
+            if(typeid(corners[j]) == typeid(float))
+                EXPECT_FLOAT_EQ(corners[j][k], cam.getWorldSpaceCorners()[j][k]);
+            else
+                EXPECT_DOUBLE_EQ(corners[j][k], cam.getWorldSpaceCorners()[j][k]);
+        }
+    }
 
-    EXPECT_EQ(extents, cam.getFrustumExtents());
+    if(typeid(Ogre::Real) == typeid(float)) {
+        EXPECT_FLOAT_EQ(extents.bottom, cam.getFrustumExtents().bottom);
+        EXPECT_FLOAT_EQ(extents.top, cam.getFrustumExtents().top);
+        EXPECT_FLOAT_EQ(extents.left, cam.getFrustumExtents().left);
+        EXPECT_FLOAT_EQ(extents.right, cam.getFrustumExtents().right);
+    } else {
+        EXPECT_DOUBLE_EQ(extents.bottom, cam.getFrustumExtents().bottom);
+        EXPECT_DOUBLE_EQ(extents.top, cam.getFrustumExtents().top);
+        EXPECT_DOUBLE_EQ(extents.left, cam.getFrustumExtents().left);
+        EXPECT_DOUBLE_EQ(extents.right, cam.getFrustumExtents().right);
+    }
+
 }
 
 TEST(Root,shutdown)

--- a/Tests/OgreMain/src/QuaternionTests.cpp
+++ b/Tests/OgreMain/src/QuaternionTests.cpp
@@ -33,7 +33,7 @@ using namespace Ogre;
 
 TEST(QuaternionTests,Norm)
 {
-    EXPECT_EQ(Quaternion(0, 2, 2, 2).Norm(), Vector3(2, 2, 2).length());
+    EXPECT_NEAR(Quaternion(0, 2, 2, 2).Norm(), Vector3(2, 2, 2).length(), 1e-6);
 }
 
 TEST(QuaternionTests,FromVectors)


### PR DESCRIPTION
fixes #2648 and also makes some changes to tests so that they run successfully with Real as double.