### PR TITLE
Fix the build

### DIFF
--- a/OgreMain/src/OgreFrustum.cpp
+++ b/OgreMain/src/OgreFrustum.cpp
@@ -464,7 +464,8 @@ namespace Ogre {
 
 #if OGRE_NO_VIEWPORT_ORIENTATIONMODE == 0
         // Deal with orientation mode
-        mProjMatrix = mProjMatrix * Quaternion(Degree(mOrientationMode * 90.f), Vector3::UNIT_Z);
+        mProjMatrix = mProjMatrix *
+            Matrix4(Quaternion(Degree(mOrientationMode * 90.f), Vector3::UNIT_Z));
 #endif
         RenderSystem* renderSystem = Root::getSingleton().getRenderSystem();
 


### PR DESCRIPTION
The Matrix4 constructor taking a Quaternion is now explicit, so explicit conversion was required in this case.