### PR TITLE
Don't fail when trying to assign too many array elements in a shader

### DIFF
--- a/OgreMain/src/OgreGpuProgramParams.cpp
+++ b/OgreMain/src/OgreGpuProgramParams.cpp
@@ -2307,9 +2307,13 @@ namespace Ogre
             return;
 
         if (count > def->arraySize * def->elementSize)
-            OGRE_EXCEPT(Exception::ERR_INVALIDPARAMS,
-                        StringUtil::format("Too many values for parameter %s: %zu > %d", name.c_str(), count,
-                                           def->arraySize * def->elementSize));
+        {
+            // The shader compiler may trim the array if the trailing elements
+            // are unused or their usage can be optimized away. Therefore,
+            // a count exceeding the array size not not an error.
+            count = def->arraySize * def->elementSize;
+        }
+
         _writeRawConstants(withArrayOffset(def, name), val, count);
     }
     void GpuProgramParameters::setNamedConstant(const String& name, const float* val, size_t count, size_t multiple)


### PR DESCRIPTION
This issue is related to #2666.

The array size reported by the shader is not the same as the size declared in the shader source. Rather, it's the size after the compiler applied its optimizations, where it can trim arrays, if it thinks their trailing elements are unused or can be optimized away.