### PR TITLE
Ignore missing shader parameters

### DIFF
--- a/OgreMain/src/OgreGpuProgramParams.cpp
+++ b/OgreMain/src/OgreGpuProgramParams.cpp
@@ -748,7 +748,7 @@ namespace Ogre
     GpuProgramParameters::GpuProgramParameters() :
         mCombinedVariability(GPV_GLOBAL)
         , mTransposeMatrices(false)
-        , mIgnoreMissingParams(false)
+        , mIgnoreMissingParams(true)
         , mActivePassIterationIndex(std::numeric_limits<size_t>::max())
     {
     }


### PR DESCRIPTION
Shader compilers are apperently allowed to remove unused parameters or parameters that can be optimised away, so throwing exceptions when trying to set such a parameter is not a good idea.

I haven't found a way to disable this option programmatically from our code, so the simplest thing to do was just to change this default.