### PR TITLE
Fix access to an iterator after its container has beed destroyed

### DIFF
--- a/RenderSystems/GLES2/src/OgreGLES2RenderSystem.cpp
+++ b/RenderSystems/GLES2/src/OgreGLES2RenderSystem.cpp
@@ -902,10 +902,12 @@ namespace Ogre {
             }
             
 #if OGRE_NO_VIEWPORT_ORIENTATIONMODE == 0
+            // This works fine whether getConfigOptions() returns by value or by reference.
+            const ConfigOptionMap& configOptions = mGLSupport->getConfigOptions();
             ConfigOptionMap::const_iterator opt;
-            ConfigOptionMap::const_iterator end = mGLSupport->getConfigOptions().end();
+            ConfigOptionMap::const_iterator end = configOptions.end();
             
-            if ((opt = mGLSupport->getConfigOptions().find("Orientation")) != end)
+            if ((opt = configOptions.find("Orientation")) != end)
             {
                 String val = opt->second.currentValue;
                 if (val.find("Landscape") != String::npos)


### PR DESCRIPTION
The problem was in this line:

    ConfigOptionMap::const_iterator end = mGLSupport->getConfigOptions().end();

and in this one:

    if ((opt = mGLSupport->getConfigOptions().find("Orientation")) != end)

Because getConfigOptions() returns a container by value, that container is destroyed immediately after we take an iterator to it. Then we use that iterator after it's container has been destroyed.

This problem was reported by Clang as a warning.