### PR TITLE
Check the result of std::find to prevent erasing 'end' iterator

### DIFF
--- a/Components/RTShaderSystem/src/OgreShaderProgramManager.cpp
+++ b/Components/RTShaderSystem/src/OgreShaderProgramManager.cpp
@@ -71,7 +71,7 @@ void ProgramManager::releasePrograms(const ProgramSet* programSet)
             continue;
 
 	const auto it = std::find(mShaderList.begin(), mShaderList.end(), prg);
-        // TODO: this check should not be necessary, but we observed strange prg.use_count() in the wild 
+        // TODO: this check should not be necessary, but we observed strange prg.use_count() in the wild
         if(it != mShaderList.end())
             mShaderList.erase(it);
         GpuProgramManager::getSingleton().remove(prg);

--- a/Components/RTShaderSystem/src/OgreShaderProgramManager.cpp
+++ b/Components/RTShaderSystem/src/OgreShaderProgramManager.cpp
@@ -71,6 +71,7 @@ void ProgramManager::releasePrograms(const ProgramSet* programSet)
             continue;
 
 	const auto it = std::find(mShaderList.begin(), mShaderList.end(), prg);
+        // TODO: this check should not be necessary, but we observed strange prg.use_count() in the wild 
         if(it != mShaderList.end())
             mShaderList.erase(it);
         GpuProgramManager::getSingleton().remove(prg);

--- a/Components/RTShaderSystem/src/OgreShaderProgramManager.cpp
+++ b/Components/RTShaderSystem/src/OgreShaderProgramManager.cpp
@@ -70,7 +70,9 @@ void ProgramManager::releasePrograms(const ProgramSet* programSet)
         if(prg.use_count() > ResourceGroupManager::RESOURCE_SYSTEM_NUM_REFERENCE_COUNTS + 2)
             continue;
 
-        mShaderList.erase(std::find(mShaderList.begin(), mShaderList.end(), prg));
+	const auto it = std::find(mShaderList.begin(), mShaderList.end(), prg);
+        if(it != mShaderList.end())
+            mShaderList.erase(it);
         GpuProgramManager::getSingleton().remove(prg);
     }
 }


### PR DESCRIPTION
It seems to be possible that the result of std::find in this context is the 'end' iterator. So I added a check.