### PR TITLE
Main: correctly export typeinfo for Vector

### DIFF
--- a/OgreMain/include/OgrePrerequisites.h
+++ b/OgreMain/include/OgrePrerequisites.h
@@ -40,6 +40,13 @@ namespace Ogre {
 
     #define OGRE_MIN_VERSION(MAJOR, MINOR, PATCH) OGRE_VERSION >= ((MAJOR << 16) | (MINOR << 8) | PATCH)
 
+// OSX needs this correctly export typeinfo, however on MSVC there is huge fallout with it. Linux is fine either way.
+#if OGRE_COMPILER == OGRE_COMPILER_MSVC
+    #define _OgreMaybeExport
+#else
+    #define _OgreMaybeExport _OgreExport
+#endif
+
     // define the real number values to be used
     // default to use 'float' unless precompiler option set
     #if OGRE_DOUBLE_PRECISION == 1
@@ -239,7 +246,7 @@ namespace Ogre {
     class TransformKeyFrame;
     class Timer;
     class UserObjectBindings;
-    template <int dims, typename T> class Vector;
+    template <int dims, typename T> class _OgreMaybeExport Vector;
     typedef Vector<2, Real> Vector2;
     typedef Vector<2, int> Vector2i;
     typedef Vector<3, Real> Vector3;

--- a/OgreMain/include/OgreVector.h
+++ b/OgreMain/include/OgreVector.h
@@ -301,7 +301,7 @@ namespace Ogre
         you interpret the values.
     */
     template<int dims, typename T>
-    class Vector : public VectorBase<dims, T>
+    class _OgreMaybeExport Vector : public VectorBase<dims, T>
     {
     public:
         using VectorBase<dims, T>::ptr;

--- a/Tests/OgreMain/src/General.cpp
+++ b/Tests/OgreMain/src/General.cpp
@@ -549,13 +549,21 @@ TEST(Light, AnimationTrack)
 {
     Light l;
     l.setDiffuseColour(0, 0, 0);
+    l.setAttenuation(0, 0, 0, 0);
 
     Animation anim("test", 1.0);
-    auto track = anim.createNumericTrack(0, l.createAnimableValue("diffuseColour"));
-    track->createNumericKeyFrame(0)->setValue(ColourValue(1, 2, 3, 0));
-    track->createNumericKeyFrame(1)->setValue(ColourValue(2, 4, 6, 0));
+    auto diffuse = anim.createNumericTrack(0, l.createAnimableValue("diffuseColour"));
+    diffuse->createNumericKeyFrame(0)->setValue(ColourValue(1, 2, 3, 0));
+    diffuse->createNumericKeyFrame(1)->setValue(ColourValue(2, 4, 6, 0));
 
-    track->apply(0.5);
+    diffuse->apply(0.5);
 
     EXPECT_EQ(l.getDiffuseColour(), ColourValue(1.5, 3, 4.5));
+
+    auto attenuation = anim.createNumericTrack(1, l.createAnimableValue("attenuation"));
+    attenuation->createNumericKeyFrame(0)->setValue(Vector4(1, 2, 3, 4));
+    attenuation->createNumericKeyFrame(1)->setValue(Vector4(2, 4, 6, 8));
+
+    attenuation->apply(0.5);
+    EXPECT_EQ(l.getAttenuation(), Vector4f(1.5, 3, 4.5, 6));
 }


### PR DESCRIPTION
OSX seems particularly picky here