### PR TITLE
Implement a fallback for Ogre::Font::getGlyphInfo()

### DIFF
--- a/Components/Overlay/include/OgreFont.h
+++ b/Components/Overlay/include/OgreFont.h
@@ -255,7 +255,7 @@ namespace Ogre
                 if (i == mCodePointMap.end())
                 {
                     OGRE_EXCEPT(Exception::ERR_ITEM_NOT_FOUND, StringUtil::format(
-                        "Code point %d not found in font %s", id, mName.c_str()));
+                        "Code point %d and fallback 63 not found in font %s", id, mName.c_str()));
                 }
             }
             return i->second;

--- a/Components/Overlay/include/OgreFont.h
+++ b/Components/Overlay/include/OgreFont.h
@@ -249,8 +249,14 @@ namespace Ogre
             CodePointMap::const_iterator i = mCodePointMap.find(id);
             if (i == mCodePointMap.end())
             {
-                OGRE_EXCEPT(Exception::ERR_ITEM_NOT_FOUND,
-                            StringUtil::format("Code point %d not found in font %s", id, mName.c_str()));
+                // Try a fallback first.
+                i = mCodePointMap.find(static_cast<CodePoint>('?'));
+
+                if (i == mCodePointMap.end())
+                {
+                    OGRE_EXCEPT(Exception::ERR_ITEM_NOT_FOUND, StringUtil::format(
+                        "Code point %d not found in font %s", id, mName.c_str()));
+                }
             }
             return i->second;
         }


### PR DESCRIPTION
Issue:
Trying to display a non-ASCII symbol in the Overlay GUI results in an exception thrown from underneeth Ogre::Root::renderOneFrame().

Solution:
Make Ogre::Font::getGlyphInfo() return the information for the fallback '?' character when the requested character is missing from the font. Since the glyph information also contains the UV coordinates of the character, this change is enough to display question marks in place of characters missing from the font.