### PR TITLE
Remove "using namespace Ogre" from a header

### DIFF
--- a/RenderSystems/GLES2/include/EAGL/OgreEAGL2View.h
+++ b/RenderSystems/GLES2/include/EAGL/OgreEAGL2View.h
@@ -31,17 +31,15 @@ THE SOFTWARE.
 
 #include "OgreString.h"
 
-using namespace Ogre;
-
 #ifdef __OBJC__
 
 #import <UIKit/UIView.h>
 
 @interface EAGL2View : UIView {
-    String mWindowName;
+    Ogre::String mWindowName;
 }
 
-@property (nonatomic,assign) String mWindowName;
+@property (nonatomic,assign) Ogre::String mWindowName;
 
 @end
 


### PR DESCRIPTION
That directive was causing an ambiguous name lookup for name "Rect" on iOS.