### PR TITLE
Update SDL2 and Assimp to fix compiler erros with newest MinGW-w64

### DIFF
--- a/CMake/Dependencies.cmake
+++ b/CMake/Dependencies.cmake
@@ -113,16 +113,16 @@ if(OGRE_BUILD_DEPENDENCIES AND NOT EXISTS ${OGREDEPS_PATH})
     if(MSVC OR MINGW OR SKBUILD) # other platforms dont need this
         message(STATUS "Building SDL2")
         file(DOWNLOAD
-            https://libsdl.org/release/SDL2-2.0.22.tar.gz
-            ${PROJECT_BINARY_DIR}/SDL2-2.0.22.tar.gz)
+            https://libsdl.org/release/SDL2-2.24.1.tar.gz
+            ${PROJECT_BINARY_DIR}/SDL2-2.24.1.tar.gz)
         execute_process(COMMAND ${CMAKE_COMMAND} 
-            -E tar xf SDL2-2.0.22.tar.gz WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
+            -E tar xf SDL2-2.24.1.tar.gz WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
         execute_process(COMMAND ${CMAKE_COMMAND}
             -E make_directory ${PROJECT_BINARY_DIR}/SDL2-build)
         execute_process(COMMAND ${BUILD_COMMAND_COMMON}
             -DSDL_STATIC=FALSE
             -DCMAKE_INSTALL_LIBDIR=lib
-            ${PROJECT_BINARY_DIR}/SDL2-2.0.22
+            ${PROJECT_BINARY_DIR}/SDL2-2.24.1
             WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/SDL2-build)
         execute_process(COMMAND ${CMAKE_COMMAND}
             --build ${PROJECT_BINARY_DIR}/SDL2-build ${BUILD_COMMAND_OPTS})
@@ -145,10 +145,10 @@ if(OGRE_BUILD_DEPENDENCIES AND NOT EXISTS ${OGREDEPS_PATH})
 
       message(STATUS "Building Assimp")
       file(DOWNLOAD
-          https://github.com/assimp/assimp/archive/v5.2.4.tar.gz
-          ${PROJECT_BINARY_DIR}/v5.2.4.tar.gz)
+              https://github.com/assimp/assimp/archive/refs/tags/v5.2.5.zip
+          ${PROJECT_BINARY_DIR}/v5.2.5.tar.gz)
       execute_process(COMMAND ${CMAKE_COMMAND}
-          -E tar xf v5.2.4.tar.gz WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
+          -E tar xf v5.2.5.tar.gz WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
       execute_process(COMMAND ${BUILD_COMMAND_COMMON}
           -DZLIB_ROOT=${OGREDEPS_PATH}
           -DBUILD_SHARED_LIBS=OFF
@@ -156,10 +156,10 @@ if(OGRE_BUILD_DEPENDENCIES AND NOT EXISTS ${OGREDEPS_PATH})
           -DASSIMP_NO_EXPORT=TRUE
           -DASSIMP_BUILD_OGRE_IMPORTER=OFF
           -DASSIMP_BUILD_ASSIMP_TOOLS=OFF
-          ${PROJECT_BINARY_DIR}/assimp-5.2.4
-          WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/assimp-5.2.4)
+          ${PROJECT_BINARY_DIR}/assimp-5.2.5
+          WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/assimp-5.2.5)
       execute_process(COMMAND ${CMAKE_COMMAND}
-        --build ${PROJECT_BINARY_DIR}/assimp-5.2.4 ${BUILD_COMMAND_OPTS})
+        --build ${PROJECT_BINARY_DIR}/assimp-5.2.5 ${BUILD_COMMAND_OPTS})
     endif()
 
     message(STATUS "Building Bullet")


### PR DESCRIPTION
The currently used versions of SDL2 and Assimp do not compile with the newest version of MinGW-w64 (GCC 12.2+) from MSYS2. The issues where fixed in SDL2 2.24.1 and Assimp 5.2.5.

SDL2 issue:
https://github.com/libsdl-org/SDL/issues/5728
https://github.com/libsdl-org/SDL/commit/d2c4d74dd0302369251dce9375b49f394e54f76a

I can't find a ticket for Assimp but i get a lot of these errors, which disappear after updating to 5.2.5:
`ingw64/include/c++/12.2.0/bits/new_allocator.h:175:11: error: array subscript 'const aiVector3t<float>[1]' is partly outside array bounds of 'std::__cxx11::list<aiVector3t<float> > [1]' [-Werror=array-bounds]
  175 |         { ::new((void *)__p) _Up(std::forward<_Args>(__args)...); }`