### PR TITLE
ShadowRenderer: Fix useAfterFree bug when destroying shadow textures

### DIFF
--- a/OgreMain/src/OgreShadowRenderer.cpp
+++ b/OgreMain/src/OgreShadowRenderer.cpp
@@ -706,10 +706,12 @@ void SceneManager::ShadowRenderer::destroyShadowTextures(void)
     for (auto cam : mShadowTextureCameras)
     {
         mSceneManager->getRootSceneNode()->removeAndDestroyChild(cam->getParentSceneNode());
+
         // Always destroy camera since they are local to this SM
-        mSceneManager->destroyCamera(cam);
         if(auto cullcam = dynamic_cast<Camera*>(cam->getCullingFrustum()))
             mSceneManager->destroyCamera(cullcam);
+
+        mSceneManager->destroyCamera(cam);
     }
     mShadowTextures.clear();
     mShadowTextureCameras.clear();


### PR DESCRIPTION
In the method SceneManager::ShadowRenderer::destroyShadowTextures, the camera cam is destroyed and then cam->getCullingFrustrum() is called on the already destroyed object, which results in a crash if the memory at that location gets reused (or cleaned by gdb, which is how i found this bug).