### PR TITLE
GLSupport: fix requested version of GL context

### DIFF
--- a/RenderSystems/GLSupport/src/win32/OgreWin32GLSupport.cpp
+++ b/RenderSystems/GLSupport/src/win32/OgreWin32GLSupport.cpp
@@ -479,8 +479,16 @@ namespace Ogre {
             break;
         default:
             profile = WGL_CONTEXT_CORE_PROFILE_BIT_ARB;
-            majorVersion = std::max(glMajorMax, 3);
-            minorVersion = std::max(glMinorMax, 3); // 3.1 would be sufficient per spec, but we need 3.3 anyway..
+            if (glMajorMax > 3)
+            {
+                majorVersion = glMajorMax;
+                minorVersion = glMinorMax;
+            }
+            else
+            {
+                majorVersion = 3;
+                minorVersion = 3; // 3.1 would be sufficient per spec, but we need 3.3 anyway..
+            }
             break;
         }
 


### PR DESCRIPTION
Old code produced '4.3' for OpenGL 4.1 (_VMware 16.2.5_).

Regression from f9bf70d8e4b3c3d6e2cb6f9f2cacf98e8312d22c
