### PR TITLE
Minor: Adds missing OGRE_DEPRECATED modifier

### DIFF
--- a/OgreMain/include/OgreAnimationState.h
+++ b/OgreMain/include/OgreAnimationState.h
@@ -230,7 +230,7 @@ namespace Ogre {
         /** Get an iterator over all the animation states in this set.
         @deprecated use getAnimationStates()
         */
-        AnimationStateIterator getAnimationStateIterator(void);
+        OGRE_DEPRECATED AnimationStateIterator getAnimationStateIterator(void);
         /** Get an iterator over all the animation states in this set.
         @deprecated use getAnimationStates()
         */


### PR DESCRIPTION
The deprecated function `AnimationStateIterator getAnimationStateIterator(void);` is missing the OGRE_DEPRECATED modifier.