### PR TITLE
GLSupport: EGL - always derive new config on X11

### DIFF
--- a/RenderSystems/GLSupport/src/EGL/X11/OgreX11EGLWindow.cpp
+++ b/RenderSystems/GLSupport/src/EGL/X11/OgreX11EGLWindow.cpp
@@ -314,19 +314,6 @@ namespace Ogre {
 
         initNativeCreatedWindow(miscParams);
 
-        if (!mEglConfig && eglContext)
-        {
-            mEglConfig = mGLSupport->getGLConfigFromContext(eglContext);
-
-            if (!mEglConfig)
-            {
-                // This should never happen.
-                OGRE_EXCEPT(Exception::ERR_RENDERINGAPI_ERROR,
-                            "Unexpected failure to determine a EGLFBConfig",
-                            "EGLWindow::create");
-            }
-        }
-
         if (!mEglConfig)
         {
             int minAttribs[] = {


### PR DESCRIPTION
seems to be needed with MESA