### PR TITLE
Use all available processor cores to build dependencies

### DIFF
--- a/CMake/Dependencies.cmake
+++ b/CMake/Dependencies.cmake
@@ -52,7 +52,7 @@ ProcessorCount(NPROC)
 
 # can not get processor cores, fallback to default value
 if(NPROC EQUAL 0)
-    set(N 2)
+    set(NPROC 2)
 endif()
 
 set(BUILD_COMMAND_OPTS --target install -j ${NPROC} --config ${CMAKE_BUILD_TYPE})

--- a/CMake/Dependencies.cmake
+++ b/CMake/Dependencies.cmake
@@ -48,7 +48,7 @@ set(OGREDEPS_SHARED FALSE)
 
 # get available processor cores
 include(ProcessorCount)
-ProcessorCount(N)
+ProcessorCount(NPROC)
 
 # can not get processor cores, fallback to default value
 if(N EQUAL 0)

--- a/CMake/Dependencies.cmake
+++ b/CMake/Dependencies.cmake
@@ -51,7 +51,7 @@ include(ProcessorCount)
 ProcessorCount(NPROC)
 
 # can not get processor cores, fallback to default value
-if(N EQUAL 0)
+if(NPROC EQUAL 0)
     set(N 2)
 endif()
 

--- a/CMake/Dependencies.cmake
+++ b/CMake/Dependencies.cmake
@@ -46,7 +46,16 @@ endif()
 # if we build our own deps, do it static as it generally eases distribution
 set(OGREDEPS_SHARED FALSE)
 
-set(BUILD_COMMAND_OPTS --target install --config ${CMAKE_BUILD_TYPE})
+# get available processor cores
+include(ProcessorCount)
+ProcessorCount(N)
+
+# can not get processor cores, fallback to default value
+if(N EQUAL 0)
+    set(N 2)
+endif()
+
+set(BUILD_COMMAND_OPTS --target install -j ${N} --config ${CMAKE_BUILD_TYPE})
 
 set(BUILD_COMMAND_COMMON ${CMAKE_COMMAND}
   -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/CMake/Dependencies.cmake
+++ b/CMake/Dependencies.cmake
@@ -55,7 +55,7 @@ if(N EQUAL 0)
     set(N 2)
 endif()
 
-set(BUILD_COMMAND_OPTS --target install -j ${N} --config ${CMAKE_BUILD_TYPE})
+set(BUILD_COMMAND_OPTS --target install -j ${NPROC} --config ${CMAKE_BUILD_TYPE})
 
 set(BUILD_COMMAND_COMMON ${CMAKE_COMMAND}
   -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}


### PR DESCRIPTION
Building dependencies like SDK2 and assimp currently takes an unnecessary long time, because they do not use all available processor cores. With this patch, the number of available cores is automatically detected and passed to the dependency CMake scripts. This makes the build process about 2-3 times faster on my 12 Core processor when using MinGW-w64.