### PR TITLE
Avoid CTest timeout for RISC-V

### DIFF
--- a/Tests/VisualTests/CMakeLists.txt
+++ b/Tests/VisualTests/CMakeLists.txt
@@ -81,6 +81,9 @@ function (TestRenderSystem render_system)
     "-P" # the script that carries this out
       "RunVTests.cmake")
       
+  # Set a longer timeout to avoid timeouts on the riscv hardware
+  set_tests_properties("TestContext_${render_system_nospace}" PROPERTIES TIMEOUT 4500)
+
 endfunction (TestRenderSystem)
 
 # Run the tests once for each rendersystem


### PR DESCRIPTION
I get the following error when I build ogre for  Arch Linux RISC-V:
```
ninja: Entering directory `build'
[0/1] Running tests...
Test project /build/ogre/src/ogre-13.5.3/build
    Start 1: TestContext_OpenGLRenderingSubsystem
1/2 Test #1: TestContext_OpenGLRenderingSubsystem ........***Timeout 1500.09 sec
    Start 2: TestContext_OpenGLES2.xRenderingSubsystem
2/2 Test #2: TestContext_OpenGLES2.xRenderingSubsystem ...   Passed  876.72 sec

50% tests passed, 1 tests failed out of 2

Total Test time (real) = 2376.84 sec

The following tests FAILED:
	  1 - TestContext_OpenGLRenderingSubsystem (Timeout)
Errors while running CTest
```

It takes about 3000s to pass `TestContext_OpenGLRenderingSubsystem` on a HiFive Unmatched board. Passed the test and built successfully after extending the timeout.
```
ninja: Entering directory `build'
[0/1] Running tests...
Test project /build/ogre/src/ogre-13.5.3/build
    Start 1: TestContext_OpenGLRenderingSubsystem
1/2 Test #1: TestContext_OpenGLRenderingSubsystem ........   Passed  2977.31 sec
    Start 2: TestContext_OpenGLES2.xRenderingSubsystem
2/2 Test #2: TestContext_OpenGLES2.xRenderingSubsystem ...   Passed  1072.69 sec

100% tests passed, 0 tests failed out of 2

Total Test time (real) = 4050.01 sec
```