### PR TITLE
D3D9: fall back to SO_GOURAUD for SO_PHONG

### DIFF
--- a/RenderSystems/Direct3D9/src/OgreD3D9Mappings.cpp
+++ b/RenderSystems/Direct3D9/src/OgreD3D9Mappings.cpp
@@ -42,10 +42,11 @@ namespace Ogre
         {
         case SO_FLAT:
             return D3DSHADE_FLAT;
+        case SO_PHONG:
+            // phong is not supported in D3D9
+            OGRE_FALLTHROUGH;
         case SO_GOURAUD:
             return D3DSHADE_GOURAUD;
-        case SO_PHONG:
-            return D3DSHADE_PHONG;
         }
         return 0;
     }


### PR DESCRIPTION
as most D3D9 implementations do anyway