### PR TITLE
[GL]mCurrentContext is null

### DIFF
--- a/RenderSystems/GL/src/OgreGLRenderSystem.cpp
+++ b/RenderSystems/GL/src/OgreGLRenderSystem.cpp
@@ -2652,7 +2652,7 @@ namespace Ogre {
 
         // Disable textures
         _disableTextureUnitsFrom(0);
-	    
+
         // It's ready for switching
         if (mCurrentContext!=context)
         {

--- a/RenderSystems/GL/src/OgreGLRenderSystem.cpp
+++ b/RenderSystems/GL/src/OgreGLRenderSystem.cpp
@@ -2660,18 +2660,23 @@ namespace Ogre {
             // NSGLContext::makeCurrentContext does not flush automatically. everybody else does.
             glFlushRenderAPPLE();
 #endif
-            mCurrentContext->endCurrent();
+	    if (mCurrentContext)
+                mCurrentContext->endCurrent();
             mCurrentContext = context;
         }
-        mCurrentContext->setCurrent();
-
-        mStateCacheManager = mCurrentContext->createOrRetrieveStateCacheManager<GLStateCacheManager>();
-
-        // Check if the context has already done one-time initialisation
-        if(!mCurrentContext->getInitialized())
+	    
+        if (mCurrentContext)
         {
-            _oneTimeContextInitialization();
-            mCurrentContext->setInitialized();
+            mCurrentContext->setCurrent();
+
+            mStateCacheManager = mCurrentContext->createOrRetrieveStateCacheManager<GLStateCacheManager>();
+
+            // Check if the context has already done one-time initialisation
+            if(!mCurrentContext->getInitialized())
+            {
+                _oneTimeContextInitialization();
+                mCurrentContext->setInitialized();
+            }
         }
 
         // Rebind GPU programs to new context

--- a/RenderSystems/GL/src/OgreGLRenderSystem.cpp
+++ b/RenderSystems/GL/src/OgreGLRenderSystem.cpp
@@ -2652,7 +2652,7 @@ namespace Ogre {
 
         // Disable textures
         _disableTextureUnitsFrom(0);
-
+	    
         // It's ready for switching
         if (mCurrentContext!=context)
         {
@@ -2660,11 +2660,11 @@ namespace Ogre {
             // NSGLContext::makeCurrentContext does not flush automatically. everybody else does.
             glFlushRenderAPPLE();
 #endif
-	    if (mCurrentContext)
+            if (mCurrentContext)
                 mCurrentContext->endCurrent();
             mCurrentContext = context;
         }
-	    
+
         if (mCurrentContext)
         {
             mCurrentContext->setCurrent();


### PR DESCRIPTION
Corrects the use of the mCurrentContext pointer when it points to null.  
—————————————
Corrige l'utilisation du pointeur mCurrentContext alors qu'il pointe sur nul.


See:
https://forums.ogre3d.org/viewtopic.php?p=554471#p554471