### PR TITLE
Fix the function override problem under osx

### DIFF
--- a/PlugIns/EXRCodec/src/O_IStream.cpp
+++ b/PlugIns/EXRCodec/src/O_IStream.cpp
@@ -39,11 +39,11 @@ bool O_IStream::read(char c[], int n) {
     return _stream.eof();
 }
 
-Int64 O_IStream::tellg() {
+uint64_t O_IStream::tellg() {
     return _stream.getCurrentPtr() - _stream.getPtr();
 }
 
-void O_IStream::seekg(Int64 pos) {
+void O_IStream::seekg(uint64_t pos) {
     _stream.seek(pos);
 }
 

--- a/PlugIns/EXRCodec/src/O_IStream.h
+++ b/PlugIns/EXRCodec/src/O_IStream.h
@@ -46,8 +46,8 @@ public:
         IStream (file_name), _stream(stream) {}
 
     bool    read (char c[], int n) override;
-    Imf::Int64   tellg () override;
-    void    seekg (Imf::Int64 pos) override;
+    uint64_t   tellg () override;
+    void    seekg (uint64_t pos) override;
     void    clear () override;
 
 private:


### PR DESCRIPTION
Fix the following issue to keep the return value and parameter types of the override function and the inherited function consistent.

```
/Users/vcpkg/Jim/vcpkg/buildtrees/ogre/src/v13.6.2-57c75b3e04/PlugIns/EXRCodec/src/O_IStream.cpp:42:18: error: return type of out-of-line definition of 'Ogre::O_IStream::tellg' differs from that in the declaration
Int64 O_IStream::tellg() {
~~~~~            ^
/Users/vcpkg/Jim/vcpkg/buildtrees/ogre/src/v13.6.2-57c75b3e04/PlugIns/EXRCodec/src/O_IStream.h:49:16: note: previous declaration is here
    uint64_t   tellg () override;
    ~~~~~~~~   ^
/Users/vcpkg/Jim/vcpkg/buildtrees/ogre/src/v13.6.2-57c75b3e04/PlugIns/EXRCodec/src/O_IStream.cpp:46:17: error: out-of-line definition of 'seekg' does not match any declaration in 'Ogre::O_IStream'
void O_IStream::seekg(Int64 pos) {
                ^~~~~
2 errors generated.
```