### PR TITLE
Update project.gradle

### DIFF
--- a/CMake/Templates/project.gradle
+++ b/CMake/Templates/project.gradle
@@ -5,7 +5,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.1'
+        classpath 'com.android.tools.build:gradle:7.3.3'
     }
 }
 


### PR DESCRIPTION
It fixes the following issue:

#19360 Upgrade checks to Log4j 2.17.0
Issues fixed in second patch release:

#19300 Mitigations for log4j vulnerability in Gradle builds #19257 Incremental java compilation fails when renaming classname with $ character Issues fixed in first patch release:

#19058 Consider reverting breaking change about test configuration #19067 Fix multiple annotation processing issues discovered by Micronaut