### PR TITLE
MOT_* strings for all MovableObjects

### DIFF
--- a/OgreMain/include/OgreCamera.h
+++ b/OgreMain/include/OgreCamera.h
@@ -131,9 +131,6 @@ namespace Ogre {
         /// Stored number of visible batches in the last render
         unsigned int mVisBatchesLastRender;
 
-        /// Shared class-level name for Movable type
-        static String msMovableType;
-
 #ifdef OGRE_NODELESS_POSITIONING
         /// Real world orientation/position of the camera
         mutable Quaternion mRealOrientation;

--- a/OgreMain/include/OgreFrustum.h
+++ b/OgreMain/include/OgreFrustum.h
@@ -139,9 +139,6 @@ namespace Ogre
         /// Signal to update view information.
         virtual void invalidateView(void) const;
 
-        /// Shared class-level name for Movable type
-        static String msMovableType;
-
         ColourValue mDebugColour;
         /// Pointer to a reflection plane (automatically updated)
         const MovablePlane* mLinkedReflectPlane;

--- a/OgreMain/include/OgreLight.h
+++ b/OgreMain/include/OgreLight.h
@@ -593,9 +593,6 @@ namespace Ogre {
 
         Camera* mCameraToBeRelativeTo;
 
-        /// Shared class-level name for Movable type.
-        static String msMovableType;
-
         mutable PlaneBoundedVolume mNearClipVolume;
         mutable PlaneBoundedVolumeList mFrustumClipVolumes;
 

--- a/OgreMain/include/OgreMovablePlane.h
+++ b/OgreMain/include/OgreMovablePlane.h
@@ -58,7 +58,6 @@ namespace Ogre {
         mutable Vector3 mLastTranslate;
         mutable Quaternion mLastRotate;
         mutable bool mDirty;
-        static String msMovableType;
     public:
 
         MovablePlane(const String& name);

--- a/OgreMain/include/OgrePrerequisites.h
+++ b/OgreMain/include/OgrePrerequisites.h
@@ -331,6 +331,12 @@ namespace Ogre
     _OgreExport extern const String MOT_RIBBON_TRAIL;
     _OgreExport extern const String MOT_RECTANGLE2D;
     _OgreExport extern const String MOT_STATIC_GEOMETRY;
+    _OgreExport extern const String MOT_CAMERA;
+    _OgreExport extern const String MOT_FRUSTRUM;
+    _OgreExport extern const String MOT_MOVABLE_PLANE;
+    _OgreExport extern const String MOT_INSTANCE_BATCH;
+    _OgreExport extern const String MOT_INSTANCED_ENTITY;
+    _OgreExport extern const String MOT_SIMPLE_RENDERABLE;
 }
 
 #endif // __OgrePrerequisites_H__

--- a/OgreMain/src/OgreCamera.cpp
+++ b/OgreMain/src/OgreCamera.cpp
@@ -32,7 +32,7 @@ THE SOFTWARE.
 
 namespace Ogre {
 
-    String Camera::msMovableType = "Camera";
+    const String MOT_CAMERA = "Camera";
     //-----------------------------------------------------------------------
     Camera::Camera( const String& name, SceneManager* sm)
         : Frustum(name),
@@ -648,7 +648,7 @@ namespace Ogre {
     //-----------------------------------------------------------------------
     const String& Camera::getMovableType(void) const
     {
-        return msMovableType;
+        return MOT_CAMERA;
     }
     //-----------------------------------------------------------------------
     void Camera::setLodBias(Real factor)

--- a/OgreMain/src/OgreFrustum.cpp
+++ b/OgreMain/src/OgreFrustum.cpp
@@ -31,7 +31,7 @@ THE SOFTWARE.
 
 namespace Ogre {
 
-    String Frustum::msMovableType = "Frustum";
+    const String MOT_FRUSTRUM = "Frustum";
     const Real Frustum::INFINITE_FAR_PLANE_ADJUST = 0.00001;
     //-----------------------------------------------------------------------
     Frustum::Frustum(const String& name) : 
@@ -734,7 +734,7 @@ namespace Ogre {
     //-----------------------------------------------------------------------
     const String& Frustum::getMovableType(void) const
     {
-        return msMovableType;
+        return MOT_FRUSTRUM;
     }
     //-----------------------------------------------------------------------
     Real Frustum::getBoundingRadius(void) const

--- a/OgreMain/src/OgreInstanceBatch.cpp
+++ b/OgreMain/src/OgreInstanceBatch.cpp
@@ -34,6 +34,8 @@ THE SOFTWARE.
 
 namespace Ogre
 {
+    const String MOT_INSTANCE_BATCH = "InstanceBatch";
+
     InstanceBatch::InstanceBatch( InstanceManager *creator, MeshPtr &meshReference,
                                     const MaterialPtr &material, size_t instancesPerBatch,
                                     const Mesh::IndexMap *indexToBoneMap, const String &batchName ) :
@@ -428,8 +430,7 @@ namespace Ogre
     //-----------------------------------------------------------------------
     const String& InstanceBatch::getMovableType(void) const
     {
-        static String sType = "InstanceBatch";
-        return sType;
+        return MOT_INSTANCE_BATCH;
     }
     //-----------------------------------------------------------------------
     void InstanceBatch::_notifyCurrentCamera( Camera* cam )

--- a/OgreMain/src/OgreInstancedEntity.cpp
+++ b/OgreMain/src/OgreInstancedEntity.cpp
@@ -35,6 +35,8 @@ THE SOFTWARE.
 
 namespace Ogre
 {
+    const String MOT_INSTANCED_ENTITY = "InstancedEntity";
+
     NameGenerator InstancedEntity::msNameGenerator("");
 
     InstancedEntity::InstancedEntity( InstanceBatch *batchOwner, uint32 instanceID, InstancedEntity* sharedTransformEntity ) :
@@ -150,8 +152,7 @@ namespace Ogre
     //-----------------------------------------------------------------------
     const String& InstancedEntity::getMovableType(void) const
     {
-        static String sType = "InstancedEntity";
-        return sType;
+        return MOT_INSTANCED_ENTITY;
     }
     //-----------------------------------------------------------------------
     size_t InstancedEntity::getTransforms( Matrix4 *xform ) const

--- a/OgreMain/src/OgreMovablePlane.cpp
+++ b/OgreMain/src/OgreMovablePlane.cpp
@@ -30,7 +30,7 @@ THE SOFTWARE.
 
 namespace Ogre {
 
-    String MovablePlane::msMovableType = "MovablePlane";
+    const String MOT_MOVABLE_PLANE = "MovablePlane";
     //-----------------------------------------------------------------------
     //-----------------------------------------------------------------------
     MovablePlane::MovablePlane(const String& name) : Plane(), MovableObject(name),
@@ -96,6 +96,6 @@ namespace Ogre {
     //-----------------------------------------------------------------------
     const String& MovablePlane::getMovableType(void) const
     {
-        return msMovableType;
+        return MOT_MOVABLE_PLANE;
     }
 }

--- a/OgreMain/src/OgreSceneManager.cpp
+++ b/OgreMain/src/OgreSceneManager.cpp
@@ -3214,7 +3214,7 @@ MovableObject* SceneManager::createMovableObject(const String& name,
     const String& typeName, const NameValuePairList* params)
 {
     // Nasty hack to make generalised Camera functions work without breaking add-on SMs
-    if (typeName == "Camera")
+    if (typeName == MOT_CAMERA)
     {
         return createCamera(name);
     }
@@ -3250,7 +3250,7 @@ MovableObject* SceneManager::createMovableObject(const String& typeName, const N
 void SceneManager::destroyMovableObject(const String& name, const String& typeName)
 {
     // Nasty hack to make generalised Camera functions work without breaking add-on SMs
-    if (typeName == "Camera")
+    if (typeName == MOT_CAMERA)
     {
         destroyCamera(name);
         return;
@@ -3274,7 +3274,7 @@ void SceneManager::destroyMovableObject(const String& name, const String& typeNa
 void SceneManager::destroyAllMovableObjectsByType(const String& typeName)
 {
     // Nasty hack to make generalised Camera functions work without breaking add-on SMs
-    if (typeName == "Camera")
+    if (typeName == MOT_CAMERA)
     {
         destroyAllCameras();
         return;
@@ -3328,7 +3328,7 @@ void SceneManager::destroyAllMovableObjects(void)
 MovableObject* SceneManager::getMovableObject(const String& name, const String& typeName) const
 {
     // Nasty hack to make generalised Camera functions work without breaking add-on SMs
-    if (typeName == "Camera")
+    if (typeName == MOT_CAMERA)
     {
         return getCamera(name);
     }
@@ -3352,7 +3352,7 @@ MovableObject* SceneManager::getMovableObject(const String& name, const String& 
 bool SceneManager::hasMovableObject(const String& name, const String& typeName) const
 {
     // Nasty hack to make generalised Camera functions work without breaking add-on SMs
-    if (typeName == "Camera")
+    if (typeName == MOT_CAMERA)
     {
         return hasCamera(name);
     }

--- a/OgreMain/src/OgreSimpleRenderable.cpp
+++ b/OgreMain/src/OgreSimpleRenderable.cpp
@@ -30,6 +30,8 @@ THE SOFTWARE.
 
 namespace Ogre {
 
+    const String MOT_SIMPLE_RENDERABLE = "SimpleRenderable";
+
     uint SimpleRenderable::msGenNameCount = 0;
 
     SimpleRenderable::SimpleRenderable() : SimpleRenderable(BLANKSTRING)
@@ -109,8 +111,7 @@ namespace Ogre {
     //-----------------------------------------------------------------------
     const String& SimpleRenderable::getMovableType(void) const
     {
-        static String movType = "SimpleRenderable";
-        return movType;
+        return MOT_SIMPLE_RENDERABLE;
     }
     //-----------------------------------------------------------------------
     const LightList& SimpleRenderable::getLights(void) const

--- a/OgreMain/src/OgreStaticGeometry.cpp
+++ b/OgreMain/src/OgreStaticGeometry.cpp
@@ -791,8 +791,7 @@ namespace Ogre {
     //--------------------------------------------------------------------------
     const String& StaticGeometry::Region::getMovableType(void) const
     {
-        static String sType = "StaticGeometry";
-        return sType;
+        return MOT_STATIC_GEOMETRY;
     }
     //--------------------------------------------------------------------------
     void StaticGeometry::Region::_notifyCurrentCamera(Camera* cam)

--- a/OgreMain/src/OgreStaticGeometry.cpp
+++ b/OgreMain/src/OgreStaticGeometry.cpp
@@ -498,7 +498,7 @@ namespace Ogre {
 
         for (auto mobj : node->getAttachedObjects())
         {
-            if (mobj->getMovableType() == "Entity")
+            if (mobj->getMovableType() == MOT_ENTITY)
             {
                 addEntity(static_cast<Entity*>(mobj),
                     node->_getDerivedPosition(),

--- a/PlugIns/OctreeSceneManager/src/OgreOctreeSceneQuery.cpp
+++ b/PlugIns/OctreeSceneManager/src/OgreOctreeSceneQuery.cpp
@@ -90,7 +90,7 @@ void OctreeIntersectionSceneQuery::execute(IntersectionSceneQueryListener* liste
                     {
                         listener -> queryResult( e, m );
                         // deal with attached objects, since they are not directly attached to nodes
-                        if (m->getMovableType() == "Entity")
+                        if (m->getMovableType() == MOT_ENTITY)
                         {
                             Entity* e2 = static_cast<Entity*>(m);
                             for(auto c : e2->getAttachedObjects())
@@ -141,7 +141,7 @@ void OctreeAxisAlignedBoxSceneQuery::execute(SceneQueryListener* listener)
             {
                 listener -> queryResult( m );
                 // deal with attached objects, since they are not directly attached to nodes
-                if (m->getMovableType() == "Entity")
+                if (m->getMovableType() == MOT_ENTITY)
                 {
                     Entity* e = static_cast<Entity*>(m);
                     for (auto c : e->getAttachedObjects())
@@ -190,7 +190,7 @@ void OctreeRaySceneQuery::execute(RaySceneQueryListener* listener)
                 {
                     listener -> queryResult( m, result.second );
                     // deal with attached objects, since they are not directly attached to nodes
-                    if (m->getMovableType() == "Entity")
+                    if (m->getMovableType() == MOT_ENTITY)
                     {
                         Entity* e = static_cast<Entity*>(m);
                         for(auto c : e->getAttachedObjects())
@@ -243,7 +243,7 @@ void OctreeSphereSceneQuery::execute(SceneQueryListener* listener)
             {
                 listener -> queryResult( m );
                 // deal with attached objects, since they are not directly attached to nodes
-                if (m->getMovableType() == "Entity")
+                if (m->getMovableType() == MOT_ENTITY)
                 {
                     Entity* e = static_cast<Entity*>(m);
                     for(auto c : e->getAttachedObjects())
@@ -301,7 +301,7 @@ void OctreePlaneBoundedVolumeListSceneQuery::execute(SceneQueryListener* listene
                 {
                     listener -> queryResult( m );
                     // deal with attached objects, since they are not directly attached to nodes
-                    if (m->getMovableType() == "Entity")
+                    if (m->getMovableType() == MOT_ENTITY)
                     {
                         Entity* e = static_cast<Entity*>(m);
                         for(auto c : e->getAttachedObjects())

--- a/PlugIns/PCZSceneManager/src/OgrePCZSceneQuery.cpp
+++ b/PlugIns/PCZSceneManager/src/OgrePCZSceneQuery.cpp
@@ -88,7 +88,7 @@ namespace Ogre
                         {
                             listener -> queryResult( e, m );
                             // deal with attached objects, since they are not directly attached to nodes
-                            if (m->getMovableType() == "Entity")
+                            if (m->getMovableType() == MOT_ENTITY)
                             {
                                 Entity* e2 = static_cast<Entity*>(m);
                                 for (auto c : e2->getAttachedObjects())
@@ -140,7 +140,7 @@ namespace Ogre
                 {
                     listener -> queryResult( m );
                     // deal with attached objects, since they are not directly attached to nodes
-                    if (m->getMovableType() == "Entity")
+                    if (m->getMovableType() == MOT_ENTITY)
                     {
                         Entity* e = static_cast<Entity*>(m);
                         for (auto c : e->getAttachedObjects())
@@ -192,7 +192,7 @@ namespace Ogre
                     {
                         listener -> queryResult( m, result.second );
                         // deal with attached objects, since they are not directly attached to nodes
-                        if (m->getMovableType() == "Entity")
+                        if (m->getMovableType() == MOT_ENTITY)
                         {
                             Entity* e = static_cast<Entity*>(m);
                             for (auto c : e->getAttachedObjects())
@@ -248,7 +248,7 @@ namespace Ogre
                 {
                     listener -> queryResult( m );
                     // deal with attached objects, since they are not directly attached to nodes
-                    if (m->getMovableType() == "Entity")
+                    if (m->getMovableType() == MOT_ENTITY)
                     {
                         Entity* e = static_cast<Entity*>(m);
                         for (auto c : e->getAttachedObjects())
@@ -309,7 +309,7 @@ namespace Ogre
                     {
                         listener -> queryResult( m );
                         // deal with attached objects, since they are not directly attached to nodes
-                        if (m->getMovableType() == "Entity")
+                        if (m->getMovableType() == MOT_ENTITY)
                         {
                             Entity* e = static_cast<Entity*>(m);
                             for (auto c : e->getAttachedObjects())

--- a/Samples/ShaderSystem/src/ShaderSystem.cpp
+++ b/Samples/ShaderSystem/src/ShaderSystem.cpp
@@ -976,7 +976,7 @@ void Sample_ShaderSystem::updateTargetObjInfo()
 
     String targetObjMaterialName;
 
-    if (mTargetObj->getMovableType() == "Entity")
+    if (mTargetObj->getMovableType() == MOT_ENTITY)
     {
         Entity* targetEnt = static_cast<Entity*>(mTargetObj);
         targetObjMaterialName = targetEnt->getSubEntity(0)->getMaterialName();


### PR DESCRIPTION
Fixes [this issue](https://forums.ogre3d.org/viewtopic.php?t=96994) for a couple more MovableObjects. Also uses the MOT_* constants instead of comparing against literals.