### PR TITLE
DefaultDebugDrawer: transform bones and set axes size

### DIFF
--- a/OgreMain/include/OgreDefaultDebugDrawer.h
+++ b/OgreMain/include/OgreDefaultDebugDrawer.h
@@ -16,6 +16,7 @@ class _OgreExport DefaultDebugDrawer : public DebugDrawer
     ManualObject mAxes;
     int mDrawType;
     bool mStatic;
+    float mBoneAxesSize;
     void preFindVisibleObjects(SceneManager* source, SceneManager::IlluminationRenderStage irs, Viewport* v) override;
     void postFindVisibleObjects(SceneManager* source, SceneManager::IlluminationRenderStage irs, Viewport* v) override;
     void beginLines();
@@ -38,6 +39,8 @@ public:
     void drawWireBox(const AxisAlignedBox& aabb, const ColourValue& colour = ColourValue::White);
     /// draw coordinate axes
     void drawAxes(const Affine3& pose, float size = 1.0f);
+    /// Specifes the size of the axes drawn by drawBone()
+    void setBoneAxesSize(float size);
 };
 
 } /* namespace Ogre */

--- a/OgreMain/include/OgreDefaultDebugDrawer.h
+++ b/OgreMain/include/OgreDefaultDebugDrawer.h
@@ -31,7 +31,7 @@ public:
     /// if static, the drawer contents are preserved across frames. They are cleared otherwise.
     void setStatic(bool enable) { mStatic = enable; }
 
-    void drawBone(const Node* node) override;
+    void drawBone(const Node* node, const Affine3 & transform = Affine3::IDENTITY) override;
     void drawSceneNode(const SceneNode* node) override;
     void drawFrustum(const Frustum* frust) override;
     /// Allows the rendering of a wireframe bounding box.

--- a/OgreMain/include/OgreSceneManager.h
+++ b/OgreMain/include/OgreSceneManager.h
@@ -3306,7 +3306,7 @@ namespace Ogre {
     public:
         virtual ~DebugDrawer() {}
         virtual void drawSceneNode(const SceneNode* node) = 0;
-        virtual void drawBone(const Node* node) = 0;
+        virtual void drawBone(const Node* node, const Affine3 & transform = Affine3::IDENTITY) = 0;
         virtual void drawFrustum(const Frustum* frust) = 0;
     };
 

--- a/OgreMain/src/OgreDefaultDebugDrawer.cpp
+++ b/OgreMain/src/OgreDefaultDebugDrawer.cpp
@@ -8,7 +8,7 @@
 namespace Ogre
 {
 
-DefaultDebugDrawer::DefaultDebugDrawer() : mLines(""), mAxes(""), mDrawType(0), mStatic(false) {}
+DefaultDebugDrawer::DefaultDebugDrawer() : mLines(""), mAxes(""), mDrawType(0), mStatic(false), mBoneAxesSize(1.0f) {}
 
 void DefaultDebugDrawer::preFindVisibleObjects(SceneManager* source,
                                                SceneManager::IlluminationRenderStage irs, Viewport* v)
@@ -141,9 +141,13 @@ void DefaultDebugDrawer::drawAxes(const Affine3& pose, float size)
         mAxes.triangle(base + 4, base + 5, base + 6);
     }
 }
+void DefaultDebugDrawer::setBoneAxesSize(float size)
+{
+    mBoneAxesSize = size;
+}
 void DefaultDebugDrawer::drawBone(const Node* node, const Affine3 & transform)
 {
-    drawAxes(transform * node->_getFullTransform());
+    drawAxes(transform * node->_getFullTransform(), mBoneAxesSize);
 }
 void DefaultDebugDrawer::drawSceneNode(const SceneNode* node)
 {

--- a/OgreMain/src/OgreDefaultDebugDrawer.cpp
+++ b/OgreMain/src/OgreDefaultDebugDrawer.cpp
@@ -141,9 +141,9 @@ void DefaultDebugDrawer::drawAxes(const Affine3& pose, float size)
         mAxes.triangle(base + 4, base + 5, base + 6);
     }
 }
-void DefaultDebugDrawer::drawBone(const Node* node)
+void DefaultDebugDrawer::drawBone(const Node* node, const Affine3 & transform)
 {
-    drawAxes(node->_getFullTransform());
+    drawAxes(transform * node->_getFullTransform());
 }
 void DefaultDebugDrawer::drawSceneNode(const SceneNode* node)
 {

--- a/OgreMain/src/OgreEntity.cpp
+++ b/OgreMain/src/OgreEntity.cpp
@@ -681,13 +681,11 @@ namespace Ogre {
         }
 
         // HACK to display bones
-        // This won't work if the entity is not centered at the origin
-        // TODO work out a way to allow bones to be rendered when Entity not centered
         if (mDisplaySkeleton && hasSkeleton() && mManager && mManager->getDebugDrawer())
         {
             for (Bone* bone : mSkeletonInstance->getBones())
             {
-                mManager->getDebugDrawer()->drawBone(bone);
+                mManager->getDebugDrawer()->drawBone(bone, mParentNode->_getFullTransform());
             }
         }
     }


### PR DESCRIPTION
I needed this for my project. It seems to work and thought it might be useful for others. However…

The docs say that Node::_getFullTransform() “should only be called by a SceneManager which knows the derived transforms have been updated before calling this method.” I do not know if that is the case when Entity::_updateRenderQueue() is called. Please advise.

The DefaultDebugDrawer::drawAxes() size parameter could come from DefaultDebugDrawer or from Entity. Rather than add a debug data member to every Entity I thought it better to have it in just the DefaultDebugDrawer. However that means to set the value, we either have to change SceneManager’s interface, or just cast the return of SceneManager::getDebugDrawer() to a DefaultDebugDrawer *, which is what I’m doing.

Not sure about my design decisions. Open to feedback.
