### PR TITLE
Update swig into Dependencies.cmake

### DIFF
--- a/CMake/Dependencies.cmake
+++ b/CMake/Dependencies.cmake
@@ -274,7 +274,7 @@ find_package(PythonLibs)
 macro_log_feature(PYTHONLIBS_FOUND "Python" "Language bindings to use OGRE from Python" "http://www.python.org/")
 
 # SWIG
-find_package(SWIG 3.0.8 QUIET)
+find_package(SWIG 3.0.12 QUIET)
 macro_log_feature(SWIG_FOUND "SWIG" "Language bindings (Python, Java, C#) for OGRE" "http://www.swig.org/")
 
 # pugixml


### PR DESCRIPTION
update minor swig version.
fixSWIG-3.0.12 summary:

Enhance %extend to support template functions.
Language specific enhancements and fixes for C#, D, Guile, Java, PHP7. 2016/12/29 - SWIG-3.0.11 released
SWIG-3.0.11 summary:
- PHP 7 support added.
- C++11 alias templates and type aliasing support added.
- Minor fixes and enhancements for C# Go Guile Java Javascript Octave PHP Python R Ruby Scilab XML.

2016/06/12 - SWIG-3.0.10 released
This release fixes a couple of important regressions in SWIG-3.0.9 for smart pointers and importing Python modules.

2016/05/29 - SWIG-3.0.9 released
Summary of changes in SWIG-3.0.9

Add support for Python's implicit namespace packages. Fixes to support Go 1.6.
C++11 std::array support added for Java.
Improved C++ multiple inheritance support for Java/C# wrappers. Various other minor fixes and improvements for C#, D, Go, Java, Javascript, Lua, Python, R, Ruby, Scilab.