### PR TITLE
Main: NodeAnimationTrack - add setUseLocalTranslation

### DIFF
--- a/OgreMain/include/OgreAnimationTrack.h
+++ b/OgreMain/include/OgreAnimationTrack.h
@@ -34,6 +34,7 @@ THE SOFTWARE.
 #include "OgreSimpleSpline.h"
 #include "OgreRotationalSpline.h"
 #include "OgrePose.h"
+#include "OgreNode.h"
 
 namespace Ogre 
 {
@@ -339,6 +340,13 @@ namespace Ogre
         /** Gets the method of rotation calculation */
         virtual bool getUseShortestRotationPath() const;
 
+        /** Sets whether this track's translations are relative to local space.
+            Default is false, meaning translations are relative to the parent node's space. */
+        virtual void setUseLocalTranslation(bool useLocal);
+
+        /** Gets whether this track's translations are relative to local space. */
+        virtual bool getUseLocalTranslation() const;
+
         /// @copydoc AnimationTrack::getInterpolatedKeyFrame
         void getInterpolatedKeyFrame(const TimeIndex& timeIndex, KeyFrame* kf) const override;
 
@@ -383,6 +391,8 @@ namespace Ogre
         mutable bool mSplineBuildNeeded;
         /// Defines if rotation is done using shortest path
         mutable bool mUseShortestRotationPath;
+        /// Which space our translations are relative to.
+        Node::TransformSpace mTranslationSpace;
         Node* mTargetNode;
         // Prebuilt splines, must be mutable since lazy-update in const method
         mutable Splines* mSplines;

--- a/OgreMain/src/OgreAnimationTrack.cpp
+++ b/OgreMain/src/OgreAnimationTrack.cpp
@@ -364,8 +364,7 @@ namespace Ogre {
     //---------------------------------------------------------------------
     NodeAnimationTrack::NodeAnimationTrack(Animation* parent, unsigned short handle, Node* targetNode)
         : AnimationTrack(parent, handle), mSplineBuildNeeded(false), mUseShortestRotationPath(true),
-          mTargetNode(targetNode), mSplines(0)
-
+          mTranslationSpace(Node::TS_PARENT), mTargetNode(targetNode), mSplines(0)
     {
     }
     //---------------------------------------------------------------------
@@ -486,7 +485,7 @@ namespace Ogre {
 
         // add to existing. Weights are not relative, but treated as absolute multipliers for the animation
         Vector3 translate = kf.getTranslate() * weight * scl;
-        node->translate(translate);
+        node->translate(translate, mTranslationSpace);
 
         // interpolate between no-rotation and full rotation, to point 'weight', so 0 = no rotate, 1 = full
         Quaternion rotate;
@@ -564,6 +563,17 @@ namespace Ogre {
     bool NodeAnimationTrack::getUseShortestRotationPath() const
     {
         return mUseShortestRotationPath ;
+    }
+    //---------------------------------------------------------------------
+    void NodeAnimationTrack::setUseLocalTranslation(bool useLocal)
+    {
+        mTranslationSpace = useLocal ? Node::TS_LOCAL : Node::TS_PARENT;
+    }
+
+    //---------------------------------------------------------------------
+    bool NodeAnimationTrack::getUseLocalTranslation() const
+    {
+        return mTranslationSpace == Node::TS_LOCAL;
     }
     //---------------------------------------------------------------------
     void NodeAnimationTrack::_keyFrameDataChanged(void) const
@@ -670,6 +680,7 @@ namespace Ogre {
         NodeAnimationTrack* newTrack = 
             newParent->createNodeTrack(mHandle, mTargetNode);
         newTrack->mUseShortestRotationPath = mUseShortestRotationPath;
+        newTrack->mTranslationSpace = mTranslationSpace;
         populateClone(newTrack);
         return newTrack;
     }


### PR DESCRIPTION
Allows to select local space for translations on NodeAnimationTrack.

More focused version of #2840 that doesn't affect rotations and only allows choosing between parent and local.