### PR TITLE
ResourceGroupManager shutdown crash

### DIFF
--- a/OgreMain/src/OgreResourceGroupManager.cpp
+++ b/OgreMain/src/OgreResourceGroupManager.cpp
@@ -980,7 +980,7 @@ namespace Ogre {
                 }
 
                 // Remove the items here (not above) because during the erase the item destructor
-                // can unload some resources which can call _notifyResourceRemoved that removes 
+                // can unload some resources which can call _notifyResourceRemoved that removes
                 // the corresponding items from our container - this invalidates the iterator and we crash.
                 for (const auto& iter : arDel)
                 {

--- a/OgreMain/src/OgreResourceGroupManager.cpp
+++ b/OgreMain/src/OgreResourceGroupManager.cpp
@@ -971,23 +971,24 @@ namespace Ogre {
             // Iterate over all priorities
             for (auto & oi : grpi.second->loadResourceOrderMap)
             {
-                // Iterate over all resources
-                for (LoadUnloadResourceList::iterator l = oi.second.begin();
-                    l != oi.second.end(); )
+                // Iterate over all resources and collect which should be removed
+                std::vector<ResourcePtr> arDel;
+                arDel.reserve(oi.second.size());
+                for (const auto& iter : oi.second) {
+                    if (iter->getCreator() == manager)
+                        arDel.emplace_back(iter);
+                }
+
+                // Remove the items here (not above) because during the erase the item destructor
+                // can unload some resources which can call _notifyResourceRemoved that removes 
+                // the corresponding items from our container - this invalidates the iterator and we crash.
+                for (const auto& iter : arDel)
                 {
-                    if ((*l)->getCreator() == manager)
-                    {
-                        // Increment first since iterator will be invalidated
-                        LoadUnloadResourceList::iterator del = l++;
-                        oi.second.erase(del);
-                    }
-                    else
-                    {
-                        ++l;
-                    }
+                    auto iFind = std::find(oi.second.begin(), oi.second.end(), iter);
+                    if (iFind != oi.second.end())
+                        oi.second.erase(iFind);
                 }
             }
-
         }
     }
     //-----------------------------------------------------------------------


### PR DESCRIPTION
On application close the ResourceGroupManager::_notifyAllResourcesRemoved is called which removes all resources from the loadResourceOrderMap.

When we erase the resource from the container the resource can be deleted (if the use-counter = 0). In this case D3D9HLSLProgram d-tor is called which tries to unload its resources (HighLevelGpuProgram::unloadImpl) and it calls ResourceGroupManager::_notifyResourceRemoved. This method removes these resources from the same container what we are operating above which invalidates our iterator and we crash.