### PR TITLE
Main: HardwareBuffer - get rid of unused isSystemMemory flag

### DIFF
--- a/OgreMain/include/OgreHardwareBuffer.h
+++ b/OgreMain/include/OgreHardwareBuffer.h
@@ -172,7 +172,6 @@ namespace Ogre {
             size_t mLockSize;
             std::unique_ptr<HardwareBuffer> mDelegate;
             std::unique_ptr<HardwareBuffer> mShadowBuffer;
-            bool mSystemMemory;
             bool mShadowUpdated;
             bool mSuppressHardwareUpdate;
             bool mIsLocked;
@@ -188,9 +187,9 @@ namespace Ogre {
 
         public:
             /// Constructor, to be called by HardwareBufferManager only
-            HardwareBuffer(Usage usage, bool systemMemory, bool useShadowBuffer)
-                : mSizeInBytes(0), mLockStart(0), mLockSize(0), mSystemMemory(systemMemory),
-                  mShadowUpdated(false), mSuppressHardwareUpdate(false), mIsLocked(false), mUsage(usage)
+            HardwareBuffer(Usage usage, bool useShadowBuffer)
+                : mSizeInBytes(0), mLockStart(0), mLockSize(0), mShadowUpdated(false), mSuppressHardwareUpdate(false),
+                  mIsLocked(false), mUsage(usage)
             {
                 // If use shadow buffer, upgrade to WRITE_ONLY on hardware side
                 if (useShadowBuffer && usage == HBU_CPU_ONLY)
@@ -320,9 +319,8 @@ namespace Ogre {
             virtual void copyData(HardwareBuffer& srcBuffer, size_t srcOffset, 
                 size_t dstOffset, size_t length, bool discardWholeBuffer = false)
             {
-                if(mDelegate && !srcBuffer.isSystemMemory())
+                if(mDelegate)
                 {
-                    // GPU copy
                     mDelegate->copyData(*srcBuffer.mDelegate, srcOffset, dstOffset, length, discardWholeBuffer);
                     return;
                 }
@@ -365,8 +363,6 @@ namespace Ogre {
             size_t getSizeInBytes(void) const { return mSizeInBytes; }
             /// Returns the Usage flags with which this buffer was created
             Usage getUsage(void) const { return mUsage; }
-            /// Returns whether this buffer is held in system memory
-            bool isSystemMemory(void) const { return mSystemMemory; }
             /// Returns whether this buffer has a system memory shadow for quicker reading
             bool hasShadowBuffer(void) const { return mShadowBuffer || (mDelegate && mDelegate->hasShadowBuffer()); }
             /// Returns whether or not this buffer is currently locked.

--- a/OgreMain/include/OgreHardwareIndexBuffer.h
+++ b/OgreMain/include/OgreHardwareIndexBuffer.h
@@ -59,7 +59,7 @@ namespace Ogre {
         public:
             /// Should be called by HardwareBufferManager
             HardwareIndexBuffer(HardwareBufferManagerBase* mgr, IndexType idxType, size_t numIndexes,
-                                Usage usage, bool useSystemMemory, bool useShadowBuffer);
+                                Usage usage, bool useShadowBuffer);
             HardwareIndexBuffer(HardwareBufferManagerBase* mgr, IndexType idxType, size_t numIndexes,
                                 HardwareBuffer* delegate);
             ~HardwareIndexBuffer();

--- a/OgreMain/include/OgreHardwarePixelBuffer.h
+++ b/OgreMain/include/OgreHardwarePixelBuffer.h
@@ -83,7 +83,7 @@ namespace Ogre {
         /// Should be called by HardwareBufferManager
         HardwarePixelBuffer(uint32 mWidth, uint32 mHeight, uint32 mDepth,
                 PixelFormat mFormat,
-                HardwareBuffer::Usage usage, bool useSystemMemory, bool useShadowBuffer);
+                HardwareBuffer::Usage usage, bool useShadowBuffer);
         ~HardwarePixelBuffer();
 
         /** Make every lock method from HardwareBuffer available.

--- a/OgreMain/include/OgreHardwareVertexBuffer.h
+++ b/OgreMain/include/OgreHardwareVertexBuffer.h
@@ -56,7 +56,7 @@ namespace Ogre {
         public:
             /// Should be called by HardwareBufferManager
             HardwareVertexBuffer(HardwareBufferManagerBase* mgr, size_t vertexSize, size_t numVertices,
-                                 Usage usage, bool useSystemMemory, bool useShadowBuffer);
+                                 Usage usage, bool useShadowBuffer);
             HardwareVertexBuffer(HardwareBufferManagerBase* mgr, size_t vertexSize, size_t numVertices,
                                  HardwareBuffer* delegate);
             ~HardwareVertexBuffer();

--- a/OgreMain/src/OgreDefaultHardwareBufferManager.cpp
+++ b/OgreMain/src/OgreDefaultHardwareBufferManager.cpp
@@ -31,7 +31,7 @@ THE SOFTWARE.
 namespace Ogre {
 
     DefaultHardwareBuffer::DefaultHardwareBuffer(size_t sizeInBytes)
-    : HardwareBuffer(HBU_CPU_ONLY, true, false) // always software, never shadowed
+    : HardwareBuffer(HBU_CPU_ONLY, false) // always software, never shadowed
     {
         mSizeInBytes = sizeInBytes;
         // Allocate aligned memory for better SIMD processing friendly.

--- a/OgreMain/src/OgreHardwareIndexBuffer.cpp
+++ b/OgreMain/src/OgreHardwareIndexBuffer.cpp
@@ -34,9 +34,8 @@ namespace Ogre {
 
     //-----------------------------------------------------------------------------
     HardwareIndexBuffer::HardwareIndexBuffer(HardwareBufferManagerBase* mgr, IndexType idxType, 
-        size_t numIndexes, HardwareBuffer::Usage usage,
-        bool useSystemMemory, bool useShadowBuffer) 
-        : HardwareBuffer(usage, useSystemMemory, useShadowBuffer)
+        size_t numIndexes, HardwareBuffer::Usage usage, bool useShadowBuffer)
+        : HardwareBuffer(usage, useShadowBuffer)
         , mIndexType(idxType)
         , mMgr(mgr)
         , mNumIndexes(numIndexes)
@@ -62,8 +61,7 @@ namespace Ogre {
 
     HardwareIndexBuffer::HardwareIndexBuffer(HardwareBufferManagerBase* mgr, IndexType idxType,
                                              size_t numIndexes, HardwareBuffer* delegate)
-        : HardwareIndexBuffer(mgr, idxType, numIndexes, delegate->getUsage(), delegate->isSystemMemory(),
-                              false)
+        : HardwareIndexBuffer(mgr, idxType, numIndexes, delegate->getUsage(), false)
     {
         mDelegate.reset(delegate);
     }

--- a/OgreMain/src/OgreHardwarePixelBuffer.cpp
+++ b/OgreMain/src/OgreHardwarePixelBuffer.cpp
@@ -36,8 +36,8 @@ namespace Ogre
     //-----------------------------------------------------------------------------    
     HardwarePixelBuffer::HardwarePixelBuffer(uint32 width, uint32 height, uint32 depth,
             PixelFormat format,
-            HardwareBuffer::Usage usage, bool useSystemMemory, bool useShadowBuffer):
-        HardwareBuffer(usage, useSystemMemory, useShadowBuffer),
+            HardwareBuffer::Usage usage, bool useShadowBuffer):
+        HardwareBuffer(usage, useShadowBuffer),
         mCurrentLockOptions(), mWidth(width), mHeight(height), mDepth(depth),
         mFormat(format)
     {

--- a/OgreMain/src/OgreHardwareVertexBuffer.cpp
+++ b/OgreMain/src/OgreHardwareVertexBuffer.cpp
@@ -33,9 +33,8 @@ namespace Ogre {
 
     //-----------------------------------------------------------------------------
     HardwareVertexBuffer::HardwareVertexBuffer(HardwareBufferManagerBase* mgr, size_t vertexSize,
-        size_t numVertices, HardwareBuffer::Usage usage,
-        bool useSystemMemory, bool useShadowBuffer) 
-        : HardwareBuffer(usage, useSystemMemory, useShadowBuffer),
+        size_t numVertices, HardwareBuffer::Usage usage, bool useShadowBuffer)
+        : HardwareBuffer(usage, useShadowBuffer),
           mIsInstanceData(false),
           mMgr(mgr),
           mNumVertices(numVertices),
@@ -54,8 +53,7 @@ namespace Ogre {
     }
     HardwareVertexBuffer::HardwareVertexBuffer(HardwareBufferManagerBase* mgr, size_t vertexSize,
                                                size_t numVertices, HardwareBuffer* delegate)
-        : HardwareVertexBuffer(mgr, vertexSize, numVertices, delegate->getUsage(), delegate->isSystemMemory(),
-                               false)
+        : HardwareVertexBuffer(mgr, vertexSize, numVertices, delegate->getUsage(), false)
     {
         mDelegate.reset(delegate);
     }

--- a/RenderSystems/Direct3D11/src/OgreD3D11HardwareBuffer.cpp
+++ b/RenderSystems/Direct3D11/src/OgreD3D11HardwareBuffer.cpp
@@ -36,7 +36,7 @@ namespace Ogre {
         BufferType btype, size_t sizeBytes,
         HardwareBuffer::Usage usage, D3D11Device & device, 
         bool useShadowBuffer, bool streamOut)
-        : HardwareBuffer(usage, false,  useShadowBuffer),
+        : HardwareBuffer(usage, useShadowBuffer),
         mUseTempStagingBuffer(false),
         mBufferType(btype),
         mDevice(device)

--- a/RenderSystems/Direct3D11/src/OgreD3D11HardwarePixelBuffer.cpp
+++ b/RenderSystems/Direct3D11/src/OgreD3D11HardwarePixelBuffer.cpp
@@ -63,7 +63,7 @@ namespace Ogre {
 
     D3D11HardwarePixelBuffer::D3D11HardwarePixelBuffer(D3D11Texture * parentTexture, D3D11Device & device, UINT mipLevel,
         size_t width, size_t height, size_t depth, UINT face, PixelFormat format, HardwareBuffer::Usage usage):
-    HardwarePixelBuffer(width, height, depth, format, usage, false, false),
+    HardwarePixelBuffer(width, height, depth, format, usage, false),
         mParentTexture(parentTexture),
         mDevice(device),
         mFace(face),

--- a/RenderSystems/Direct3D9/src/OgreD3D9HardwareBuffer.cpp
+++ b/RenderSystems/Direct3D9/src/OgreD3D9HardwareBuffer.cpp
@@ -41,7 +41,7 @@ namespace Ogre {
     D3D9HardwareBuffer::D3D9HardwareBuffer(D3DFORMAT type, size_t sizeInBytes,
         Usage usage,
         bool useShadowBuffer)
-        : HardwareBuffer(usage, false, useShadowBuffer)
+        : HardwareBuffer(usage, useShadowBuffer)
     {
         mType = type;
         mSizeInBytes = sizeInBytes;

--- a/RenderSystems/Direct3D9/src/OgreD3D9HardwarePixelBuffer.cpp
+++ b/RenderSystems/Direct3D9/src/OgreD3D9HardwarePixelBuffer.cpp
@@ -47,7 +47,7 @@ namespace Ogre {
 
 D3D9HardwarePixelBuffer::D3D9HardwarePixelBuffer(HardwareBuffer::Usage usage, 
                                                  D3D9Texture* ownerTexture):
-    HardwarePixelBuffer(0, 0, 0, PF_UNKNOWN, usage, false, false),
+    HardwarePixelBuffer(0, 0, 0, PF_UNKNOWN, usage, false),
     mDoMipmapGen(false), mHWMipmaps(false), mOwnerTexture(ownerTexture)
 {   
 }

--- a/RenderSystems/GL/src/OgreGLHardwareBuffer.cpp
+++ b/RenderSystems/GL/src/OgreGLHardwareBuffer.cpp
@@ -38,7 +38,7 @@ namespace Ogre {
     //---------------------------------------------------------------------
     GLHardwareVertexBuffer::GLHardwareVertexBuffer(GLenum target, size_t sizeInBytes,
         Usage usage, bool useShadowBuffer)
-        : HardwareBuffer(usage, false, useShadowBuffer), mTarget(target), mLockedToScratch(false),
+        : HardwareBuffer(usage, useShadowBuffer), mTarget(target), mLockedToScratch(false),
         mScratchOffset(0), mScratchSize(0), mScratchPtr(0), mScratchUploadOnUnlock(false)
     {
         mSizeInBytes = sizeInBytes;

--- a/RenderSystems/GL3Plus/src/OgreGL3PlusHardwareBuffer.cpp
+++ b/RenderSystems/GL3Plus/src/OgreGL3PlusHardwareBuffer.cpp
@@ -35,7 +35,7 @@ Copyright (c) 2000-2014 Torus Knot Software Ltd
 namespace Ogre {
 
     GL3PlusHardwareBuffer::GL3PlusHardwareBuffer(GLenum target, size_t sizeInBytes, uint32 usage, bool useShadowBuffer)
-    : HardwareBuffer(usage, false, useShadowBuffer), mTarget(target)
+    : HardwareBuffer(usage, useShadowBuffer), mTarget(target)
     {
         mSizeInBytes = sizeInBytes;
         mRenderSystem = static_cast<GL3PlusRenderSystem*>(Root::getSingleton().getRenderSystem());

--- a/RenderSystems/GLES2/src/OgreGLES2HardwareBuffer.cpp
+++ b/RenderSystems/GLES2/src/OgreGLES2HardwareBuffer.cpp
@@ -34,7 +34,7 @@ THE SOFTWARE.
 
 namespace Ogre {
     GLES2HardwareBuffer::GLES2HardwareBuffer(GLenum target, size_t sizeInBytes, uint32 usage, bool useShadowBuffer)
-        : HardwareBuffer(usage, false, useShadowBuffer || HANDLE_CONTEXT_LOSS), mTarget(target)
+        : HardwareBuffer(usage, useShadowBuffer || HANDLE_CONTEXT_LOSS), mTarget(target)
     {
         mSizeInBytes = sizeInBytes;
         mRenderSystem = static_cast<GLES2RenderSystem*>(Root::getSingleton().getRenderSystem());

--- a/RenderSystems/GLSupport/src/OgreGLHardwarePixelBufferCommon.cpp
+++ b/RenderSystems/GLSupport/src/OgreGLHardwarePixelBufferCommon.cpp
@@ -32,7 +32,7 @@ namespace Ogre
 GLHardwarePixelBufferCommon::GLHardwarePixelBufferCommon(uint32 inWidth, uint32 inHeight,
                                                        uint32 inDepth, PixelFormat inFormat,
                                                        HardwareBuffer::Usage usage)
-    : HardwarePixelBuffer(inWidth, inHeight, inDepth, inFormat, usage, false, false),
+    : HardwarePixelBuffer(inWidth, inHeight, inDepth, inFormat, usage, false),
       mBuffer(inWidth, inHeight, inDepth, inFormat),
       mGLInternalFormat(0)
 {

--- a/RenderSystems/Metal/src/OgreMetalHardwareBufferCommon.mm
+++ b/RenderSystems/Metal/src/OgreMetalHardwareBufferCommon.mm
@@ -38,7 +38,7 @@ namespace Ogre
     MetalHardwareBufferCommon::MetalHardwareBufferCommon( size_t sizeBytes, Usage usage, bool useShadowBuffer,
                                                           uint16 alignment,
                                                           MetalDevice *device ) :
-        HardwareBuffer(usage, false, false),
+        HardwareBuffer(usage, false),
         mBuffer( 0 ),
         mDevice( device )
     {

--- a/RenderSystems/Metal/src/OgreMetalHardwarePixelBuffer.mm
+++ b/RenderSystems/Metal/src/OgreMetalHardwarePixelBuffer.mm
@@ -39,7 +39,7 @@ namespace Ogre {
     MetalHardwarePixelBuffer::MetalHardwarePixelBuffer( uint32 width, uint32 height,
                                                         uint32 depth, PixelFormat format,
                                                         bool hwGamma, HardwareBuffer::Usage usage )
-        : HardwarePixelBuffer(width, height, depth, format, usage, false, false),
+        : HardwarePixelBuffer(width, height, depth, format, usage, false),
           mBuffer(width, height, depth, format)
     {
     }

--- a/RenderSystems/Tiny/src/OgreTinyHardwarePixelBuffer.cpp
+++ b/RenderSystems/Tiny/src/OgreTinyHardwarePixelBuffer.cpp
@@ -7,7 +7,7 @@
 namespace Ogre {
 
     TinyHardwarePixelBuffer::TinyHardwarePixelBuffer(const PixelBox& data, Usage usage)
-        : HardwarePixelBuffer(data.getWidth(), data.getHeight(), data.getDepth(), data.format, usage, true, false), mBuffer(data)
+        : HardwarePixelBuffer(data.getWidth(), data.getHeight(), data.getDepth(), data.format, usage, false), mBuffer(data)
     {
     }
 

--- a/RenderSystems/Vulkan/src/OgreVulkanHardwareBuffer.cpp
+++ b/RenderSystems/Vulkan/src/OgreVulkanHardwareBuffer.cpp
@@ -35,7 +35,7 @@ namespace Ogre
 {
     VulkanHardwareBuffer::VulkanHardwareBuffer(uint32 target,
         size_t sizeBytes, Usage usage, bool useShadowBuffer, VulkanDevice *device ) :
-        HardwareBuffer(usage, false, useShadowBuffer),
+        HardwareBuffer(usage, useShadowBuffer),
         mBuffer(VK_NULL_HANDLE),
         mDevice( device ),
         mTarget( target ),

--- a/RenderSystems/Vulkan/src/OgreVulkanTextureGpu.cpp
+++ b/RenderSystems/Vulkan/src/OgreVulkanTextureGpu.cpp
@@ -44,7 +44,7 @@ namespace Ogre
 {
     VulkanHardwarePixelBuffer::VulkanHardwarePixelBuffer(VulkanTextureGpu* tex, uint32 width, uint32 height, uint32 depth,
                                                         uint8 face, uint32 mip)
-        : HardwarePixelBuffer(width, height, depth, tex->getFormat(), tex->getUsage(), false, false), mParent(tex),
+        : HardwarePixelBuffer(width, height, depth, tex->getFormat(), tex->getUsage(), false), mParent(tex),
         mFace(face), mLevel(mip)
     {
         if(mParent->getUsage() & TU_RENDERTARGET)


### PR DESCRIPTION
it was obsoleted when shadow buffers were introduced