### PR TITLE
docs: fix shadow tutorial code example

### DIFF
--- a/Docs/src/ogre-shadows.md
+++ b/Docs/src/ogre-shadows.md
@@ -14,6 +14,10 @@ question). Parts of the scene visible only to the camera must be
 shadowed. We do not care about parts of the scene seen only by the
 light.
 
+Please note that this tutorial is more explicit and in depth than required
+to merely render shadows in OGRE as to teach you the theory behind the 
+rendering shadows as well.
+
 In practice, the snapshot from the viewpoint of the light is stored as a
 floating point depth buffer. It is important to use a format that
 supports enough precision to avoid shadow acne (z-fighting) on lit
@@ -336,10 +340,11 @@ as it may affect how certain resources are loaded.
 
 ```cpp
 // Use Ogre's custom shadow mapping ability
+MaterialManager *materialMgr = Ogre::MaterialManager::getSingletonPtr();
 sceneMgr->setShadowTexturePixelFormat(PF_DEPTH16);
 sceneMgr->setShadowTechnique( SHADOWTYPE_TEXTURE_ADDITIVE );
-sceneMgr->setShadowTextureCasterMaterial("Ogre/DepthShadowmap/Caster/Float");
-sceneMgr->setShadowTextureReceiverMaterial("Ogre/DepthShadowmap/Receiver/Float");
+sceneMgr->setShadowTextureCasterMaterial(materialMgr->getByName("Ogre/DepthShadowmap/Caster/Float"));
+sceneMgr->setShadowTextureReceiverMaterial(materialMgr->getByName("Ogre/DepthShadowmap/Receiver/Float"));
 sceneMgr->setShadowTextureSelfShadow(true); 
 sceneMgr->setShadowTextureSize(1024);
 ```

--- a/Docs/src/ogre-shadows.md
+++ b/Docs/src/ogre-shadows.md
@@ -15,7 +15,7 @@ shadowed. We do not care about parts of the scene seen only by the
 light.
 
 Please note that this tutorial is more explicit and in depth than required
-to merely render shadows in OGRE as to teach you the theory behind the 
+to merely render shadows in OGRE as to teach you the theory behind the
 rendering shadows as well.
 
 In practice, the snapshot from the viewpoint of the light is stored as a


### PR DESCRIPTION
As I mentioned in this [forum thread](https://forums.ogre3d.org/viewtopic.php?t=97082), this tutorial uses code that cannot compile since [setShadowTextureCasterMaterial](https://ogrecave.github.io/ogre/api/latest/class_ogre_1_1_scene_manager.html#aa22c0af6835b4a0524b4122756cdd93c) does not accept strings. Thus, I added `MaterialManager::getByName` to get the `MaterialPtr` which it required. 

Additionally, I added a paragraph near the beginning explaining that the tutorial is more in depth than in needed just to have shadows in OGRE, so that people reading it aren't mislead if they just want to add shadows to their scene, since the tutorial is quite old.