### PR TITLE
docs: update scripting manual

### DIFF
--- a/Docs/src/high-level-programs.md
+++ b/Docs/src/high-level-programs.md
@@ -20,7 +20,9 @@ vertex_program myVertexProgram asm
 }
 ```
 
-As you can see, that’s very simple, and defining a fragment or geometry program is exactly the same, just with @c vertex_program replaced with @c fragment_program or @c geometry_program, respectively. You give the program a name in the header, followed by the word ’asm’ to indicate that this is a low-level program. Inside the braces, you specify where the source is going to come from (and this is loaded from any of the resource locations as with other media), and also indicate the syntax being used. You might wonder why the syntax specification is required when many of the assembler syntaxes have a header identifying them anyway - well the reason is that the engine needs to know what syntax the program is in before reading it, because during compilation of the material, we want to skip programs which use an unsupportable syntax quickly, without loading the program first.
+As you can see, that’s very simple, and defining a fragment or geometry program is exactly the same, just with @c vertex_program replaced with @c fragment_program or @c geometry_program, respectively. Likewise, for tessellation and compute programs, use @c tessellation_hull_program, @c tessellation_domain_program, and @c compute_program.
+
+You give the program a name in the header, followed by the word ’asm’ to indicate that this is a low-level program. Inside the braces, you specify where the source is going to come from (and this is loaded from any of the resource locations as with other media), and also indicate the syntax being used. You might wonder why the syntax specification is required when many of the assembler syntaxes have a header identifying them anyway - well the reason is that the engine needs to know what syntax the program is in before reading it, because during compilation of the material, we want to skip programs which use an unsupportable syntax quickly, without loading the program first.
 
 # Default Program Parameters {#Default-Program-Parameters}
 

--- a/Docs/src/material-scripts.md
+++ b/Docs/src/material-scripts.md
@@ -1489,7 +1489,7 @@ Format: comp_func &lt;func&gt;
 
 # Using GPU Programs in a Pass {#Using-Vertex_002fGeometry_002fFragment-Programs-in-a-Pass}
 
-Within a pass section of a material script, you can reference a vertex, geometry and / or a fragment program which is been defined in a .program script (See [GPU Program Scripts](@ref Declaring-Vertex_002fGeometry_002fFragment-Programs)). The programs are defined separately from the usage of them in the pass, since the programs are very likely to be reused between many separate materials, probably across many different .material scripts, so this approach lets you define the program only once and use it many times.
+Within a pass section of a material script, you can reference a vertex, geometry, tessellation, compute, and / or a fragment program which is been defined in a .program script (See [GPU Program Scripts](@ref Declaring-Vertex_002fGeometry_002fFragment-Programs)). The programs are defined separately from the usage of them in the pass, since the programs are very likely to be reused between many separate materials, probably across many different .material scripts, so this approach lets you define the program only once and use it many times.
 
 As well as naming the program in question, you can also provide parameters to it. Here’s a simple example:
 
@@ -1503,11 +1503,15 @@ vertex_program_ref myVertexProgram
 
 In this example, we bind a vertex program called ’myVertexProgram’ (which will be defined elsewhere) to the pass, and give it 2 parameters, one is an ’auto’ parameter, meaning we do not have to supply a value as such, just a recognised code (in this case it’s the world/view/projection matrix which is kept up to date automatically by Ogre). The second parameter is a manually specified parameter, a 4-element float. The indexes are described later.
 
-The syntax of the link to a vertex program and a fragment or geometry program are identical, the only difference is that ’fragment\_program\_ref’ and ’geometry\_program\_ref’ are used respectively instead of ’vertex\_program\_ref’.
+The syntax of the link to a vertex program and a fragment or geometry program are identical, the only difference is that `fragment_program_ref` and `geometry_program_ref` are used respectively instead of `vertex_program_ref`. For tessellation shaders, use `tessellation_hull_program_ref` and `tessellation_domain_program_ref` to link to the hull tessellation program and the domain tessellation program respectively. Compute shader programs can be linked with `compute_program_ref`.
 
 For many situations vertex, geometry and fragment programs are associated with each other in a pass but this is not cast in stone. You could have a vertex program that can be used by several different fragment programs. Another situation that arises is that you can mix fixed pipeline and programmable pipeline (shaders) together. You could use the non-programmable vertex fixed function pipeline and then provide a fragment\_program\_ref in a pass i.e. there would be no vertex\_program\_ref section in the pass. The fragment program referenced in the pass must meet the requirements as defined in the related API in order to read from the outputs of the vertex fixed pipeline. You could also just have a vertex program that outputs to the fragment fixed function pipeline.
 
 The requirements to read from or write to the fixed function pipeline are similar between rendering API’s (DirectX and OpenGL) but how its actually done in each type of shader (vertex, geometry or fragment) depends on the shader language. For HLSL (DirectX API) and associated asm consult MSDN at <http://msdn.microsoft.com/library/>. For GLSL (OpenGL), consult section 7.6 of the GLSL spec 1.1 available at <http://www.opengl.org/registry/>. The built in varying variables provided in GLSL allow your program to read/write to the fixed function pipeline varyings. For Cg consult the Language Profiles section in CgUsersManual.pdf that comes with the Cg Toolkit available at <https://developer.nvidia.com/cg-toolkit>. For HLSL and Cg its the varying bindings that allow your shader programs to read/write to the fixed function pipeline varyings.
+
+Some of Ogre's render systems do not support the Fixed Function pipeline. In that, case if you supply vertex shader, you will need to supply a fragment shader as well or use the RTSS.
+
+Compute shader can be referenced in your materials with syntax like vertex shadeds.
 
 # Adding new Techniques, Passes, to copied materials {#Adding-new-Techniques_002c-Passes_002c-to-copied-materials_003a}
 

--- a/Docs/src/material-scripts.md
+++ b/Docs/src/material-scripts.md
@@ -1511,7 +1511,7 @@ The requirements to read from or write to the fixed function pipeline are simila
 
 Some of Ogre's render systems do not support the Fixed Function pipeline. In that, case if you supply vertex shader, you will need to supply a fragment shader as well or use the RTSS.
 
-Compute shader can be referenced in your materials with syntax like vertex shadeds.
+Compute shader can be referenced in your materials with syntax like vertex shaders.
 
 # Adding new Techniques, Passes, to copied materials {#Adding-new-Techniques_002c-Passes_002c-to-copied-materials_003a}
 

--- a/Docs/src/ogre-shadows.md
+++ b/Docs/src/ogre-shadows.md
@@ -14,6 +14,10 @@ question). Parts of the scene visible only to the camera must be
 shadowed. We do not care about parts of the scene seen only by the
 light.
 
+Please note that this tutorial is more explicit and in depth than required
+to merely render shadows in OGRE as to teach you the theory behind the 
+rendering shadows as well.
+
 In practice, the snapshot from the viewpoint of the light is stored as a
 floating point depth buffer. It is important to use a format that
 supports enough precision to avoid shadow acne (z-fighting) on lit
@@ -336,10 +340,11 @@ as it may affect how certain resources are loaded.
 
 ```cpp
 // Use Ogre's custom shadow mapping ability
+MaterialManager *materialMgr = Ogre::MaterialManager::getSingletonPtr();
 sceneMgr->setShadowTexturePixelFormat(PF_DEPTH16);
 sceneMgr->setShadowTechnique( SHADOWTYPE_TEXTURE_ADDITIVE );
-sceneMgr->setShadowTextureCasterMaterial("Ogre/DepthShadowmap/Caster/Float");
-sceneMgr->setShadowTextureReceiverMaterial("Ogre/DepthShadowmap/Receiver/Float");
+sceneMgr->setShadowTextureCasterMaterial(materialMgr->getByName("Ogre/DepthShadowmap/Caster/Float"));
+sceneMgr->setShadowTextureReceiverMaterial(materialMgr->getByName("Ogre/DepthShadowmap/Receiver/Float"));
 sceneMgr->setShadowTextureSelfShadow(true); 
 sceneMgr->setShadowTextureSize(1024);
 ```

--- a/Docs/src/ogre-shadows.md
+++ b/Docs/src/ogre-shadows.md
@@ -15,7 +15,7 @@ shadowed. We do not care about parts of the scene seen only by the
 light.
 
 Please note that this tutorial is more explicit and in depth than required
-to merely render shadows in OGRE as to teach you the theory behind the 
+to merely render shadows in OGRE as to teach you the theory behind the
 rendering shadows as well.
 
 In practice, the snapshot from the viewpoint of the light is stored as a

--- a/Docs/src/scripts.md
+++ b/Docs/src/scripts.md
@@ -23,6 +23,7 @@ The extensions, however, do specify the order in which the scripts are parsed, w
 3. "*.particle"
 4. "*.compositor"
 5. "*.os"
+6. "*.overlay"
 
 # Format {#Format}
 


### PR DESCRIPTION
this pull request does two things:
1. adds .overlay to the list files of searched for scripts (placed at the end as it appears to be by my testing)
2. adds the basics of declaring and referencing tessellation and compute scripts to material and GPU program pages. 

If I understand the git message correctly, it also adds terminal new lines to the end of text files I edited. If this is a problem, I can look into suppressing this behaviour in my editor. 