### PR TITLE
Update zlib dependency to 1.3

### DIFF
--- a/CMake/Dependencies.cmake
+++ b/CMake/Dependencies.cmake
@@ -146,17 +146,17 @@ if(OGRE_BUILD_DEPENDENCIES AND NOT EXISTS ${OGREDEPS_PATH})
     if(MSVC OR MINGW OR SKBUILD) # other platforms dont need this
       message(STATUS "Building zlib") # only needed for Assimp
       file(DOWNLOAD
-          http://zlib.net/zlib-1.2.13.tar.gz
-          ${PROJECT_BINARY_DIR}/zlib-1.2.13.tar.gz
-          EXPECTED_HASH SHA256=b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30)
+          http://zlib.net/zlib-1.3.tar.gz
+          ${PROJECT_BINARY_DIR}/zlib-1.3.tar.gz
+          EXPECTED_HASH SHA256=60373b133d630f74f4a1f94c1185a53f)
       execute_process(COMMAND ${CMAKE_COMMAND}
-          -E tar xf zlib-1.2.13.tar.gz WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
+          -E tar xf zlib-1.3.tar.gz WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
       execute_process(COMMAND ${BUILD_COMMAND_COMMON}
           -DBUILD_SHARED_LIBS=${OGREDEPS_SHARED}
-          ${PROJECT_BINARY_DIR}/zlib-1.2.13
-          WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/zlib-1.2.13)
+          ${PROJECT_BINARY_DIR}/zlib-1.3
+          WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/zlib-1.3)
       execute_process(COMMAND ${CMAKE_COMMAND}
-          --build ${PROJECT_BINARY_DIR}/zlib-1.2.13 ${BUILD_COMMAND_OPTS})
+          --build ${PROJECT_BINARY_DIR}/zlib-1.3 ${BUILD_COMMAND_OPTS})
 
       message(STATUS "Building Assimp")
       file(DOWNLOAD

--- a/CMake/Dependencies.cmake
+++ b/CMake/Dependencies.cmake
@@ -148,7 +148,7 @@ if(OGRE_BUILD_DEPENDENCIES AND NOT EXISTS ${OGREDEPS_PATH})
       file(DOWNLOAD
           http://zlib.net/zlib-1.3.tar.gz
           ${PROJECT_BINARY_DIR}/zlib-1.3.tar.gz
-          EXPECTED_HASH SHA256=60373b133d630f74f4a1f94c1185a53f)
+          EXPECTED_HASH SHA256=ff0ba4c292013dbc27530b3a81e1f9a813cd39de01ca5e0f8bf355702efa593e)
       execute_process(COMMAND ${CMAKE_COMMAND}
           -E tar xf zlib-1.3.tar.gz WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
       execute_process(COMMAND ${BUILD_COMMAND_COMMON}


### PR DESCRIPTION
Fix build on Windows using MinGW, building the dependencies was throwing this error:

```
-- Building zlib
CMake Error at CMake/Dependencies.cmake:148 (file):
  file DOWNLOAD cannot compute hash on failed download

    status: [22;"HTTP response code said error"]
Call Stack (most recent call first):
  CMakeLists.txt:282 (include)
```
![Screenshot from 2023-08-21 12-27-38](https://github.com/OGRECave/ogre/assets/996529/d3fd6237-209e-477a-a11e-8ca3a09a930d)

The reason is that zlib version 1.12.13 is not available anymore in this link http://zlib.net/zlib-1.2.13.tar.gz
Zlib 1.3 was released on August 18, 2023.

This PR updates the zlib dependency to version 1.13, which builds and runs fine.