### PR TITLE
CMAKE_CL_64 is deprecated and only works with Microsoft Visual Studio

### DIFF
--- a/CMake/Packages/FindCg.cmake
+++ b/CMake/Packages/FindCg.cmake
@@ -46,7 +46,7 @@ findpkg_framework(Cg)
 
 find_path(Cg_INCLUDE_DIR NAMES cg.h HINTS ${Cg_FRAMEWORK_INCLUDES} ${Cg_INC_SEARCH_PATH} ${Cg_PKGC_INCLUDE_DIRS} PATH_SUFFIXES Cg)
 
-if (CMAKE_CL_64)
+if (CMAKE_SIZEOF_VOID_P EQUAL 8)
   set (Cg_LIB_SEARCH_PATH ${Cg_HOME}/lib.x64 ${ENV_Cg_LIB64_PATH}
     ${ENV_Cg_HOME}/lib.x64 ${Cg_LIB_SEARCH_PATH})
 else()
@@ -59,7 +59,7 @@ find_library(Cg_LIBRARY_DBG NAMES ${Cg_LIBRARY_NAMES_DBG} HINTS ${Cg_LIB_SEARCH_
 make_library_set(Cg_LIBRARY)
 
 if (WIN32)
-	if (CMAKE_CL_64)
+	if (CMAKE_SIZEOF_VOID_P EQUAL 8)
 		set(Cg_BIN_SEARCH_PATH ${OGRE_DEPENDENCIES_DIR}/bin ${CMAKE_SOURCE_DIR}/Dependencies/bin ${Cg_HOME}/bin.x64
 			${ENV_Cg_BIN64_PATH} ${ENV_Cg_HOME}/bin.x64 ${ENV_OGRE_DEPENDENCIES_DIR}/bin
 			${OGRE_SOURCE}/Dependencies/bin ${ENV_OGRE_SOURCE}/Dependencies/bin

--- a/CMake/Packages/FindDirectX.cmake
+++ b/CMake/Packages/FindDirectX.cmake
@@ -18,13 +18,13 @@
 if(WIN32) # The only platform it makes sense to check for DirectX9 SDK
   include(FindPkgMacros)
   findpkg_begin(DirectX9)
-  
+
   # Get path, convert backslashes as ${ENV_DXSDK_DIR}
   getenv_path(DXSDK_DIR)
   getenv_path(DirectX_HOME)
   getenv_path(DirectX_ROOT)
   getenv_path(DirectX_BASE)
-  
+
   # construct search paths
   set(DirectX9_PREFIX_PATH 
     "${DXSDK_DIR}" "${ENV_DXSDK_DIR}"
@@ -45,15 +45,16 @@ if(WIN32) # The only platform it makes sense to check for DirectX9 SDK
     DirectX9_LIBRARY
 	DirectX9_INCLUDE_DIR
   )
-  
+
   find_path(DirectX9_INCLUDE_DIR NAMES d3d9.h D3DCommon.h HINTS ${DirectX9_INC_SEARCH_PATH})
+
   # dlls are in DirectX9_ROOT_DIR/Developer Runtime/x64|x86
   # lib files are in DirectX9_ROOT_DIR/Lib/x64|x86
-  if(CMAKE_CL_64)
+  if(CMAKE_SIZEOF_VOID_P EQUAL 8)
     set(DirectX9_LIBPATH_SUFFIX "x64")
-  else(CMAKE_CL_64)
+  else(CMAKE_SIZEOF_VOID_P EQUAL 8)
     set(DirectX9_LIBPATH_SUFFIX "x86")
-  endif(CMAKE_CL_64)
+  endif(CMAKE_SIZEOF_VOID_P EQUAL 8)
   find_library(DirectX9_LIBRARY NAMES d3d9 HINTS ${DirectX9_LIB_SEARCH_PATH} PATH_SUFFIXES ${DirectX9_LIBPATH_SUFFIX})
   find_library(DirectX9_D3DX9_LIBRARY NAMES d3dx9 HINTS ${DirectX9_LIB_SEARCH_PATH} PATH_SUFFIXES ${DirectX9_LIBPATH_SUFFIX})
   find_library(DirectX9_DXGUID_LIBRARY NAMES dxguid HINTS ${DirectX9_LIB_SEARCH_PATH} PATH_SUFFIXES ${DirectX9_LIBPATH_SUFFIX})
@@ -63,8 +64,7 @@ if(WIN32) # The only platform it makes sense to check for DirectX9 SDK
     ${DirectX9_D3DX9_LIBRARY}
     ${DirectX9_DXGUID_LIBRARY}
   )
-  
+
   mark_as_advanced(DirectX9_D3DX9_LIBRARY DirectX9_DXGUID_LIBRARY
     DirectX9_DXGI_LIBRARY DirectX9_D3DCOMPILER_LIBRARY) 
-
 endif(WIN32)

--- a/CMake/Packages/FindDirectX11.cmake
+++ b/CMake/Packages/FindDirectX11.cmake
@@ -84,11 +84,11 @@ if(WIN32) # The only platform it makes sense to check for DirectX11 SDK
 
 		# dlls are in DirectX11_ROOT_DIR/Developer Runtime/x64|x86
 		# lib files are in DirectX11_ROOT_DIR/Lib/x64|x86
-		if(CMAKE_CL_64)
+		if(CMAKE_SIZEOF_VOID_P EQUAL 8)
 			set(DirectX11_LIBPATH_SUFFIX "x64")
-		else(CMAKE_CL_64)
+		else(CMAKE_SIZEOF_VOID_P EQUAL 8)
 			set(DirectX11_LIBPATH_SUFFIX "x86")
-		endif(CMAKE_CL_64)
+		endif(CMAKE_SIZEOF_VOID_P EQUAL 8)
 
 		# look for D3D11 components
 		find_path(DirectX11_INCLUDE_DIR NAMES d3d11.h HINTS ${DirectX11_INC_SEARCH_PATH})
@@ -127,5 +127,5 @@ if(WIN32) # The only platform it makes sense to check for DirectX11 SDK
 	endif () # Legacy Direct X SDK
 
 	findpkg_finish(DirectX11)
-	
+
 endif(WIN32)

--- a/CMake/Packages/FindSoftimage.cmake
+++ b/CMake/Packages/FindSoftimage.cmake
@@ -49,11 +49,11 @@ set(Softimage_PREFIX_PATH
   "$ENV{ProgramW6432}/Autodesk/Softimage 2013/XSISDK"
 )
 
-if (CMAKE_CL_64)
+if (CMAKE_SIZEOF_VOID_P EQUAL 8)
   set(Softimage_LIBPATH_SUFFIX "nt-x86-64")
-else(CMAKE_CL_64)
+else(CMAKE_SIZEOF_VOID_P EQUAL 8)
   set(Softimage_LIBPATH_SUFFIX "nt-x86")
-endif(CMAKE_CL_64)
+endif(CMAKE_SIZEOF_VOID_P EQUAL 8)
 
 create_search_paths(Softimage)
 # redo search if prefix path changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,7 +155,7 @@ if (MSVC)
 
   # Enable intrinsics on MSVC in debug mode
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /Oi")
-  if (CMAKE_CL_64)
+  if (MSVC AND CMAKE_SIZEOF_VOID_P EQUAL 8)
     # Visual Studio bails out on debug builds in 64bit mode unless
 	# this flag is set...
 	set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /bigobj")

--- a/OgreMain/CMakeLists.txt
+++ b/OgreMain/CMakeLists.txt
@@ -176,7 +176,7 @@ target_include_directories(OgreMain PUBLIC
   PRIVATE "${OGRE_PROFILING_REMOTERY_PATH}")
 
 # In visual studio 2010 - 64 bit we get this error: "LINK : fatal error LNK1210: exceeded internal ILK size limit; link with /INCREMENTAL:NO"
-if(WIN32 AND MSVC10 AND CMAKE_CL_64)
+if(WIN32 AND MSVC10 AND CMAKE_SIZEOF_VOID_P EQUAL 8)
   set_target_properties(OgreMain PROPERTIES 
                         VERSION ${OGRE_SOVERSION}
                         LINK_FLAGS "/INCREMENTAL:NO"


### PR DESCRIPTION
Instead of using `CMAKE_CL_64`, we should be using `CMAKE_SIZEOF_VOID_P`.
In the official CMAKE documentation it says that `CMAKE_CL_64` is deprecated (https://cmake.org/cmake/help/latest/variable/CMAKE_CL_64.html)
And the 64-bit detection does not work in `MinGW64`.
