### PR TITLE
fix: Assimp importer animations

### DIFF
--- a/PlugIns/Assimp/src/AssimpLoader.cpp
+++ b/PlugIns/Assimp/src/AssimpLoader.cpp
@@ -604,7 +604,7 @@ void AssimpLoader::parseAnimation(const aiScene* mScene, int index, aiAnimation*
             defBonePoseInv.makeInverseTransform(bone->getPosition(), bone->getScale(),
                                                 bone->getOrientation());
 
-            NodeAnimationTrack* track = animation->createNodeTrack(i, bone);
+            NodeAnimationTrack* track = animation->createNodeTrack(bone->getHandle(), bone);
 
             // Ogre needs translate rotate and scale for each keyframe in the track
             KeyframesMap keyframes;


### PR DESCRIPTION
Fixes the imported model animations from the Assimp plugin.

before|after
-|-
<img width="1004" alt="Screenshot 2023-08-27 at 01 15 44" src="https://github.com/OGRECave/ogre/assets/996529/5d4d9a64-3ad2-408a-bdaa-07a5200a7483">|<img width="1004" alt="Screenshot 2023-08-27 at 01 14 42" src="https://github.com/OGRECave/ogre/assets/996529/28f9dcb8-f1e6-42b4-8e52-f96ed6981e8e">
