### PR TITLE
Main: ParticleSystem - do not track Affectors and Emitters in Factories

### DIFF
--- a/OgreMain/include/OgreParticleAffectorFactory.h
+++ b/OgreMain/include/OgreParticleAffectorFactory.h
@@ -55,7 +55,7 @@ namespace Ogre {
     class _OgreExport ParticleAffectorFactory : public FXAlloc
     {
     protected:
-        std::vector<ParticleAffector*> mAffectors;
+        OGRE_DEPRECATED std::vector<ParticleAffector*> mAffectors;
     public:
         ParticleAffectorFactory() {}
         virtual ~ParticleAffectorFactory();

--- a/OgreMain/include/OgreParticleEmitterFactory.h
+++ b/OgreMain/include/OgreParticleEmitterFactory.h
@@ -56,7 +56,7 @@ namespace Ogre {
     class _OgreExport ParticleEmitterFactory : public FXAlloc
     {
     protected:
-        std::vector<ParticleEmitter*> mEmitters;
+        OGRE_DEPRECATED std::vector<ParticleEmitter*> mEmitters;
     public:
         ParticleEmitterFactory() {}
         virtual ~ParticleEmitterFactory();

--- a/OgreMain/src/OgreParticleEmitter.cpp
+++ b/OgreMain/src/OgreParticleEmitter.cpp
@@ -686,6 +686,7 @@ namespace Ogre
     //-----------------------------------------------------------------------
     ParticleEmitterFactory::~ParticleEmitterFactory()
     {
+        OGRE_IGNORE_DEPRECATED_BEGIN
         // Destroy all emitters
         for (auto& e : mEmitters)
         {
@@ -693,15 +694,18 @@ namespace Ogre
         }
             
         mEmitters.clear();
+        OGRE_IGNORE_DEPRECATED_END
     }
     //-----------------------------------------------------------------------
     void ParticleEmitterFactory::destroyEmitter(ParticleEmitter* e)        
     {
+        delete e;
+        OGRE_IGNORE_DEPRECATED_BEGIN
         auto i = std::find(std::begin(mEmitters), std::end(mEmitters), e);
         if (i != std::end(mEmitters)) {
             mEmitters.erase(i);
-            OGRE_DELETE e;
         }
+        OGRE_IGNORE_DEPRECATED_END
     }
 
     //-----------------------------------------------------------------------

--- a/OgreMain/src/OgreParticleSystem.cpp
+++ b/OgreMain/src/OgreParticleSystem.cpp
@@ -1552,6 +1552,7 @@ namespace Ogre {
     //-----------------------------------------------------------------------
     ParticleAffectorFactory::~ParticleAffectorFactory() 
     {
+        OGRE_IGNORE_DEPRECATED_BEGIN
         // Destroy all affectors
         for (auto *a : mAffectors)
         {
@@ -1559,20 +1560,23 @@ namespace Ogre {
         }
             
         mAffectors.clear();
+        OGRE_IGNORE_DEPRECATED_END
     }
     //-----------------------------------------------------------------------
     void ParticleAffectorFactory::destroyAffector(ParticleAffector* e)
     {
+        delete e;
+        OGRE_IGNORE_DEPRECATED_BEGIN
         std::vector<ParticleAffector*>::iterator i;
         for (i = mAffectors.begin(); i != mAffectors.end(); ++i)
         {
             if ((*i) == e)
             {
                 mAffectors.erase(i);
-                OGRE_DELETE e;
                 break;
             }
         }
+        OGRE_IGNORE_DEPRECATED_END
     }
 
 }

--- a/PlugIns/ParticleFX/include/OgreTextureAnimatorAffector.h
+++ b/PlugIns/ParticleFX/include/OgreTextureAnimatorAffector.h
@@ -66,12 +66,7 @@ namespace Ogre {
     {
         String getName() const override { return "TextureAnimator"; }
 
-        ParticleAffector* createAffector(ParticleSystem* psys) override
-        {
-            ParticleAffector* p = OGRE_NEW TextureAnimatorAffector(psys);
-            mAffectors.push_back(p);
-            return p;
-        }
+        ParticleAffector* createAffector(ParticleSystem* psys) override { return new TextureAnimatorAffector(psys); }
     };
 
     /** @} */

--- a/PlugIns/ParticleFX/src/OgreBoxEmitterFactory.h
+++ b/PlugIns/ParticleFX/src/OgreBoxEmitterFactory.h
@@ -46,13 +46,7 @@ namespace Ogre {
     public:
         String getName() const override { return "Box"; }
 
-        ParticleEmitter* createEmitter(ParticleSystem* psys) override
-        {
-            ParticleEmitter* emit = OGRE_NEW BoxEmitter(psys);
-            mEmitters.push_back(emit);
-            return emit;
-        }
-
+        ParticleEmitter* createEmitter(ParticleSystem* psys) override { return new BoxEmitter(psys); }
     };
 
 }

--- a/PlugIns/ParticleFX/src/OgreColourFaderAffectorFactory.h
+++ b/PlugIns/ParticleFX/src/OgreColourFaderAffectorFactory.h
@@ -39,12 +39,7 @@ namespace Ogre {
     {
         String getName() const override { return "ColourFader"; }
 
-        ParticleAffector* createAffector(ParticleSystem* psys) override
-        {
-            ParticleAffector* p = OGRE_NEW ColourFaderAffector(psys);
-            mAffectors.push_back(p);
-            return p;
-        }
+        ParticleAffector* createAffector(ParticleSystem* psys) override { return new ColourFaderAffector(psys); }
     };
 
 

--- a/PlugIns/ParticleFX/src/OgreColourFaderAffectorFactory2.h
+++ b/PlugIns/ParticleFX/src/OgreColourFaderAffectorFactory2.h
@@ -39,12 +39,7 @@ namespace Ogre {
     {
         String getName() const override { return "ColourFader2"; }
 
-        ParticleAffector* createAffector(ParticleSystem* psys) override
-        {
-            ParticleAffector* p = OGRE_NEW ColourFaderAffector2(psys);
-            mAffectors.push_back(p);
-            return p;
-        }
+        ParticleAffector* createAffector(ParticleSystem* psys) override { return new ColourFaderAffector2(psys); }
     };
 
 

--- a/PlugIns/ParticleFX/src/OgreColourImageAffectorFactory.h
+++ b/PlugIns/ParticleFX/src/OgreColourImageAffectorFactory.h
@@ -39,12 +39,7 @@ namespace Ogre {
     {
         String getName() const override { return "ColourImage"; }
 
-        ParticleAffector* createAffector(ParticleSystem* psys) override
-        {
-            ParticleAffector* p = OGRE_NEW ColourImageAffector(psys);
-            mAffectors.push_back(p);
-            return p;
-        }
+        ParticleAffector* createAffector(ParticleSystem* psys) override { return new ColourImageAffector(psys); }
     };
 
 

--- a/PlugIns/ParticleFX/src/OgreColourInterpolatorAffectorFactory.h
+++ b/PlugIns/ParticleFX/src/OgreColourInterpolatorAffectorFactory.h
@@ -39,12 +39,7 @@ namespace Ogre {
     {
         String getName() const override { return "ColourInterpolator"; }
 
-        ParticleAffector* createAffector(ParticleSystem* psys) override
-        {
-            ParticleAffector* p = new ColourInterpolatorAffector(psys);
-            mAffectors.push_back(p);
-            return p;
-        }
+        ParticleAffector* createAffector(ParticleSystem* psys) override { return new ColourInterpolatorAffector(psys); }
     };
 
 

--- a/PlugIns/ParticleFX/src/OgreCylinderEmitterFactory.h
+++ b/PlugIns/ParticleFX/src/OgreCylinderEmitterFactory.h
@@ -47,13 +47,7 @@ namespace Ogre {
     public:
         String getName() const override { return "Cylinder"; }
 
-        ParticleEmitter* createEmitter(ParticleSystem* psys) override
-        {
-            ParticleEmitter* emit = OGRE_NEW CylinderEmitter(psys);
-            mEmitters.push_back(emit);
-            return emit;
-        }
-
+        ParticleEmitter* createEmitter(ParticleSystem* psys) override { return new CylinderEmitter(psys); }
     };
 
 }

--- a/PlugIns/ParticleFX/src/OgreDeflectorPlaneAffectorFactory.h
+++ b/PlugIns/ParticleFX/src/OgreDeflectorPlaneAffectorFactory.h
@@ -39,12 +39,7 @@ namespace Ogre {
     {
         String getName() const override { return "DeflectorPlane"; }
 
-        ParticleAffector* createAffector(ParticleSystem* psys) override
-        {
-            ParticleAffector* p = OGRE_NEW DeflectorPlaneAffector(psys);
-            mAffectors.push_back(p);
-            return p;
-        }
+        ParticleAffector* createAffector(ParticleSystem* psys) override { return new DeflectorPlaneAffector(psys); }
     };
 
 

--- a/PlugIns/ParticleFX/src/OgreDirectionRandomiserAffectorFactory.h
+++ b/PlugIns/ParticleFX/src/OgreDirectionRandomiserAffectorFactory.h
@@ -41,9 +41,7 @@ namespace Ogre {
 
         ParticleAffector* createAffector(ParticleSystem* psys) override
         {
-            ParticleAffector* p = OGRE_NEW DirectionRandomiserAffector(psys);
-            mAffectors.push_back(p);
-            return p;
+            return new DirectionRandomiserAffector(psys);
         }
     };
 

--- a/PlugIns/ParticleFX/src/OgreEllipsoidEmitterFactory.h
+++ b/PlugIns/ParticleFX/src/OgreEllipsoidEmitterFactory.h
@@ -49,9 +49,7 @@ namespace Ogre {
 
         ParticleEmitter* createEmitter(ParticleSystem* psys) override
         {
-            ParticleEmitter* emit = OGRE_NEW EllipsoidEmitter(psys);
-            mEmitters.push_back(emit);
-            return emit;
+            return new EllipsoidEmitter(psys);
         }
 
     };

--- a/PlugIns/ParticleFX/src/OgreHollowEllipsoidEmitterFactory.h
+++ b/PlugIns/ParticleFX/src/OgreHollowEllipsoidEmitterFactory.h
@@ -47,13 +47,7 @@ namespace Ogre {
     public:
         String getName() const override { return "HollowEllipsoid"; }
 
-        ParticleEmitter* createEmitter(ParticleSystem* psys) override
-        {
-            ParticleEmitter* emit = OGRE_NEW HollowEllipsoidEmitter(psys);
-            mEmitters.push_back(emit);
-            return emit;
-        }
-
+        ParticleEmitter* createEmitter(ParticleSystem* psys) override { return new HollowEllipsoidEmitter(psys); }
     };
 
 }

--- a/PlugIns/ParticleFX/src/OgreLinearForceAffectorFactory.h
+++ b/PlugIns/ParticleFX/src/OgreLinearForceAffectorFactory.h
@@ -39,12 +39,7 @@ namespace Ogre {
     {
         String getName() const override { return "LinearForce"; }
 
-        ParticleAffector* createAffector(ParticleSystem* psys) override
-        {
-            ParticleAffector* p = OGRE_NEW LinearForceAffector(psys);
-            mAffectors.push_back(p);
-            return p;
-        }
+        ParticleAffector* createAffector(ParticleSystem* psys) override { return new LinearForceAffector(psys); }
     };
 
 

--- a/PlugIns/ParticleFX/src/OgrePointEmitterFactory.h
+++ b/PlugIns/ParticleFX/src/OgrePointEmitterFactory.h
@@ -46,13 +46,7 @@ namespace Ogre {
     public:
         String getName() const override { return "Point"; }
 
-        ParticleEmitter* createEmitter(ParticleSystem* psys) override
-        {
-            ParticleEmitter* emit = OGRE_NEW PointEmitter(psys);
-            mEmitters.push_back(emit);
-            return emit;
-        }
-
+        ParticleEmitter* createEmitter(ParticleSystem* psys) override { return new PointEmitter(psys); }
     };
 
 }

--- a/PlugIns/ParticleFX/src/OgreRingEmitterFactory.h
+++ b/PlugIns/ParticleFX/src/OgreRingEmitterFactory.h
@@ -47,13 +47,7 @@ namespace Ogre {
     public:
         String getName() const override { return "Ring"; }
 
-        ParticleEmitter* createEmitter(ParticleSystem* psys) override
-        {
-            ParticleEmitter* emit = OGRE_NEW RingEmitter(psys);
-            mEmitters.push_back(emit);
-            return emit;
-        }
-
+        ParticleEmitter* createEmitter(ParticleSystem* psys) override { return new RingEmitter(psys); }
     };
 
 }

--- a/PlugIns/ParticleFX/src/OgreRotationAffectorFactory.h
+++ b/PlugIns/ParticleFX/src/OgreRotationAffectorFactory.h
@@ -39,12 +39,7 @@ namespace Ogre {
     {
         String getName() const override { return "Rotator"; }
 
-        ParticleAffector* createAffector(ParticleSystem* psys) override
-        {
-            ParticleAffector* p = OGRE_NEW RotationAffector(psys);
-            mAffectors.push_back(p);
-            return p;
-        }
+        ParticleAffector* createAffector(ParticleSystem* psys) override { return new RotationAffector(psys); }
     };
 
 

--- a/PlugIns/ParticleFX/src/OgreScaleAffectorFactory.h
+++ b/PlugIns/ParticleFX/src/OgreScaleAffectorFactory.h
@@ -39,12 +39,7 @@ namespace Ogre {
     {
         String getName() const override { return "Scaler"; }
 
-        ParticleAffector* createAffector(ParticleSystem* psys) override
-        {
-            ParticleAffector* p = OGRE_NEW ScaleAffector(psys);
-            mAffectors.push_back(p);
-            return p;
-        }
+        ParticleAffector* createAffector(ParticleSystem* psys) override { return new ScaleAffector(psys); }
     };
 
 


### PR DESCRIPTION
this is redundant with ParticleSystem and slows down clearing due to O(N) lookup and erase