### PR TITLE
Main: fix spelling error

### DIFF
--- a/OgreMain/include/OgrePrerequisites.h
+++ b/OgreMain/include/OgrePrerequisites.h
@@ -333,6 +333,8 @@ namespace Ogre
     _OgreExport extern const String MOT_RECTANGLE2D;
     _OgreExport extern const String MOT_STATIC_GEOMETRY;
     _OgreExport extern const String MOT_CAMERA;
+    /// @deprecated use #MOT_FRUSTUM
+    _OgreExport extern const String MOT_FRUSTRUM;
     _OgreExport extern const String MOT_FRUSTUM;
     _OgreExport extern const String MOT_MOVABLE_PLANE;
     _OgreExport extern const String MOT_INSTANCE_BATCH;

--- a/OgreMain/include/OgrePrerequisites.h
+++ b/OgreMain/include/OgrePrerequisites.h
@@ -333,7 +333,7 @@ namespace Ogre
     _OgreExport extern const String MOT_RECTANGLE2D;
     _OgreExport extern const String MOT_STATIC_GEOMETRY;
     _OgreExport extern const String MOT_CAMERA;
-    _OgreExport extern const String MOT_FRUSTRUM;
+    _OgreExport extern const String MOT_FRUSTUM;
     _OgreExport extern const String MOT_MOVABLE_PLANE;
     _OgreExport extern const String MOT_INSTANCE_BATCH;
     _OgreExport extern const String MOT_INSTANCED_ENTITY;

--- a/OgreMain/src/OgreFrustum.cpp
+++ b/OgreMain/src/OgreFrustum.cpp
@@ -31,7 +31,7 @@ THE SOFTWARE.
 
 namespace Ogre {
 
-    const String MOT_FRUSTRUM = "Frustum";
+    const String MOT_FRUSTUM = "Frustum";
     const Real Frustum::INFINITE_FAR_PLANE_ADJUST = 0.00001;
     //-----------------------------------------------------------------------
     Frustum::Frustum(const String& name) : 
@@ -734,7 +734,7 @@ namespace Ogre {
     //-----------------------------------------------------------------------
     const String& Frustum::getMovableType(void) const
     {
-        return MOT_FRUSTRUM;
+        return MOT_FRUSTUM;
     }
     //-----------------------------------------------------------------------
     Real Frustum::getBoundingRadius(void) const

--- a/OgreMain/src/OgreFrustum.cpp
+++ b/OgreMain/src/OgreFrustum.cpp
@@ -32,6 +32,7 @@ THE SOFTWARE.
 namespace Ogre {
 
     const String MOT_FRUSTUM = "Frustum";
+    const String MOT_FRUSTRUM = MOT_FRUSTUM;
     const Real Frustum::INFINITE_FAR_PLANE_ADJUST = 0.00001;
     //-----------------------------------------------------------------------
     Frustum::Frustum(const String& name) : 


### PR DESCRIPTION
I introduced a spelling error (frustrum instead of frustum) with [this](https://github.com/OGRECave/ogre/pull/2842) commit. Hopefully fixing it isn't too breaking. I doubt many people have tested for frustums since 14 came out and updating any broken code should be trivial.