### PR TITLE
add SceneNode deletion convenience methods

### DIFF
--- a/OgreMain/include/OgreSceneNode.h
+++ b/OgreMain/include/OgreSceneNode.h
@@ -294,7 +294,7 @@ namespace Ogre {
          * Removes and destroys all the children of this node
          * @par
          * Use this method to complete destroy a node, for example,
-         * if you want to recreate its render tree from scratch. 
+         * if you want to recreate its render tree from scratch.
          * @par
          * Does **not** destroy animations, textures, meshes associated with those movable objects
          * Does not destroy the node itself

--- a/OgreMain/include/OgreSceneNode.h
+++ b/OgreMain/include/OgreSceneNode.h
@@ -162,6 +162,12 @@ namespace Ogre {
         */
         virtual void detachAllObjects(void);
 
+        /** Detaches and destroys all objects attached to this node.
+         *
+         * Does not destroy objects attached to children of this node
+        */
+        void destroyAllObjects(void);
+
         /** Determines whether this node is in the scene graph, i.e.
             whether it's ultimate ancestor is the root scene node.
         */
@@ -269,6 +275,31 @@ namespace Ogre {
             node will be detached but will not be destroyed.
         */
         void removeAndDestroyAllChildren(void);
+
+        /** Removes and destroys the child and all movable objects attached to the child,
+         * and does the same to any children of that child node.
+         *
+         * Does **not** destroy animation, textures, meshes associated with those movable objects
+         * */
+        void destroyChildGraphSegment(const String& name);
+        ///@overload
+        void destroyChildGraphSegment(unsigned short index);
+        ///@overload
+        void destroyChildGraphSegment(SceneNode * child);
+
+        /** Destroys everything attatched to or decended from this node
+         * @par
+         * Detaches and destroys all objects attached to this node or
+         * its children.
+         * Removes and destroys all the children of this node 
+         * @par
+         * Use this method to complete destroy a node, for example,
+         * if you want to recreate its render tree from scratch.  
+         * @par
+         * Does **not** destroy animations, textures, meshes associated with those movable objects
+         * Does not destroy the node itself
+         * */
+        void destroyGraphSegment();
 
         /**
          * Load a scene from a file as children of this node

--- a/OgreMain/include/OgreSceneNode.h
+++ b/OgreMain/include/OgreSceneNode.h
@@ -255,7 +255,7 @@ namespace Ogre {
             node but does not destroy it, this method destroys the child
             and all of it's children. 
         @par
-            Use this if you wish to recursively destroy a node as well as 
+            Use this if you wish to recursively destroy a node as well as
             detaching it from it's parent. Note that any objects attached to
             the nodes will be detached but will not themselves be destroyed.
         */
@@ -291,10 +291,10 @@ namespace Ogre {
          * @par
          * Detaches and destroys all objects attached to this node or
          * its children.
-         * Removes and destroys all the children of this node 
+         * Removes and destroys all the children of this node
          * @par
          * Use this method to complete destroy a node, for example,
-         * if you want to recreate its render tree from scratch.  
+         * if you want to recreate its render tree from scratch. 
          * @par
          * Does **not** destroy animations, textures, meshes associated with those movable objects
          * Does not destroy the node itself

--- a/OgreMain/include/OgreSceneNode.h
+++ b/OgreMain/include/OgreSceneNode.h
@@ -281,11 +281,11 @@ namespace Ogre {
          *
          * Does **not** destroy animation, textures, meshes associated with those movable objects
          * */
-        void destroyChildGraphSegment(const String& name);
+        void destroyChildAndObjects(const String& name);
         ///@overload
-        void destroyChildGraphSegment(unsigned short index);
+        void destroyChildAndObjects(unsigned short index);
         ///@overload
-        void destroyChildGraphSegment(SceneNode * child);
+        void destroyChildAndObjects(SceneNode * child);
 
         /** Destroys everything attatched to or decended from this node
          * @par
@@ -299,7 +299,7 @@ namespace Ogre {
          * Does **not** destroy animations, textures, meshes associated with those movable objects
          * Does not destroy the node itself
          * */
-        void destroyGraphSegment();
+        void destroyAllChildrenAndObjects();
 
         /**
          * Load a scene from a file as children of this node

--- a/OgreMain/src/OgreSceneNode.cpp
+++ b/OgreMain/src/OgreSceneNode.cpp
@@ -196,7 +196,7 @@ namespace Ogre {
     //-----------------------------------------------------------------------
     void SceneNode::destroyAllObjects(void)
     {
-        while (getAttachedObjects().empty() {
+        while (!getAttachedObjects().empty()) {
             auto obj = getAttachedObjects().front();
             getCreator()->destroyMovableObject(obj);
         }
@@ -287,20 +287,18 @@ namespace Ogre {
     //-----------------------------------------------------------------------
     void SceneNode::removeAndDestroyChild(const String& name)
     {
-        SceneNode* pChild = static_cast<SceneNode*>(getChild(name));
+        SceneNode* pChild = static_cast<SceneNode*>(removeChild(name));
         pChild->removeAndDestroyAllChildren();
 
-        removeChild(name);
         pChild->getCreator()->destroySceneNode(name);
 
     }
     //-----------------------------------------------------------------------
     void SceneNode::removeAndDestroyChild(unsigned short index)
     {
-        SceneNode* pChild = static_cast<SceneNode*>(getChildren()[index]);
+        SceneNode* pChild = static_cast<SceneNode*>(removeChild(index));
         pChild->removeAndDestroyAllChildren();
 
-        removeChild(index);
         pChild->getCreator()->destroySceneNode(pChild);
     }
     //-----------------------------------------------------------------------
@@ -325,31 +323,30 @@ namespace Ogre {
         needUpdate();
     }
     //-----------------------------------------------------------------------
-    void SceneNode::destroyChildGraphSegment(const String& name) {
+    void SceneNode::destroyChildAndObjects(const String& name) {
         SceneNode* pChild = static_cast<SceneNode*>(getChild(name));
-        pChild->destroyGraphSegment();
+        pChild->destroyAllChildrenAndObjects();
 
         removeChild(name);
         pChild->getCreator()->destroySceneNode(name);
 
     }
 
-    void SceneNode::destroyChildGraphSegment(unsigned short index) {
-        SceneNode* pChild = static_cast<SceneNode*>(getChildren()[index]);
-        pChild->destroyGraphSegment();
+    void SceneNode::destroyChildAndObjects(unsigned short index) {
+        SceneNode* pChild = static_cast<SceneNode*>(removeChild(index));
+        pChild->destroyAllChildrenAndObjects();
 
-        removeChild(index);
         pChild->getCreator()->destroySceneNode(pChild);
     }
 
-    void SceneNode::destroyChildGraphSegment(SceneNode * child)
+    void SceneNode::destroyChildAndObjects(SceneNode * child)
     {
         auto it = std::find(getChildren().begin(), getChildren().end(), child);
         OgreAssert(it != getChildren().end(), "Not a child of this SceneNode");
-        destroyChildGraphSegment(it - getChildren().begin());
+        destroyChildAndObjects(it - getChildren().begin());
     }
 
-    void SceneNode::destroyGraphSegment()
+    void SceneNode::destroyAllChildrenAndObjects()
     {
         //remove objects directly attached to this node
         destroyAllObjects();
@@ -358,7 +355,7 @@ namespace Ogre {
         while(!getChildren().empty()) {
             SceneNode* child = static_cast<SceneNode*>(getChildren().front());
             //recurse
-            child->destroyGraphSegment();
+            child->destroyAllChildrenAndObjects();
 
             //destroy child
             child->getCreator()->destroySceneNode(child);

--- a/OgreMain/src/OgreSceneNode.cpp
+++ b/OgreMain/src/OgreSceneNode.cpp
@@ -196,8 +196,8 @@ namespace Ogre {
     //-----------------------------------------------------------------------
     void SceneNode::destroyAllObjects(void)
     {
-        while (getAttachedObjects().size() > 0) {
-            auto obj = getAttachedObjects()[0];
+        while (getAttachedObjects().empty() {
+            auto obj = getAttachedObjects().front();
             getCreator()->destroyMovableObject(obj);
         }
         needUpdate();

--- a/OgreMain/src/OgreSceneNode.cpp
+++ b/OgreMain/src/OgreSceneNode.cpp
@@ -195,7 +195,7 @@ namespace Ogre {
     }
     //-----------------------------------------------------------------------
     void SceneNode::destroyAllObjects(void)
-    { 
+    {
         while (getAttachedObjects().size() > 0) {
             auto obj = getAttachedObjects()[0];
             getCreator()->destroyMovableObject(obj);
@@ -347,8 +347,8 @@ namespace Ogre {
         auto it = std::find(getChildren().begin(), getChildren().end(), child);
         OgreAssert(it != getChildren().end(), "Not a child of this SceneNode");
         destroyChildGraphSegment(it - getChildren().begin());
-        
     }
+
     void SceneNode::destroyGraphSegment()
     {
         //remove objects directly attached to this node

--- a/OgreMain/src/OgreSceneNode.cpp
+++ b/OgreMain/src/OgreSceneNode.cpp
@@ -356,8 +356,6 @@ namespace Ogre {
         //go over children
         while(!getChildren().empty()) {
             SceneNode* child = static_cast<SceneNode*>(getChildren().front());
-            //destroy all objects attached to the child
-            child->destroyAllObjects();
             //recurse
             child->destroyGraphSegment();
 

--- a/OgreMain/src/OgreSceneNode.cpp
+++ b/OgreMain/src/OgreSceneNode.cpp
@@ -196,7 +196,8 @@ namespace Ogre {
     //-----------------------------------------------------------------------
     void SceneNode::destroyAllObjects(void)
     { 
-        for (auto obj : getAttachedObjects()) {
+        while (getAttachedObjects().size() > 0) {
+            auto obj = getAttachedObjects()[0];
             getCreator()->destroyMovableObject(obj);
         }
         needUpdate();

--- a/Tests/OgreMain/src/General.cpp
+++ b/Tests/OgreMain/src/General.cpp
@@ -137,7 +137,7 @@ TEST_F(SceneNodeTest, detachAllObjects){
     EXPECT_EQ(child->numAttachedObjects(), 1);
 }
 
-TEST_F(SceneNodeTest, destroyGraphSegment)
+TEST_F(SceneNodeTest, destroyAllChildrenAndObjects)
 {
 	auto sinbad = mSceneMgr->createEntity("sinbad", "Sinbad.mesh");
 	SceneNode* node = mSceneMgr->getRootSceneNode()->createChildSceneNode("parent");
@@ -151,7 +151,7 @@ TEST_F(SceneNodeTest, destroyGraphSegment)
 	SceneNode* grandchild = node->createChildSceneNode("grandchild");
     grandchild->attachObject(sinbad3);
 
-    node->destroyGraphSegment();
+    node->destroyAllChildrenAndObjects();
     EXPECT_FALSE(mSceneMgr->hasSceneNode("grandchild"));
     EXPECT_FALSE(mSceneMgr->hasEntity("sinbad3"));
     EXPECT_FALSE(mSceneMgr->hasSceneNode("child"));
@@ -160,7 +160,7 @@ TEST_F(SceneNodeTest, destroyGraphSegment)
     EXPECT_TRUE(mSceneMgr->hasSceneNode("parent"));
 }
 
-TEST_F(SceneNodeTest, destroyChildGraphSegment)
+TEST_F(SceneNodeTest, destroyChildAndObjects)
 {
 
 	auto sinbad = mSceneMgr->createEntity("sinbad", "Sinbad.mesh");
@@ -175,7 +175,8 @@ TEST_F(SceneNodeTest, destroyChildGraphSegment)
 	SceneNode* grandchild = child->createChildSceneNode("grandchild");
     grandchild->attachObject(sinbad3);
 
-    node->destroyChildGraphSegment("child");
+    node->destroyChildAndObjects("child");
+
     EXPECT_FALSE(mSceneMgr->hasSceneNode("grandchild"));
     EXPECT_FALSE(mSceneMgr->hasSceneNode("child"));
     EXPECT_TRUE(mSceneMgr->hasSceneNode("parent"));

--- a/Tests/OgreMain/src/General.cpp
+++ b/Tests/OgreMain/src/General.cpp
@@ -101,13 +101,87 @@ TEST(Root,shutdown)
     root.shutdown();
 }
 
-TEST(SceneManager,removeAndDestroyAllChildren)
+TEST(SceneManager, removeAndDestroyAllChildren)
 {
     Root root("");
     SceneManager* sm = root.createSceneManager();
     sm->getRootSceneNode()->createChildSceneNode();
     sm->getRootSceneNode()->createChildSceneNode();
     sm->getRootSceneNode()->removeAndDestroyAllChildren();
+}
+
+struct SceneNodeTest : public RootWithoutRenderSystemFixture {
+    SceneManager* mSceneMgr;
+
+    void SetUp() override {
+        RootWithoutRenderSystemFixture::SetUp();
+        mSceneMgr = mRoot->createSceneManager();
+    }
+};
+
+TEST_F(SceneNodeTest, detachAllObjects){
+	auto sinbad = mSceneMgr->createEntity("sinbad", "Sinbad.mesh");
+	auto sinbad2 = mSceneMgr->createEntity("sinbad2", "Sinbad.mesh");
+	SceneNode* node = mSceneMgr->getRootSceneNode()->createChildSceneNode("parent");
+    node->attachObject(sinbad);
+    node->attachObject(sinbad2);
+
+	auto sinbad3 = mSceneMgr->createEntity("sinbad3", "Sinbad.mesh");
+	SceneNode* child = node->createChildSceneNode("child");
+    child->attachObject(sinbad3);
+    node->destroyAllObjects();
+    EXPECT_FALSE(mSceneMgr->hasEntity("sinbad"));
+    EXPECT_FALSE(mSceneMgr->hasEntity("sinbad2"));
+    EXPECT_TRUE(mSceneMgr->hasEntity("sinbad3"));
+    EXPECT_EQ(node->numAttachedObjects(), 0);
+    EXPECT_EQ(child->numAttachedObjects(), 1);
+}
+
+TEST_F(SceneNodeTest, destroyGraphSegment)
+{
+	auto sinbad = mSceneMgr->createEntity("sinbad", "Sinbad.mesh");
+	SceneNode* node = mSceneMgr->getRootSceneNode()->createChildSceneNode("parent");
+    node->attachObject(sinbad);
+
+	auto sinbad2 = mSceneMgr->createEntity("sinbad2", "Sinbad.mesh");
+	SceneNode* child = node->createChildSceneNode("child");
+    child->attachObject(sinbad2);
+
+	auto sinbad3 = mSceneMgr->createEntity("sinbad3", "Sinbad.mesh");
+	SceneNode* grandchild = node->createChildSceneNode("grandchild");
+    grandchild->attachObject(sinbad3);
+
+    node->destroyGraphSegment();
+    EXPECT_FALSE(mSceneMgr->hasSceneNode("grandchild"));
+    EXPECT_FALSE(mSceneMgr->hasEntity("sinbad3"));
+    EXPECT_FALSE(mSceneMgr->hasSceneNode("child"));
+    EXPECT_FALSE(mSceneMgr->hasEntity("sinbad2"));
+    EXPECT_FALSE(mSceneMgr->hasEntity("sinbad"));
+    EXPECT_TRUE(mSceneMgr->hasSceneNode("parent"));
+}
+
+TEST_F(SceneNodeTest, destroyChildGraphSegment)
+{
+
+	auto sinbad = mSceneMgr->createEntity("sinbad", "Sinbad.mesh");
+	SceneNode* node = mSceneMgr->getRootSceneNode()->createChildSceneNode("parent");
+    node->attachObject(sinbad);
+
+	auto sinbad2 = mSceneMgr->createEntity("sinbad2", "Sinbad.mesh");
+	SceneNode* child = node->createChildSceneNode("child");
+    child->attachObject(sinbad2);
+
+	auto sinbad3 = mSceneMgr->createEntity("sinbad3", "Sinbad.mesh");
+	SceneNode* grandchild = child->createChildSceneNode("grandchild");
+    grandchild->attachObject(sinbad3);
+
+    node->destroyChildGraphSegment("child");
+    EXPECT_FALSE(mSceneMgr->hasSceneNode("grandchild"));
+    EXPECT_FALSE(mSceneMgr->hasSceneNode("child"));
+    EXPECT_TRUE(mSceneMgr->hasSceneNode("parent"));
+    EXPECT_FALSE(mSceneMgr->hasEntity("sinbad2"));
+    EXPECT_FALSE(mSceneMgr->hasEntity("sinbad3"));
+    EXPECT_TRUE(mSceneMgr->hasEntity("sinbad"));
 }
 
 static void createRandomEntityClones(Entity* ent, size_t cloneCount, const Vector3& min,


### PR DESCRIPTION
This commit adds convenience method to delete a node and its attached objects, as I needed and people asked about [here](https://forums.ogre3d.org/viewtopic.php?t=28547) and [here](https://forums.ogre3d.org/viewtopic.php?t=53647). 

The use case is if you want to clear a `SceneNode` and put everything back from scratch (a simple if slower way of updating an object to reflect game state), or if you wish to stop rendering a node (and thus things attached to it can be garbage collected). 

This patch adds three new non-virtual methods to `SceneNode` that analogous to the other methods but also delete the detached objects:

`SceneNode::destroyGraphSegment`, analogous to `SceneNode::removeAndDestroyAllChildren`, except it also destroys all MovableObjects attached to `this` and to any of the descendants. In other words, all children are destroyed and any objects attached to them and any objects attached to `this`.

`SceneNode::destroyChildGraphSegment`, analogous to `SceneNode::removeAndDestroyChild`, except it also destroys the objects attached to the child. 

`SceneNode::destroyAllObjects`, analogous to `SceneNode::detatchAllObjects`, except it destroys the objects too. Unlike detatchAllObjects, this function is not virtual. I believe it is not required for it to be, since everything it does could be achieved using external methods. Moreover, I did not want to increase memory footprint of SceneNode. I called it `destroyAllObjects` rather than `detatchAndDestroyAllObjects` to keep the name short and because detatching is already considered part of destroying MovableObjects.

The naming scheme of `GraphSegment` was chosen as `removeAndDestroyAllChildrenAndAttached` seemed too long. `removeAndDestroy` in the original methods' names feel redundant to me, but best not changed as to not break the API. 

There are tests added to test the basic behaviour of the 3 added methods included in this pull request.

This code deletes MovableObjects only; I have never worked with skeletons or animations, so it may not delete those. I am not sure if deleting animations would even be desired behaviour, as animations might be more analogous to meshes than entities.

Please view the code with some skepticism, as I am unfamiliar with the Ogre code base and thus, it is greater risk that I broke expected behaviour or introduced undefined behaviour. And I am of course, happy to make any changes that are needed.