### PR TITLE
GLES2: turn on normalization for VET_INT_10_10_10_2_NORM

### DIFF
--- a/RenderSystems/GLES2/src/OgreGLES2RenderSystem.cpp
+++ b/RenderSystems/GLES2/src/OgreGLES2RenderSystem.cpp
@@ -1703,6 +1703,7 @@ namespace Ogre {
             case VET_USHORT2_NORM:
             case VET_SHORT4_NORM:
             case VET_USHORT4_NORM:
+            case VET_INT_10_10_10_2_NORM:
                 normalised = GL_TRUE;
                 break;
             default:


### PR DESCRIPTION
This patch turns on normalized access to `VET_INT_10_10_10_2_NORM` vertex attributes under the GLES2 backend.
Every other RS that supports this format enables normalized access ([1][2][3]) and the `_NORM` suffix implies that it should be normalized, so maybe it was just not tested with GLES2.

[1] https://github.com/OGRECave/ogre/blob/6ee8101f0b72f31ba31697866f4d91a217354c35/RenderSystems/GL3Plus/src/OgreGL3PlusRenderSystem.cpp#L1685-L1686
[2] https://github.com/OGRECave/ogre/blob/6ee8101f0b72f31ba31697866f4d91a217354c35/RenderSystems/Vulkan/src/OgreVulkanMappings.cpp#L206-L207
[3] https://github.com/OGRECave/ogre/blob/6ee8101f0b72f31ba31697866f4d91a217354c35/RenderSystems/Metal/src/OgreMetalMappings.mm#L345