### PR TITLE
Static Geometry collection access in scenemanager (fixes #113)

### DIFF
--- a/OgreMain/include/Ogre.i
+++ b/OgreMain/include/Ogre.i
@@ -666,6 +666,10 @@ SHARED_PTR(HardwarePixelBuffer);
         typedef pointer_category category;
         static const char* type_name() { return "Ogre::Camera"; }
     };
+    template<> struct traits<Ogre::StaticGeometry> {
+        typedef pointer_category category;
+        static const char* type_name() { return "Ogre::StaticGeometry"; }
+    };
     }
 %}
 #endif
@@ -884,6 +888,7 @@ SHARED_PTR(Mesh);
 %newobject Ogre::SceneManager::createRayQuery(const Ray&);
 %rename(SceneManager_Listener) Ogre::SceneManager::Listener;
 %template(MovableObjectMap) std::map<std::string, Ogre::MovableObject*>;
+%template(StaticGeometryMap) std::map<std::string, Ogre::StaticGeometry*>;
 %template(CameraMap) std::map<std::string, Ogre::Camera*>;
 %include "OgreSceneManager.h"
 %include "OgreDefaultDebugDrawer.h"

--- a/OgreMain/include/OgreSceneManager.h
+++ b/OgreMain/include/OgreSceneManager.h
@@ -405,6 +405,7 @@ namespace Ogre {
         typedef std::map<String, Camera* > CameraList;
         typedef std::map<String, Animation*> AnimationList;
         typedef std::map<String, MovableObject*> MovableObjectMap;
+        typedef std::map<String, StaticGeometry* > StaticGeometryMap;
     private:
         HardwareVertexBufferPtr mInstanceBuffer;
 
@@ -421,8 +422,7 @@ namespace Ogre {
         /// Queue of objects for rendering
         std::unique_ptr<RenderQueue> mRenderQueue;
 
-        typedef std::map<String, StaticGeometry* > StaticGeometryList;
-        StaticGeometryList mStaticGeometryList;
+        StaticGeometryMap mStaticGeometryList;
 
         typedef std::map<String, InstanceManager*> InstanceManagerMap;
         InstanceManagerMap  mInstanceManagerMap;
@@ -2979,6 +2979,8 @@ namespace Ogre {
         StaticGeometry* getStaticGeometry(const String& name) const;
         /** Returns whether a static geometry instance with the given name exists. */
         bool hasStaticGeometry(const String& name) const;
+        /** Returns all static geometry instances with names. */
+        const StaticGeometryMap* getStaticGeometryCollection() const;
         /** Remove & destroy a StaticGeometry instance. */
         void destroyStaticGeometry(StaticGeometry* geom);
         /** Remove & destroy a StaticGeometry instance. */

--- a/OgreMain/src/OgreSceneManager.cpp
+++ b/OgreMain/src/OgreSceneManager.cpp
@@ -2948,7 +2948,7 @@ StaticGeometry* SceneManager::createStaticGeometry(const String& name)
 //---------------------------------------------------------------------
 StaticGeometry* SceneManager::getStaticGeometry(const String& name) const
 {
-    StaticGeometryList::const_iterator i = mStaticGeometryList.find(name);
+    StaticGeometryMap::const_iterator i = mStaticGeometryList.find(name);
     if (i == mStaticGeometryList.end())
     {
         OGRE_EXCEPT(Exception::ERR_ITEM_NOT_FOUND, 
@@ -2963,6 +2963,12 @@ bool SceneManager::hasStaticGeometry(const String& name) const
     return (mStaticGeometryList.find(name) != mStaticGeometryList.end());
 }
 
+//-----------------------------------------------------------------------
+const SceneManager::StaticGeometryMap* SceneManager:: getStaticGeometryCollection() const
+{
+  return &mStaticGeometryList;
+}
+
 //---------------------------------------------------------------------
 void SceneManager::destroyStaticGeometry(StaticGeometry* geom)
 {
@@ -2971,7 +2977,7 @@ void SceneManager::destroyStaticGeometry(StaticGeometry* geom)
 //---------------------------------------------------------------------
 void SceneManager::destroyStaticGeometry(const String& name)
 {
-    StaticGeometryList::iterator i = mStaticGeometryList.find(name);
+    StaticGeometryMap::iterator i = mStaticGeometryList.find(name);
     if (i != mStaticGeometryList.end())
     {
         OGRE_DELETE i->second;


### PR DESCRIPTION
Added access to the full map of names to StaticGeometry held by the SceneManager.

Renamed the internal typedef `StaticGeometryList` to `StaticGeometryMap` to make it similar to `MoveableObjectMap` as I made it public but I didn't renamed the internal `mStaticGeometryList`.