### PR TITLE
Update OgreGLSLPreprocessor.h

### DIFF
--- a/RenderSystems/GLSupport/include/GLSL/OgreGLSLPreprocessor.h
+++ b/RenderSystems/GLSupport/include/GLSL/OgreGLSLPreprocessor.h
@@ -161,7 +161,7 @@ namespace Ogre {
             void SetValue (long iValue);
 
             /// Test two tokens for equality
-            bool operator == (const Token &iOther)
+            bool operator == (const Token &iOther) const
             {
                 if (iOther.Length != Length)
                     return false;


### PR DESCRIPTION
- missing 'const' lead to error in C++20