### PR TITLE
CMake : Dependencies - updated zlib's broken link

### DIFF
--- a/CMake/Dependencies.cmake
+++ b/CMake/Dependencies.cmake
@@ -146,7 +146,7 @@ if(OGRE_BUILD_DEPENDENCIES AND NOT EXISTS ${OGREDEPS_PATH})
     if(MSVC OR MINGW OR SKBUILD) # other platforms dont need this
       message(STATUS "Building zlib") # only needed for Assimp
       file(DOWNLOAD
-          https://www.zlib.net/zlib-1.3.tar.gz
+          https://github.com/madler/zlib/releases/download/v1.3/zlib-1.3.tar.gz
           ${PROJECT_BINARY_DIR}/zlib-1.3.tar.gz
           EXPECTED_HASH SHA256=ff0ba4c292013dbc27530b3a81e1f9a813cd39de01ca5e0f8bf355702efa593e)
       execute_process(COMMAND ${CMAKE_COMMAND}

--- a/CMake/Dependencies.cmake
+++ b/CMake/Dependencies.cmake
@@ -148,7 +148,7 @@ if(OGRE_BUILD_DEPENDENCIES AND NOT EXISTS ${OGREDEPS_PATH})
       file(DOWNLOAD
           https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz
           ${PROJECT_BINARY_DIR}/zlib-1.3.tar.gz
-          EXPECTED_HASH SHA256=ff0ba4c292013dbc27530b3a81e1f9a813cd39de01ca5e0f8bf355702efa593e)
+          EXPECTED_HASH SHA256=9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23)
       execute_process(COMMAND ${CMAKE_COMMAND}
           -E tar xf zlib-1.3.tar.gz WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
       execute_process(COMMAND ${BUILD_COMMAND_COMMON}

--- a/CMake/Dependencies.cmake
+++ b/CMake/Dependencies.cmake
@@ -146,7 +146,7 @@ if(OGRE_BUILD_DEPENDENCIES AND NOT EXISTS ${OGREDEPS_PATH})
     if(MSVC OR MINGW OR SKBUILD) # other platforms dont need this
       message(STATUS "Building zlib") # only needed for Assimp
       file(DOWNLOAD
-          https://github.com/madler/zlib/releases/download/v1.3/zlib-1.3.tar.gz
+          https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz
           ${PROJECT_BINARY_DIR}/zlib-1.3.tar.gz
           EXPECTED_HASH SHA256=ff0ba4c292013dbc27530b3a81e1f9a813cd39de01ca5e0f8bf355702efa593e)
       execute_process(COMMAND ${CMAKE_COMMAND}


### PR DESCRIPTION
While I was compiling the source code in CMake, the application gave me an error message saying that it could not find zlib's source code. Therefore, I changed the original link (located in the _Dependencies.cmake_ file) with the original release located on GitHub. Everything now works just fine.