### PR TITLE
Always provide bones matrices if hw anim enabled.

### DIFF
--- a/OgreMain/src/OgreSubEntity.cpp
+++ b/OgreMain/src/OgreSubEntity.cpp
@@ -177,17 +177,17 @@ namespace Ogre {
                 mSubMesh->parent->sharedBlendIndexToBoneIndexMap : mSubMesh->blendIndexToBoneIndexMap;
             assert(indexMap.size() <= mParentEntity->mNumBoneMatrices);
 
-            if (mParentEntity->_isSkeletonAnimated())
+            if (MeshManager::getBonesUseObjectSpace())
+            {
+                *xform++ = mParentEntity->_getParentNodeFullTransform();
+            }
+
+            if (mParentEntity->hasSkeleton())
             {
                 // Bones, use cached matrices built when Entity::_updateRenderQueue was called
                 auto boneMatrices = MeshManager::getBonesUseObjectSpace() ? mParentEntity->mBoneMatrices
                                                                           : mParentEntity->mBoneWorldMatrices;
                 assert(boneMatrices);
-
-                if (MeshManager::getBonesUseObjectSpace())
-                {
-                    *xform++ = mParentEntity->_getParentNodeFullTransform();
-                }
 
                 for (auto idx : indexMap)
                 {


### PR DESCRIPTION
This fixes an issue where no bones matrices would be generated if there was no active animation.
This would result in incorrect vertex calculations, since the shaders expect bone matrices independently of whether there's an active animation or not.

I ran into this issue after upgrading Ogre and enabling World Space Bones. We use our own shaders and I adjusted them and everything ran nicely, until I had a situation with a mesh that didn't have any active animations. The vertices would get messed up.
This change fixed that, but it's not completely obvious to me how this worked previously (with local bones) but not now (with world space bones), so I'm a bit cautious about this fix. It needs some more eyes.
