### PR TITLE
Add set/get default color implementation for Bullet DebugDrawer class

### DIFF
--- a/Components/Bullet/include/OgreBullet.h
+++ b/Components/Bullet/include/OgreBullet.h
@@ -143,6 +143,8 @@ class _OgreBulletExport DebugDrawer : public btIDebugDraw
     ManualObject mLines;
     int mDebugMode;
 
+    DefaultColors colors;
+
 public:
     DebugDrawer(SceneNode* node, btCollisionWorld* world)
         : mNode(node), mWorld(world), mLines(""), mDebugMode(DBG_DrawWireframe)
@@ -158,6 +160,10 @@ public:
         if (!mLines.getSections().empty()) // begin was called
             mLines.end();
     }
+
+    void setDefaultColors(const DefaultColors& defaultColors) override { colors = defaultColors; };
+
+    DefaultColors getDefaultColors() const override { return colors; };
 
     void drawLine(const btVector3& from, const btVector3& to, const btVector3& color) override;
 

--- a/Components/Bullet/include/OgreBullet.i
+++ b/Components/Bullet/include/OgreBullet.i
@@ -41,6 +41,7 @@
 #define ATTRIBUTE_ALIGNED16(a) a
 typedef float btScalar;
 %include "LinearMath/btVector3.h"
+%include "LinearMath/btIDebugDraw.h"
 %include "BulletCollision/NarrowPhaseCollision/btManifoldPoint.h"
 %include "BulletCollision/CollisionDispatch/btCollisionObject.h"
 %include "BulletDynamics/Dynamics/btRigidBody.h"


### PR DESCRIPTION
Currently, is only possible to debug OgreBullet wrapper with the default black wireframe color. The only workaround was possible if you create your own debug wrapper by inhering from the existing one and then overwriting set/get defaultColors methods involving a lot of code for such a simple thing.