### PR TITLE
Main: GpuProgramManager - bump Microcode cache version

### DIFF
--- a/OgreMain/src/OgreGpuProgramManager.cpp
+++ b/OgreMain/src/OgreGpuProgramManager.cpp
@@ -351,7 +351,7 @@ namespace {
         }
         
         StreamSerialiser serialiser(stream);
-        serialiser.writeChunkBegin(CACHE_CHUNK_ID, 2);
+        serialiser.writeChunkBegin(CACHE_CHUNK_ID, 3);
 
         // write the size of the array
         uint32 sizeOfArray = static_cast<uint32>(mMicrocodeCache.size());
@@ -391,9 +391,10 @@ namespace {
             return;
         }
 
-        if(chunk->id != CACHE_CHUNK_ID || chunk->version != 2)
+        if(chunk->id != CACHE_CHUNK_ID || chunk->version != 3)
         {
             LogManager::getSingleton().logWarning("Invalid Microcode Cache");
+            serialiser.readChunkEnd(CACHE_CHUNK_ID);
             return;
         }
         // write the size of the array


### PR DESCRIPTION
as we changed the disk format for D3D11 in 14.2

fixes  #3056