### PR TITLE
Main: Material - compile before loading techs

### DIFF
--- a/OgreMain/src/OgreMaterial.cpp
+++ b/OgreMain/src/OgreMaterial.cpp
@@ -127,15 +127,16 @@ namespace Ogre {
     //-----------------------------------------------------------------------
     void Material::loadImpl(void)
     {
+        // compile if required
+        if (mCompilationRequired)
+            compile();
+
         // Load all supported techniques
         for (auto *t : mSupportedTechniques)
         {
             t->_load();
         }
 
-        // compile if required
-        if (mCompilationRequired)
-            compile();
     }
     //-----------------------------------------------------------------------
     void Material::unloadImpl(void)


### PR DESCRIPTION
If there are techniques that use shaders they are all "unsupported" until compilation has happened.