### PR TITLE
fix mismatch operand type for operator ==

### DIFF
--- a/RenderSystems/GL3Plus/src/OgreGL3PlusPixelFormat.cpp
+++ b/RenderSystems/GL3Plus/src/OgreGL3PlusPixelFormat.cpp
@@ -329,7 +329,7 @@ namespace Ogre  {
     GLenum GL3PlusPixelUtil::getClosestGLImageInternalFormat(PixelFormat format)
     {
         GLenum GLformat = getGLImageInternalFormat(format);
-        return (format == GL_NONE ? GL_RGBA8 : GLformat);
+        return (GLformat == GL_NONE ? GL_RGBA8 : GLformat);
     }
 
 


### PR DESCRIPTION
variable `format` 's type is `PixelFormat`, it shouldn't compared to `GL_NONE`.

it  is  mismatched.

i change it to `GLformat`

