### PR TITLE
Add support for LT_RECTLIGHT to DotScene

### DIFF
--- a/PlugIns/DotScene/include/OgreDotSceneLoader.h
+++ b/PlugIns/DotScene/include/OgreDotSceneLoader.h
@@ -72,6 +72,7 @@ protected:
 
     void processLightRange(pugi::xml_node& XMLNode, Ogre::Light* pLight);
     void processLightAttenuation(pugi::xml_node& XMLNode, Ogre::Light* pLight);
+	void processLightSourceSize(pugi::xml_node& XMLNode, Ogre::Light* pLight);
 
     Ogre::SceneManager* mSceneMgr;
     Ogre::SceneNode* mAttachNode;

--- a/PlugIns/DotScene/misc/dotscene.dtd
+++ b/PlugIns/DotScene/misc/dotscene.dtd
@@ -36,11 +36,11 @@
     template    CDATA    #REQUIRED
 >
 
-<!ELEMENT light (colourDiffuse?, colourSpecular?, lightRange?, lightAttenuation?, userData?)>
+<!ELEMENT light (colourDiffuse?, colourSpecular?, lightRange?, lightAttenuation?, lightSourceSize?, userData?)>
 <!ATTLIST light
     name            CDATA    #IMPLIED
     id                ID        #IMPLIED
-    type            (point | directional | spot ) "point"
+    type            (point | directional | spot | rect) "point"
     visible            (true | false) "true"
     castShadows        (true | false) "true"
     powerScale      CDATA   "1.0"
@@ -79,6 +79,12 @@
     inner    CDATA    #REQUIRED
     outer    CDATA    #REQUIRED
     falloff CDATA    #REQUIRED
+>
+
+<!ELEMENT lightSourceSize EMPTY>
+<!ATTLIST lightSourceSize
+    width   CDATA    #REQUIRED
+    height  CDATA    #REQUIRED
 >
 
 <!ELEMENT entity (userData?)>

--- a/PlugIns/DotScene/src/DotSceneLoader.cpp
+++ b/PlugIns/DotScene/src/DotSceneLoader.cpp
@@ -338,6 +338,8 @@ void DotSceneLoader::processLight(pugi::xml_node& XMLNode, SceneNode* pParent)
         pLight->setType(Light::LT_SPOTLIGHT);
     else if (sValue == "radPoint")
         pLight->setType(Light::LT_POINT);
+    else if (sValue == "rect")
+        pLight->setType(Light::LT_RECTLIGHT);
 
     pLight->setVisible(getAttribBool(XMLNode, "visible", true));
     pLight->setCastShadows(getAttribBool(XMLNode, "castShadows", true));
@@ -361,6 +363,14 @@ void DotSceneLoader::processLight(pugi::xml_node& XMLNode, SceneNode* pParent)
         if (auto pElement = XMLNode.child("lightAttenuation"))
             processLightAttenuation(pElement, pLight);
     }
+
+    if (sValue == "rect")
+    {
+        // Process lightSourceSize (?)
+        if (auto pElement = XMLNode.child("lightSourceSize"))
+            processLightSourceSize(pElement, pLight);
+	}
+
     // Process userDataReference (?)
     if (auto pElement = XMLNode.child("userData"))
         processUserData(pElement, pLight->getUserObjectBindings());
@@ -845,6 +855,16 @@ void DotSceneLoader::processLightAttenuation(pugi::xml_node& XMLNode, Light* pLi
 
     // Setup the light attenuation
     pLight->setAttenuation(range, constant, linear, quadratic);
+}
+
+void DotSceneLoader::processLightSourceSize(pugi::xml_node& XMLNode, Light* pLight)
+{
+    // Process attributes
+    Real width = getAttribReal(XMLNode, "width");
+    Real height = getAttribReal(XMLNode, "height");
+
+    // Setup the light range
+    pLight->setSourceSize(width, height);
 }
 
 void DotSceneLoader::processUserData(pugi::xml_node& XMLNode, UserObjectBindings& userData)


### PR DESCRIPTION
Rectangular Area Lights were added in OGRE 14.1, but they are not loaded by DotScene.
https://www.ogre3d.org/2023/09/12/ogre-14-1-released#rectangular-area-lights
