### PR TITLE
Main: Log - spell out %T as MinGW does not support %T

### DIFF
--- a/OgreMain/src/OgreLog.cpp
+++ b/OgreMain/src/OgreLog.cpp
@@ -137,7 +137,7 @@ namespace Ogre
                     {
                         auto t = std::time(nullptr);
                         auto pTime = std::localtime(&t);
-                        mLog << std::put_time(pTime, "%T: ");
+                        mLog << std::put_time(pTime, "%H:%M:%S: ");
                     }
                     mLog << message << std::endl;
 


### PR DESCRIPTION
fixes #3078 