### PR TITLE
Remove improper "active" attribute from skyBox in DotSceneLoader

### DIFF
--- a/PlugIns/DotScene/misc/dotscene.dtd
+++ b/PlugIns/DotScene/misc/dotscene.dtd
@@ -119,7 +119,7 @@
 <!ATTLIST skyBox
     material    CDATA #REQUIRED
     distance    CDATA     "5000"
-    drawFirst   (true | false)    "true"
+    drawFirst    (true | false)    "true"
 >
 
 <!ELEMENT skyDome (rotation?)>

--- a/PlugIns/DotScene/misc/dotscene.dtd
+++ b/PlugIns/DotScene/misc/dotscene.dtd
@@ -119,7 +119,7 @@
 <!ATTLIST skyBox
     material    CDATA #REQUIRED
     distance    CDATA     "5000"
-    drawFirst    (true | false)    "true"
+    drawFirst   (true | false)    "true"
 >
 
 <!ELEMENT skyDome (rotation?)>

--- a/PlugIns/DotScene/src/DotSceneLoader.cpp
+++ b/PlugIns/DotScene/src/DotSceneLoader.cpp
@@ -775,9 +775,6 @@ void DotSceneLoader::processSkyBox(pugi::xml_node& XMLNode)
     String material = getAttrib(XMLNode, "material", "BaseWhite");
     Real distance = getAttribReal(XMLNode, "distance", 5000);
     bool drawFirst = getAttribBool(XMLNode, "drawFirst", true);
-    bool active = getAttribBool(XMLNode, "active", false);
-    if (!active)
-        return;
 
     // Process rotation (?)
     Quaternion rotation = Quaternion::IDENTITY;


### PR DESCRIPTION
This option is being used in `DotSceneLoader.cpp` but is absent in the DTD.
