### PR TITLE
Font: Memory leak

### DIFF
--- a/Components/Overlay/src/OgreFont.cpp
+++ b/Components/Overlay/src/OgreFont.cpp
@@ -528,6 +528,13 @@ namespace Ogre
                 // Advance a column
                 if(width)
                     l += (width + char_spacer);
+
+#ifndef HAVE_FREETYPE
+                if (buffer != NULL)
+                {
+                    STBTT_free(buffer, font.userdata);
+                }
+#endif
             }
         }
 #ifdef HAVE_FREETYPE


### PR DESCRIPTION
If HAVE_FREETYPE macro is not defined, the memory allocated in buffer is not freed