### PR TITLE
Add missing OGRE-BitesQt pkgconfig file

### DIFF
--- a/CMake/Templates/OGRE-BitesQt.pc.in
+++ b/CMake/Templates/OGRE-BitesQt.pc.in
@@ -1,0 +1,11 @@
+prefix=@OGRE_PREFIX_PATH@
+exec_prefix=${prefix}
+libdir=${prefix}/@OGRE_LIB_DIRECTORY@
+includedir=${prefix}/include
+
+Name: OGRE-BitesQt
+Description: BitesQt component for OGRE
+Version: @OGRE_VERSION@
+Requires: OGRE = @OGRE_VERSION@ @OGRE_BITESQT_ADDITIONAL_PACKAGES@
+Libs: -L${libdir} -lOgreBitesQt@OGRE_LIB_SUFFIX@
+Cflags: -I${includedir}/OGRE/Bites @OGRE_CFLAGS@

--- a/Components/Bites/CMakeLists.txt
+++ b/Components/Bites/CMakeLists.txt
@@ -221,6 +221,9 @@ if(_OgreBitesQt)
       "$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include_private>")
   endif()
   ogre_config_component(OgreBitesQt)
+  set(OGRE_BITESQT_ADDITIONAL_PACKAGES ", Qt${QT_VERSION_MAJOR}Gui")
+  configure_file(${OGRE_TEMPLATES_DIR}/OGRE-BitesQt.pc.in ${PROJECT_BINARY_DIR}/pkgconfig/OGRE-BitesQt.pc @ONLY)
+  install(FILES ${PROJECT_BINARY_DIR}/pkgconfig/OGRE-BitesQt.pc DESTINATION ${OGRE_LIB_DIRECTORY}/pkgconfig)
 endif()
 
 # install


### PR DESCRIPTION
This work adds OGRE-BitesQt.pc.in template file and necessary cmake commands to configure and install it, if applicable. 
Note that the commands are not placed in `ConfigureBuild.cmake` as most (or all) the other pkgconfig configurations are done. The reason for doing it in `Component/Bites/CMakeLists.txt` is that some necessary variables are not defined earlier.

I assume most people use OGRE's find package script over pkgconfig, since this has not been reported. Nevertheless, it is useful to provide it for completeness.
