### PR TITLE
Improve Wayland initialization

### DIFF
--- a/RenderSystems/GLSupport/include/EGL/Wayland/OgreWaylandEGLSupport.h
+++ b/RenderSystems/GLSupport/include/EGL/Wayland/OgreWaylandEGLSupport.h
@@ -22,21 +22,20 @@ public:
 
 protected:
     VideoModes mCbVideoModes;
+    EGLWindow* mInitialWindow = nullptr;
+
+    void start() override;
+
+    void doInit();
 
 public:
     WaylandEGLSupport(int profile);
     virtual ~WaylandEGLSupport();
 
-    inline void setNativeDisplay(NativeDisplayType t)
-    {
-        mIsExternalDisplay = true;
-        mNativeDisplay = t;
-    }
     NativeDisplayType getNativeDisplay(void);
     // This just sets the native variables needed by EGLSupport::getGLDisplay
     // Then it calls EGLSupport::getGLDisplay to do the rest of the work.
     EGLDisplay getGLDisplay();
-    void doInit();
 
     RenderWindow* newWindow(const String& name, unsigned int width, unsigned int height, bool fullScreen,
                             const NameValuePairList* miscParams = 0) override;

--- a/RenderSystems/GLSupport/include/EGL/Wayland/OgreWaylandEGLSupport.h
+++ b/RenderSystems/GLSupport/include/EGL/Wayland/OgreWaylandEGLSupport.h
@@ -17,7 +17,6 @@ namespace Ogre
 class _OgrePrivate WaylandEGLSupport : public EGLSupport
 {
 public:
-    wl_surface* mWlSurface;
     bool mIsExternalDisplay;
 
 protected:

--- a/RenderSystems/GLSupport/include/EGL/Wayland/OgreWaylandEGLWindow.h
+++ b/RenderSystems/GLSupport/include/EGL/Wayland/OgreWaylandEGLWindow.h
@@ -15,6 +15,7 @@ class _OgrePrivate WaylandEGLWindow : public EGLWindow
 {
 protected:
     WaylandEGLSupport* mGLSupport;
+    wl_surface* mWlSurface;
 
     void initNativeCreatedWindow(const NameValuePairList* miscParams);
     void createNativeWindow(uint& width, uint& height);

--- a/RenderSystems/GLSupport/src/EGL/OgreEGLSupport.cpp
+++ b/RenderSystems/GLSupport/src/EGL/OgreEGLSupport.cpp
@@ -320,6 +320,7 @@ namespace Ogre {
         {
             OGRE_EXCEPT(Exception::ERR_RENDERINGAPI_ERROR, "eglBindAPI failed");
         }
+        EGL_CHECK_ERROR
 
         if(mContextProfile != CONTEXT_ES) {
             contextAttrs[1] = 4;
@@ -349,7 +350,7 @@ namespace Ogre {
         while(!context && (contextAttrs[1] >= 1))
         {
             context = eglCreateContext(eglDisplay, glconfig, shareList, contextAttrs);
-            EGL_CHECK_ERROR
+            eglGetError(); // errors from eglCreateContext are not fatal
             contextAttrs[1] -= contextAttrs[3] == 0; // only decrement if minor == 0
 
             if(hasEGL15)

--- a/RenderSystems/GLSupport/src/EGL/OgreEGLSupport.cpp
+++ b/RenderSystems/GLSupport/src/EGL/OgreEGLSupport.cpp
@@ -377,8 +377,11 @@ namespace Ogre {
 
     void EGLSupport::stop()
     {
-        eglTerminate(mGLDisplay);
-        EGL_CHECK_ERROR
+        if (mGLDisplay)
+        {
+            eglTerminate(mGLDisplay);
+            EGL_CHECK_ERROR
+        }
     }
 
     void EGLSupport::initialiseExtensions() {

--- a/RenderSystems/GLSupport/src/EGL/Wayland/OgreWaylandEGLSupport.cpp
+++ b/RenderSystems/GLSupport/src/EGL/Wayland/OgreWaylandEGLSupport.cpp
@@ -62,6 +62,8 @@ void WaylandEGLSupport::doInit()
     }
 
     free(glConfigs);
+
+    initialiseExtensions();
 }
 
 WaylandEGLSupport::~WaylandEGLSupport()
@@ -106,9 +108,33 @@ RenderWindow* WaylandEGLSupport::newWindow(const String& name, unsigned int widt
 {
     EGLWindow* window = new WaylandEGLWindow(this);
 
+    if (!mInitialWindow)
+    {
+        mInitialWindow = window;
+
+        NameValuePairList::const_iterator opt;
+        NameValuePairList::const_iterator end = miscParams->end();
+
+        if ((opt = miscParams->find("externalWlDisplay")) != end)
+        {
+            mNativeDisplay = (wl_display*)StringConverter::parseSizeT(opt->second);
+            mIsExternalDisplay = true;
+        }
+
+        doInit();
+    }
+
     window->create(name, width, height, fullScreen, miscParams);
 
     return window;
+}
+
+void WaylandEGLSupport::start()
+{
+    LogManager::getSingleton().logMessage(
+        "******************************\n"
+        "*** Starting EGL Subsystem ***\n"
+        "******************************");
 }
 
 // WaylandEGLSupport::getGLDisplay sets up the native variable

--- a/RenderSystems/GLSupport/src/EGL/Wayland/OgreWaylandEGLSupport.cpp
+++ b/RenderSystems/GLSupport/src/EGL/Wayland/OgreWaylandEGLSupport.cpp
@@ -20,7 +20,6 @@ GLNativeSupport* getGLSupport(int profile) { return new WaylandEGLSupport(profil
 
 WaylandEGLSupport::WaylandEGLSupport(int profile) : EGLSupport(profile)
 {
-    mWlSurface = nullptr;
     mIsExternalDisplay = false;
 }
 

--- a/RenderSystems/GLSupport/src/EGL/Wayland/OgreWaylandEGLWindow.cpp
+++ b/RenderSystems/GLSupport/src/EGL/Wayland/OgreWaylandEGLWindow.cpp
@@ -41,11 +41,6 @@ void WaylandEGLWindow::initNativeCreatedWindow(const NameValuePairList* miscPara
         NameValuePairList::const_iterator opt;
         NameValuePairList::const_iterator end = miscParams->end();
 
-        if ((opt = miscParams->find("externalWlDisplay")) != end)
-        {
-            mNativeDisplay = (wl_display*)StringConverter::parseSizeT(opt->second);
-            mGLSupport->setNativeDisplay(mNativeDisplay);
-        }
         if ((opt = miscParams->find("externalWlSurface")) != end)
         {
             mGLSupport->mWlSurface = (wl_surface*)StringConverter::parseSizeT(opt->second);
@@ -130,6 +125,8 @@ void WaylandEGLWindow::create(const String& name, uint width, uint height, bool 
     ::EGLContext eglContext = nullptr;
     unsigned int vsyncInterval = 1;
 
+    mNativeDisplay = mGLSupport->getNativeDisplay();
+
     mIsFullScreen = fullScreen;
 
     if (miscParams)
@@ -206,7 +203,6 @@ void WaylandEGLWindow::create(const String& name, uint width, uint height, bool 
     }
 
     initNativeCreatedWindow(miscParams);
-    mGLSupport->doInit();
 
     if (!mEglConfig)
     {

--- a/RenderSystems/GLSupport/src/EGL/Wayland/OgreWaylandEGLWindow.cpp
+++ b/RenderSystems/GLSupport/src/EGL/Wayland/OgreWaylandEGLWindow.cpp
@@ -21,6 +21,7 @@ namespace Ogre
 WaylandEGLWindow::WaylandEGLWindow(WaylandEGLSupport* glsupport) : EGLWindow(glsupport)
 {
     mGLSupport = glsupport;
+    mWlSurface = nullptr;
     mNativeDisplay = nullptr;
 }
 
@@ -43,10 +44,10 @@ void WaylandEGLWindow::initNativeCreatedWindow(const NameValuePairList* miscPara
 
         if ((opt = miscParams->find("externalWlSurface")) != end)
         {
-            mGLSupport->mWlSurface = (wl_surface*)StringConverter::parseSizeT(opt->second);
+            mWlSurface = (wl_surface*)StringConverter::parseSizeT(opt->second);
         }
     }
-    OgreAssert(mGLSupport->mWlSurface, "externalWlSurface required");
+    OgreAssert(mWlSurface, "externalWlSurface required");
 }
 
 void WaylandEGLWindow::createNativeWindow(uint& width, uint& height)
@@ -55,7 +56,7 @@ void WaylandEGLWindow::createNativeWindow(uint& width, uint& height)
 
     if (!mWindow)
     {
-        mWindow = wl_egl_window_create(mGLSupport->mWlSurface, width, height);
+        mWindow = wl_egl_window_create(mWlSurface, width, height);
     }
 
     if (mWindow == EGL_NO_SURFACE)
@@ -68,7 +69,7 @@ void WaylandEGLWindow::createNativeWindow(uint& width, uint& height)
         switchFullScreen(true);
     }
 
-    wl_surface_commit(mGLSupport->mWlSurface);
+    wl_surface_commit(mWlSurface);
     wl_display_dispatch_pending(mNativeDisplay);
     wl_display_flush(mNativeDisplay);
 }
@@ -97,8 +98,8 @@ void WaylandEGLWindow::resize(uint width, uint height)
             for (auto& it : mViewportList)
                 it.second->_updateDimensions();
 
-            wl_surface_damage(mGLSupport->mWlSurface, 0, 0, mWidth, mHeight);
-            wl_surface_commit(mGLSupport->mWlSurface);
+            wl_surface_damage(mWlSurface, 0, 0, mWidth, mHeight);
+            wl_surface_commit(mWlSurface);
             wl_display_dispatch_pending(mNativeDisplay);
             wl_display_flush(mNativeDisplay);
         }
@@ -249,7 +250,7 @@ void WaylandEGLWindow::create(const String& name, uint width, uint height, bool 
     mHeight = height;
 
     finaliseWindow();
-    wl_surface_commit(mGLSupport->mWlSurface);
+    wl_surface_commit(mWlSurface);
 }
 
 } // namespace Ogre


### PR DESCRIPTION
There are some problems with Wayland initialization:
* An assertion fails, and the list of EGL extensions contains all client extensions twice and none of the display extensions, because WaylandEGLSupport::start() is called when mGLDisplay has not yet been set.
* GLNativeSupport::mFSAAlevels is duplicated every time a WaylandEGLWindow is created, because of the WaylandEGLSupport::doInit() call in WaylandEGLWindow::create().
* The wl_surface is stored in WaylandEGLSupport, but each WaylandEGLWindow should be able to have its own wl_surface.

I changed WaylandEGLSupport::start() to only print a message, and delayed the EGL initialization to the first time WaylandEGLSupport::newWindow() is called. This is similar to the way Win32GLSupport handles initialization.

I also fixed some minor errors I found when setting ENABLE_EGL_CHECK to 1 for testing purposes: eglTerminate could be called with a null mGLDisplay if more than one render system was loaded, causing an EGL_BAD_DISPLAY error, and trying to create an unsupported EGL context triggered an exception.