### PR TITLE
RTShader: Enable specular lighting when vertex colours are tracked

### DIFF
--- a/Components/RTShaderSystem/src/OgreShaderFFPLighting.cpp
+++ b/Components/RTShaderSystem/src/OgreShaderFFPLighting.cpp
@@ -336,7 +336,8 @@ bool FFPLighting::preAddToRenderState(const RenderState* renderState, Pass* srcP
 	
 	setTrackVertexColourType(srcPass->getVertexColourTracking());
 
-	mSpecularEnable = srcPass->getShininess() > 0.0 && srcPass->getSpecular() != ColourValue::Black;
+	mSpecularEnable = srcPass->getShininess() > 0.0 &&
+		(srcPass->getSpecular() != ColourValue::Black || (srcPass->getVertexColourTracking() & TVC_SPECULAR) != 0);
 
 	// Case this pass should run once per light(s) -> override the light policy.
 	if (srcPass->getIteratePerLight())


### PR DESCRIPTION
The RTShaderSystem only looks at specular colour and shininess when it checks whether specular lighting should be enabled or not. When specular is set to track the vertex colour in a material script, the actual colour value is still black, so specular lighting is disabled. I added an extra check to fix this.

It would also be possible to set the specular colour to white in the script translator if vertex colour tracking is enabled, but that might have other side effects.

