### PR TITLE
Either increment the iterator or assign when erasing

### DIFF
--- a/OgreMain/src/OgreRenderSystem.cpp
+++ b/OgreMain/src/OgreRenderSystem.cpp
@@ -556,14 +556,18 @@ namespace Ogre {
         // Remove all the render targets. Destroy primary target last since others may depend on it.
         // Keep mRenderTargets valid all the time, so that render targets could receive
         // appropriate notifications, for example FBO based about GL context destruction.
-        RenderTarget* primary {nullptr};
-        for (auto &&a : mRenderTargets) {
-            if (!primary && a.second->isPrimary()) {
-                primary = a.second;
+        RenderTarget* primary{nullptr};
+        for (auto it = mRenderTargets.begin(); it != mRenderTargets.end();)
+        {
+            if (!primary && it->second->isPrimary())
+            {
+                primary = it->second;
+                ++it;
                 continue;
             }
-            OGRE_DELETE a.second;
-            mRenderTargets.erase(a.first);
+
+            OGRE_DELETE it->second;
+            it = mRenderTargets.erase(it);
         }
         OGRE_DELETE primary;
         mRenderTargets.clear();


### PR DESCRIPTION
Erasing the element invalidates the iterator so this is not possible in a simple range-based for loop causing a crash.

I encountered this when configuring a setup with multiple renderWindows, the program crashed during shutdown of the ogre root. We used `renderWindow->destroy()` to clean up the window, now we use `Ogre::Root::getSingleton().destroyRenderTarget(renderWindow)` instead because this circumvents the `erase` call in the loop. But I figured I would submit a pull request to fix the for loop anyway.