### PR TITLE
OgreBites: Check whether SDL supports Wayland and X11

### DIFF
--- a/Components/Bites/src/OgreApplicationContextSDL.cpp
+++ b/Components/Bites/src/OgreApplicationContextSDL.cpp
@@ -70,14 +70,18 @@ NativeWindowPair ApplicationContextSDL::createWindow(const Ogre::String& name, O
 #if OGRE_PLATFORM == OGRE_PLATFORM_LINUX
     if (wmInfo.subsystem == SDL_SYSWM_WAYLAND)
     {
+#ifdef SDL_VIDEO_DRIVER_WAYLAND
         Ogre::LogManager::getSingleton().logMessage("[SDL] Creating Wayland window");
         p.miscParams["externalWlDisplay"] = Ogre::StringConverter::toString(size_t(wmInfo.info.wl.display));
         p.miscParams["externalWlSurface"] = Ogre::StringConverter::toString(size_t(wmInfo.info.wl.surface));
+#endif
     }
     else if (wmInfo.subsystem == SDL_SYSWM_X11)
     {
+#ifdef SDL_VIDEO_DRIVER_X11
         Ogre::LogManager::getSingleton().logMessage("[SDL] Creating X11 window");
         p.miscParams["externalWindowHandle"] = Ogre::StringConverter::toString(size_t(wmInfo.info.x11.window));
+#endif
     }
 #elif OGRE_PLATFORM == OGRE_PLATFORM_WIN32
     p.miscParams["externalWindowHandle"] = Ogre::StringConverter::toString(size_t(wmInfo.info.win.window));


### PR DESCRIPTION
OgreBites fails to compile if SDL is not built with both Wayland and X11 support. wmInfo.info.wl and wmInfo.info.x11 only exist if SDL supports Wayland and X11 respectively.