### PR TITLE
RenderSysten_GL: Prevent using a shared FBO renderbuffer if necessary

### DIFF
--- a/RenderSystems/GL/include/OgreGLFBORenderTexture.h
+++ b/RenderSystems/GL/include/OgreGLFBORenderTexture.h
@@ -89,6 +89,10 @@ namespace Ogre {
         /** Request a render buffer. If format is GL_NONE, return a zero buffer.
         */
         GLSurfaceDesc requestRenderBuffer(GLenum format, uint32 width, uint32 height, uint fsaa);
+
+        /** Creates a new render buffer. Caller takes ownership.
+        */
+        GLSurfaceDesc createNewRenderBuffer(GLenum format, uint32 width, uint32 height, uint fsaa);
         /** Get a FBO without depth/stencil for temporary use, like blitting between textures.
         */
         GLuint getTemporaryFBO() { return mTempFBO; }

--- a/RenderSystems/GL/include/OgreGLFBORenderTexture.h
+++ b/RenderSystems/GL/include/OgreGLFBORenderTexture.h
@@ -85,14 +85,9 @@ namespace Ogre {
 
         GLFBORenderTexture *createRenderTexture(const String &name,
             const GLSurfaceDesc &target, bool writeGamma, uint fsaa) override;
-        
-        /** Request a render buffer. If format is GL_NONE, return a zero buffer.
-        */
-        GLSurfaceDesc requestRenderBuffer(GLenum format, uint32 width, uint32 height, uint fsaa);
 
-        /** Creates a new render buffer. Caller takes ownership.
-        */
-        GLSurfaceDesc createNewRenderBuffer(GLenum format, uint32 width, uint32 height, uint fsaa);
+        GLSurfaceDesc createNewRenderBuffer(unsigned format, uint32 width, uint32 height, uint fsaa) override;
+
         /** Get a FBO without depth/stencil for temporary use, like blitting between textures.
         */
         GLuint getTemporaryFBO() { return mTempFBO; }

--- a/RenderSystems/GL/include/OgreGLFrameBufferObject.h
+++ b/RenderSystems/GL/include/OgreGLFrameBufferObject.h
@@ -59,6 +59,10 @@ namespace Ogre {
     private:
         GLFBOManager *mManager;
         GLSurfaceDesc mMultisampleColourBuffer;
+        // mMultisampleColourBuffer.buffer is either shared through caching, or owned,
+        // if owned, mOwnedMultisampleColourBuffer contains mMultisampleColourBuffer.buffer
+        // otherwise, mOwnedMultisampleColourBuffer == nullptr
+        std::unique_ptr<GLHardwarePixelBufferCommon> mOwnedMultisampleColourBuffer;
 
         void initialise() override;
     };

--- a/RenderSystems/GL/include/OgreGLFrameBufferObject.h
+++ b/RenderSystems/GL/include/OgreGLFrameBufferObject.h
@@ -58,11 +58,6 @@ namespace Ogre {
         GLFBOManager *getManager() { return mManager; }
     private:
         GLFBOManager *mManager;
-        GLSurfaceDesc mMultisampleColourBuffer;
-        // mMultisampleColourBuffer.buffer is either shared through caching, or owned,
-        // if owned, mOwnedMultisampleColourBuffer contains mMultisampleColourBuffer.buffer
-        // otherwise, mOwnedMultisampleColourBuffer == nullptr
-        std::unique_ptr<GLHardwarePixelBufferCommon> mOwnedMultisampleColourBuffer;
 
         void initialise() override;
     };

--- a/RenderSystems/GL/src/OgreGLFBORenderTexture.cpp
+++ b/RenderSystems/GL/src/OgreGLFBORenderTexture.cpp
@@ -487,7 +487,10 @@ static const uchar depthBits[] =
     {
         /// Check if the render target is in the rendertarget->FBO map
         if(auto fbo = dynamic_cast<GLRenderTarget*>(target)->getFBO())
+        {
+            fbo->determineFBOBufferSharingAllowed(*target);
             fbo->bind(true);
+        }
         else
             // Old style context (window/pbuffer) or copying render texture
             glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, 0);
@@ -512,14 +515,21 @@ static const uchar depthBits[] =
             else
             {
                 // New one
-                GLRenderBuffer *rb = new GLRenderBuffer(format, width, height, fsaa);
-                mRenderBufferMap[key] = RBRef(rb);
-                retval.buffer = rb;
-                retval.zoffset = 0;
-                retval.numSamples = fsaa;
+                retval = createNewRenderBuffer(format, width, height, fsaa);
+                mRenderBufferMap[key] = retval.buffer;
             }
         }
         //std::cerr << "Requested renderbuffer with format " << std::hex << format << std::dec << " of " << width << "x" << height << " :" << retval.buffer << std::endl;
+        return retval;
+    }
+
+    GLSurfaceDesc GLFBOManager::createNewRenderBuffer(GLenum format, uint32 width, uint32 height, uint fsaa)
+    {
+        GLSurfaceDesc retval;
+        auto* rb = new GLRenderBuffer(format, width, height, fsaa);
+        retval.buffer = rb;
+        retval.zoffset = 0;
+        retval.numSamples = fsaa;
         return retval;
     }
 }

--- a/RenderSystems/GL/src/OgreGLFBORenderTexture.cpp
+++ b/RenderSystems/GL/src/OgreGLFBORenderTexture.cpp
@@ -495,35 +495,8 @@ static const uchar depthBits[] =
             // Old style context (window/pbuffer) or copying render texture
             glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, 0);
     }
-    
-    GLSurfaceDesc GLFBOManager::requestRenderBuffer(GLenum format, uint32 width, uint32 height, uint fsaa)
-    {
-        GLSurfaceDesc retval;
-        retval.buffer = 0; // Return 0 buffer if GL_NONE is requested
-        if(format != GL_NONE)
-        {
-            RBFormat key(format, width, height, fsaa);
-            RenderBufferMap::iterator it = mRenderBufferMap.find(key);
-            if(it != mRenderBufferMap.end())
-            {
-                retval.buffer = it->second.buffer;
-                retval.zoffset = 0;
-                retval.numSamples = fsaa;
-                // Increase refcount
-                ++it->second.refcount;
-            }
-            else
-            {
-                // New one
-                retval = createNewRenderBuffer(format, width, height, fsaa);
-                mRenderBufferMap[key] = retval.buffer;
-            }
-        }
-        //std::cerr << "Requested renderbuffer with format " << std::hex << format << std::dec << " of " << width << "x" << height << " :" << retval.buffer << std::endl;
-        return retval;
-    }
 
-    GLSurfaceDesc GLFBOManager::createNewRenderBuffer(GLenum format, uint32 width, uint32 height, uint fsaa)
+    GLSurfaceDesc GLFBOManager::createNewRenderBuffer(unsigned format, uint32 width, uint32 height, uint fsaa)
     {
         GLSurfaceDesc retval;
         auto* rb = new GLRenderBuffer(format, width, height, fsaa);

--- a/RenderSystems/GL/src/OgreGLFrameBufferObject.cpp
+++ b/RenderSystems/GL/src/OgreGLFrameBufferObject.cpp
@@ -39,39 +39,37 @@ THE SOFTWARE.
 namespace Ogre {
 
 //-----------------------------------------------------------------------------
-    GLFrameBufferObject::GLFrameBufferObject(GLFBOManager *manager, uint fsaa):
-        GLFrameBufferObjectCommon(fsaa), mManager(manager)
+GLFrameBufferObject::GLFrameBufferObject(GLFBOManager* manager, uint fsaa)
+    : GLFrameBufferObjectCommon(fsaa, *manager), mManager(manager)
+{
+    // Generate framebuffer object
+    glGenFramebuffersEXT(1, &mFB);
+    // check multisampling
+    if (GLAD_GL_EXT_framebuffer_blit && GLAD_GL_EXT_framebuffer_multisample)
     {
-        // Generate framebuffer object
-        glGenFramebuffersEXT(1, &mFB);
-        // check multisampling
-        if (GLAD_GL_EXT_framebuffer_blit && GLAD_GL_EXT_framebuffer_multisample)
-        {
-            // check samples supported
-            GLint maxSamples;
-            glGetIntegerv(GL_MAX_SAMPLES_EXT, &maxSamples);
-            mNumSamples = std::min(mNumSamples, (GLsizei)maxSamples);
-        }
-        else
-        {
-            mNumSamples = 0;
-        }
-        // will we need a second FBO to do multisampling?
-        if (mNumSamples)
-        {
-            glGenFramebuffersEXT(1, &mMultisampleFB);
-        }
-        else
-        {
-            mMultisampleFB = 0;
-        }
+        // check samples supported
+        GLint maxSamples;
+        glGetIntegerv(GL_MAX_SAMPLES_EXT, &maxSamples);
+        mNumSamples = std::min(mNumSamples, (GLsizei)maxSamples);
+    }
+    else
+    {
+        mNumSamples = 0;
+    }
+    // will we need a second FBO to do multisampling?
+    if (mNumSamples)
+    {
+        glGenFramebuffersEXT(1, &mMultisampleFB);
+    }
+    else
+    {
+        mMultisampleFB = 0;
+    }
     }
     GLFrameBufferObject::~GLFrameBufferObject()
     {
         mManager->releaseRenderBuffer(mDepth);
         mManager->releaseRenderBuffer(mStencil);
-        if (!mOwnedMultisampleColourBuffer)
-            mManager->releaseRenderBuffer(mMultisampleColourBuffer);
         // Delete framebuffer object
         glDeleteFramebuffersEXT(1, &mFB);        
         if (mMultisampleFB)
@@ -83,11 +81,7 @@ namespace Ogre {
         // Release depth and stencil, if they were bound
         mManager->releaseRenderBuffer(mDepth);
         mManager->releaseRenderBuffer(mStencil);
-
-        if (mOwnedMultisampleColourBuffer)
-            mOwnedMultisampleColourBuffer.reset();
-        else
-            mManager->releaseRenderBuffer(mMultisampleColourBuffer);
+        releaseMultisampleColourBuffer();
 
         // First buffer must be bound
         if(!mColour[0].buffer)
@@ -150,13 +144,7 @@ namespace Ogre {
             // Create AA render buffer (colour)
             // note, this can be shared too because we blit it to the final FBO
             // right after the render is finished
-            if (mAllowRenderBufferSharing)
-                mMultisampleColourBuffer = mManager->requestRenderBuffer(format, width, height, mNumSamples);
-            else
-            {
-                mMultisampleColourBuffer = mManager->createNewRenderBuffer(format, width, height, mNumSamples);
-                mOwnedMultisampleColourBuffer.reset(mMultisampleColourBuffer.buffer);
-            }
+            initialiseMultisampleColourBuffer(format, width, height);
 
             // Attach it, because we won't be attaching below and non-multisample has
             // actually been attached to other FBO

--- a/RenderSystems/GL3Plus/include/OgreGL3PlusFBORenderTexture.h
+++ b/RenderSystems/GL3Plus/include/OgreGL3PlusFBORenderTexture.h
@@ -77,9 +77,7 @@ namespace Ogre {
         GL3PlusFBORenderTexture *createRenderTexture(const String &name,
                                                              const GLSurfaceDesc &target, bool writeGamma, uint fsaa) override;
 
-        /** Request a render buffer. If format is GL_NONE, return a zero buffer.
-         */
-        GLSurfaceDesc requestRenderBuffer(GLenum format, uint32 width, uint32 height, uint fsaa);
+        GLSurfaceDesc createNewRenderBuffer(unsigned format, uint32 width, uint32 height, uint fsaa) override;
 
         GL3PlusStateCacheManager* getStateCacheManager();
     private:

--- a/RenderSystems/GL3Plus/include/OgreGL3PlusFrameBufferObject.h
+++ b/RenderSystems/GL3Plus/include/OgreGL3PlusFrameBufferObject.h
@@ -61,7 +61,6 @@ namespace Ogre {
         GL3PlusFBOManager *getManager() { return mManager; }
     private:
         GL3PlusFBOManager *mManager;
-        GLSurfaceDesc mMultisampleColourBuffer;
 
         void initialise() override;
     };

--- a/RenderSystems/GL3Plus/src/OgreGL3PlusFBORenderTexture.cpp
+++ b/RenderSystems/GL3Plus/src/OgreGL3PlusFBORenderTexture.cpp
@@ -469,33 +469,13 @@ namespace Ogre {
         return retval;
     }
 
-    GLSurfaceDesc GL3PlusFBOManager::requestRenderBuffer(GLenum format, uint32 width, uint32 height, uint fsaa)
+    GLSurfaceDesc GL3PlusFBOManager::createNewRenderBuffer(unsigned format, uint32 width, uint32 height, uint fsaa)
     {
         GLSurfaceDesc retval;
-        retval.buffer = 0; // Return 0 buffer if GL_NONE is requested
-        if(format != GL_NONE)
-        {
-            RBFormat key(format, width, height, fsaa);
-            RenderBufferMap::iterator it = mRenderBufferMap.find(key);
-            if(it != mRenderBufferMap.end())
-            {
-                retval.buffer = it->second.buffer;
-                retval.zoffset = 0;
-                retval.numSamples = fsaa;
-                // Increase refcount
-                ++it->second.refcount;
-            }
-            else
-            {
-                // New one
-                GL3PlusRenderBuffer *rb = new GL3PlusRenderBuffer(format, width, height, fsaa);
-                mRenderBufferMap[key] = RBRef(rb);
-                retval.buffer = rb;
-                retval.zoffset = 0;
-                retval.numSamples = fsaa;
-            }
-        }
-        //        std::cerr << "Requested renderbuffer with format " << std::hex << format << std::dec << " of " << width << "x" << height << " :" << retval.buffer << std::endl;
+        auto* rb = new GL3PlusRenderBuffer(format, width, height, fsaa);
+        retval.buffer = rb;
+        retval.zoffset = 0;
+        retval.numSamples = fsaa;
         return retval;
     }
 

--- a/RenderSystems/GL3Plus/src/OgreGL3PlusRenderSystem.cpp
+++ b/RenderSystems/GL3Plus/src/OgreGL3PlusRenderSystem.cpp
@@ -1486,7 +1486,10 @@ namespace Ogre {
                main frame buffer.
             */
             if(auto fbo = gltarget->getFBO())
+            {
+                fbo->determineFBOBufferSharingAllowed(*target);
                 fbo->bind(true);
+            }
             else
                 _getStateCacheManager()->bindGLFrameBuffer( GL_FRAMEBUFFER, 0 );
 

--- a/RenderSystems/GLES2/include/OgreGLES2FBORenderTexture.h
+++ b/RenderSystems/GLES2/include/OgreGLES2FBORenderTexture.h
@@ -87,10 +87,8 @@ namespace Ogre {
 
         GLES2FBORenderTexture *createRenderTexture(const String &name,
             const GLSurfaceDesc &target, bool writeGamma, uint fsaa) override;
-        
-        /** Request a render buffer. If format is GL_NONE, return a zero buffer.
-        */
-        GLSurfaceDesc requestRenderBuffer(GLenum format, uint32 width, uint32 height, uint fsaa);
+
+        GLSurfaceDesc createNewRenderBuffer(unsigned format, uint32 width, uint32 height, uint fsaa) override;
 
         /** Get a FBO without depth/stencil for temporary use, like blitting between textures.
         */

--- a/RenderSystems/GLES2/include/OgreGLES2FrameBufferObject.h
+++ b/RenderSystems/GLES2/include/OgreGLES2FrameBufferObject.h
@@ -70,11 +70,6 @@ namespace Ogre {
         
     private:
         GLES2FBOManager *mManager;
-        GLSurfaceDesc mMultisampleColourBuffer;
-        // mMultisampleColourBuffer.buffer is either shared through caching, or owned,
-        // if owned, mOwnedMultisampleColourBuffer contains mMultisampleColourBuffer.buffer
-        // otherwise, mOwnedMultisampleColourBuffer == nullptr
-        std::unique_ptr<GLHardwarePixelBufferCommon> mOwnedMultisampleColourBuffer;
 
         void initialise() override;
     };

--- a/RenderSystems/GLES2/include/OgreGLES2FrameBufferObject.h
+++ b/RenderSystems/GLES2/include/OgreGLES2FrameBufferObject.h
@@ -71,6 +71,10 @@ namespace Ogre {
     private:
         GLES2FBOManager *mManager;
         GLSurfaceDesc mMultisampleColourBuffer;
+        // mMultisampleColourBuffer.buffer is either shared through caching, or owned,
+        // if owned, mOwnedMultisampleColourBuffer contains mMultisampleColourBuffer.buffer
+        // otherwise, mOwnedMultisampleColourBuffer == nullptr
+        std::unique_ptr<GLHardwarePixelBufferCommon> mOwnedMultisampleColourBuffer;
 
         void initialise() override;
     };

--- a/RenderSystems/GLES2/src/OgreGLES2FrameBufferObject.cpp
+++ b/RenderSystems/GLES2/src/OgreGLES2FrameBufferObject.cpp
@@ -38,9 +38,9 @@ THE SOFTWARE.
 namespace Ogre {
 
 //-----------------------------------------------------------------------------
-    GLES2FrameBufferObject::GLES2FrameBufferObject(GLES2FBOManager *manager, uint fsaa):
-        GLFrameBufferObjectCommon(fsaa), mManager(manager)
-    {
+GLES2FrameBufferObject::GLES2FrameBufferObject(GLES2FBOManager* manager, uint fsaa)
+    : GLFrameBufferObjectCommon(fsaa, *manager), mManager(manager)
+{
 #if OGRE_PLATFORM == OGRE_PLATFORM_APPLE_IOS
         GLint oldfb = 0;
         OGRE_CHECK_GL_ERROR(glGetIntegerv(GL_FRAMEBUFFER_BINDING, &oldfb));
@@ -72,7 +72,6 @@ namespace Ogre {
     {
         mManager->releaseRenderBuffer(mDepth);
         mManager->releaseRenderBuffer(mStencil);
-        mManager->releaseRenderBuffer(mMultisampleColourBuffer);
         // Delete framebuffer object
         if(mContext && mFB)
         {
@@ -116,7 +115,9 @@ namespace Ogre {
         // Release depth and stencil, if they were bound
         mManager->releaseRenderBuffer(mDepth);
         mManager->releaseRenderBuffer(mStencil);
-        mManager->releaseRenderBuffer(mMultisampleColourBuffer);
+
+        releaseMultisampleColourBuffer();
+
         // First buffer must be bound
         if(!mColour[0].buffer)
         {
@@ -175,7 +176,7 @@ namespace Ogre {
             // Create AA render buffer (colour)
             // note, this can be shared too because we blit it to the final FBO
             // right after the render is finished
-            mMultisampleColourBuffer = mManager->requestRenderBuffer(format, width, height, mNumSamples);
+            initialiseMultisampleColourBuffer(format, width, height);
 
             // Attach it, because we won't be attaching below and non-multisample has
             // actually been attached to other FBO

--- a/RenderSystems/GLSupport/include/OgreGLRenderTexture.h
+++ b/RenderSystems/GLSupport/include/OgreGLRenderTexture.h
@@ -68,6 +68,14 @@ namespace Ogre {
         */
         void unbindSurface(size_t attachment);
 
+        /** Determines and sets mAllowRenderBufferSharing based on given render target properties
+         */
+        void determineFBOBufferSharingAllowed(RenderTarget&);
+
+        /** Sets mAllowRenderBufferSharing, triggers re-initialization if value is different
+         */
+        void setAllowRenderBufferSharing(bool);
+
         /// Accessors
         int32 getFSAA() const { return mNumSamples; }
         uint32 getWidth() const;
@@ -93,6 +101,7 @@ namespace Ogre {
         uint32 mFB;
         uint32 mMultisampleFB;
         int32 mNumSamples;
+        bool mAllowRenderBufferSharing = true;
 
         /** Initialise object (find suitable depth and stencil format).
             Must be called every time the bindings change.

--- a/RenderSystems/GLSupport/include/OgreGLRenderTexture.h
+++ b/RenderSystems/GLSupport/include/OgreGLRenderTexture.h
@@ -36,6 +36,7 @@ Copyright (c) 2000-2014 Torus Knot Software Ltd
 
 namespace Ogre {
     class GLHardwarePixelBufferCommon;
+    class GLRTTManager;
 
     /** GL surface descriptor. Points to a 2D surface that can be rendered to.
      */
@@ -53,8 +54,8 @@ namespace Ogre {
     class _OgreGLExport GLFrameBufferObjectCommon
     {
     public:
-        GLFrameBufferObjectCommon(int32 fsaa);
-        virtual ~GLFrameBufferObjectCommon() {}
+        GLFrameBufferObjectCommon(int32 fsaa, GLRTTManager&);
+        virtual ~GLFrameBufferObjectCommon();
 
         /** Bind FrameBufferObject. Attempt to bind on incompatible GL context will cause FBO destruction and optional recreation.
         */
@@ -101,7 +102,13 @@ namespace Ogre {
         uint32 mFB;
         uint32 mMultisampleFB;
         int32 mNumSamples;
+        GLRTTManager* mRTTManager;
+        GLSurfaceDesc mMultisampleColourBuffer;
         bool mAllowRenderBufferSharing = true;
+        // mMultisampleColourBuffer.buffer is either shared through caching, or owned,
+        // if owned, mOwnedMultisampleColourBuffer contains mMultisampleColourBuffer.buffer
+        // otherwise, mOwnedMultisampleColourBuffer == nullptr
+        std::unique_ptr<GLHardwarePixelBufferCommon> mOwnedMultisampleColourBuffer;
 
         /** Initialise object (find suitable depth and stencil format).
             Must be called every time the bindings change.
@@ -111,6 +118,8 @@ namespace Ogre {
             - Not all bound surfaces have the same internal format
         */
         virtual void initialise() = 0;
+        void releaseMultisampleColourBuffer();
+        void initialiseMultisampleColourBuffer(unsigned format, uint32 width, uint32 height);
     };
 
     /** Base class for GL Render Textures
@@ -172,6 +181,18 @@ namespace Ogre {
         static GLRTTManager& getSingleton(void);
         /// @copydoc Singleton::getSingleton()
         static GLRTTManager* getSingletonPtr(void);
+
+        /** Request a render buffer. If format is GL_NONE, return a zero buffer.
+         */
+        GLSurfaceDesc requestRenderBuffer(unsigned format, uint32 width, uint32 height, uint fsaa);
+
+        /** Creates a new render buffer. Caller takes ownership.
+         */
+        virtual GLSurfaceDesc createNewRenderBuffer(unsigned format, uint32 width, uint32 height, uint fsaa)
+        {
+            return {};
+        }
+
     protected:
         /** Frame Buffer Object properties for a certain texture format.
          */

--- a/RenderSystems/GLSupport/src/OgreGLRenderTexture.cpp
+++ b/RenderSystems/GLSupport/src/OgreGLRenderTexture.cpp
@@ -30,6 +30,7 @@ Copyright (c) 2000-2014 Torus Knot Software Ltd
 #include "OgreGLHardwarePixelBufferCommon.h"
 #include "OgreGLRenderSystemCommon.h"
 #include "OgreRoot.h"
+#include "OgreViewport.h"
 
 namespace Ogre {
 
@@ -71,6 +72,38 @@ namespace Ogre {
         // Re-initialise if buffer 0 still bound
         if(mColour[0].buffer)
             initialise();
+    }
+
+    void GLFrameBufferObjectCommon::determineFBOBufferSharingAllowed(RenderTarget& target)
+    {
+        if (mNumSamples == 0)
+        {
+            // Only the multisampled buffer would be shared
+            return;
+        }
+
+        bool sharingRenderBufferIsAllowed = true;
+        for (unsigned short i = 0; i < target.getNumViewports(); ++i)
+        {
+            if (!target.getViewport(i)->getClearEveryFrame())
+            {
+                // When there's at least one viewport that doesn't clear every frame,
+                // sharing the render buffer is not allowed.
+                // The shared buffer could contain data from other multisampled FBO's which wouldn't be cleared.
+                sharingRenderBufferIsAllowed = false;
+                break;
+            }
+        }
+        setAllowRenderBufferSharing(sharingRenderBufferIsAllowed);
+    }
+
+    void GLFrameBufferObjectCommon::setAllowRenderBufferSharing(bool allowRenderBufferSharing)
+    {
+        if(mAllowRenderBufferSharing!=allowRenderBufferSharing)
+        {
+            mAllowRenderBufferSharing = allowRenderBufferSharing;
+            initialise();
+        }
     }
 
     uint32 GLFrameBufferObjectCommon::getWidth() const


### PR DESCRIPTION
A shared renderbuffer might contain data from other FBO's, this is fine as long as all viewports have clearEveryFrame=true. When any viewport has clearEveryFrame=false, data would get unintentionally combined.

This fixes #3158 