### PR TITLE
fix crashes when reusing a Dx11 program pointer.  

### DIFF
--- a/RenderSystems/Direct3D11/include/OgreD3D11HLSLProgram.h
+++ b/RenderSystems/Direct3D11/include/OgreD3D11HLSLProgram.h
@@ -126,8 +126,6 @@ namespace Ogre {
             String                  Name;
         };
 
-        std::vector<String *> mSerStrings;
-
         typedef std::vector<D3D11_SHADER_BUFFER_DESC> D3d11ShaderBufferDescs;
         typedef std::vector<D3D11_SHADER_TYPE_DESC> D3d11ShaderTypeDescs;
         typedef std::vector<UINT> InterfaceSlots;


### PR DESCRIPTION
Fix crash due to accessing freed memory in Dx11 HLSL program class.

Min repro case:
1. compile a D3D11HLSLProgram based shader via prepare().
2. trigger an unload while state=LOADSTATE_PREPARED.  (see Resource::unload () snip below)
3. this calls unprepareImpl() which *only* frees the cached string data and NOT the other 8 or so std::vectors.
4. call prepare() again. the program will crash due while iterating the std::vector data containing freed strings.

Resource::unload(void) calls either unprepareImpl() or unloadImpl () depending on the 'old' load state of a shader program.
 if (old==LOADSTATE_PREPARED) {
         unprepareImpl();
 else
         unloadImpl();
