### PR TITLE
add support for structed bindings for Ogre::Vector

### DIFF
--- a/OgreMain/include/OgreVector.h
+++ b/OgreMain/include/OgreVector.h
@@ -66,7 +66,7 @@ namespace Ogre
         const T* ptr() const { return data; }
         /** to help make VectorBase enum-like */
         template<std::size_t N> T get() {
-            static_assert(N < dims);
+            static_assert(N < dims, "invalid index");
             return data[N];
         }
     };
@@ -78,7 +78,7 @@ namespace Ogre
         Real* ptr() { return &x; }
         const Real* ptr() const { return &x; }
         template<std::size_t N> Real get() {
-            static_assert(N < 2);
+            static_assert(N < 2, "invalid index");
             return (&x)[N];
         }
 
@@ -142,7 +142,7 @@ namespace Ogre
         Real* ptr() { return &x; }
         const Real* ptr() const { return &x; }
         template<std::size_t N> Real get() {
-            static_assert(N < 3);
+            static_assert(N < 3, "invalid index");
             return (&x)[N];
         }
 
@@ -275,7 +275,7 @@ namespace Ogre
         Real* ptr() { return &x; }
         const Real* ptr() const { return &x; }
         template<std::size_t N> Real get() {
-            static_assert(N < 4);
+            static_assert(N < 4, "invalid index");
             return (&x)[N];
         }
 

--- a/OgreMain/include/OgreVector.h
+++ b/OgreMain/include/OgreVector.h
@@ -64,6 +64,11 @@ namespace Ogre
         T data[dims];
         T* ptr() { return data; }
         const T* ptr() const { return data; }
+        /** to help make VectorBase enum-like */
+        template<std::size_t N> T get() { 
+            static_assert(N < dims);
+            return data[N];
+        }
     };
     template <> struct _OgreExport VectorBase<2, Real>
     {
@@ -72,6 +77,10 @@ namespace Ogre
         Real x, y;
         Real* ptr() { return &x; }
         const Real* ptr() const { return &x; }
+        template<std::size_t N> Real get() {
+            static_assert(N < 2);
+            return (&x)[N];
+        }
 
         /** Returns a vector at a point half way between this and the passed
             in vector.
@@ -132,6 +141,10 @@ namespace Ogre
         Real x, y, z;
         Real* ptr() { return &x; }
         const Real* ptr() const { return &x; }
+        template<std::size_t N> Real get() {
+            static_assert(N < 3); 
+            return (&x)[N];
+        }
 
         /** Calculates the cross-product of 2 vectors, i.e. the vector that
             lies perpendicular to them both.
@@ -261,6 +274,10 @@ namespace Ogre
         Real x, y, z, w;
         Real* ptr() { return &x; }
         const Real* ptr() const { return &x; }
+        template<std::size_t N> Real get() {
+            static_assert(N < 4);
+            return (&x)[N];
+        }
 
         // special points
         static const Vector4 ZERO;
@@ -885,4 +902,24 @@ namespace Ogre
     /** @} */
 
 }
+
+//define the required std features to make VectorBase tuple-like
+//thus allowing structured bindings for Vector.
+namespace std {
+    template<int dims, class T> 
+    struct tuple_size<Ogre::VectorBase<dims, T>> : std::integral_constant<std::size_t, dims> {};
+    template<int dims, class T> 
+    struct tuple_size<Ogre::Vector<dims, T>> : std::integral_constant<std::size_t, dims> {};
+
+    template<int dims, class T, std::size_t N>
+    struct tuple_element<N, Ogre::Vector<dims, T>> {
+        using type = T;
+    };
+
+    template<int dims, class T, std::size_t N>
+    struct tuple_element<N, Ogre::VectorBase<dims, T>> {
+        using type = T;
+    };
+}
+
 #endif

--- a/OgreMain/include/OgreVector.h
+++ b/OgreMain/include/OgreVector.h
@@ -65,7 +65,11 @@ namespace Ogre
         T* ptr() { return data; }
         const T* ptr() const { return data; }
         /** to help make VectorBase enum-like */
-        template<std::size_t N> T get() {
+        template<std::size_t N> T& get() {
+            static_assert(N < dims, "invalid index");
+            return data[N];
+        }
+        template<std::size_t N> const T& get() const {
             static_assert(N < dims, "invalid index");
             return data[N];
         }
@@ -77,7 +81,11 @@ namespace Ogre
         Real x, y;
         Real* ptr() { return &x; }
         const Real* ptr() const { return &x; }
-        template<std::size_t N> Real get() {
+        template<std::size_t N> Real& get() {
+            static_assert(N < 2, "invalid index");
+            return (&x)[N];
+        }
+        template<std::size_t N> const Real& get() const {
             static_assert(N < 2, "invalid index");
             return (&x)[N];
         }
@@ -141,7 +149,11 @@ namespace Ogre
         Real x, y, z;
         Real* ptr() { return &x; }
         const Real* ptr() const { return &x; }
-        template<std::size_t N> Real get() {
+        template<std::size_t N> Real& get() {
+            static_assert(N < 3, "invalid index");
+            return (&x)[N];
+        }
+        template<std::size_t N> const Real& get() const {
             static_assert(N < 3, "invalid index");
             return (&x)[N];
         }
@@ -274,7 +286,11 @@ namespace Ogre
         Real x, y, z, w;
         Real* ptr() { return &x; }
         const Real* ptr() const { return &x; }
-        template<std::size_t N> Real get() {
+        template<std::size_t N> Real& get() {
+            static_assert(N < 4, "invalid index");
+            return (&x)[N];
+        }
+        template<std::size_t N> const Real& get() const {
             static_assert(N < 4, "invalid index");
             return (&x)[N];
         }

--- a/OgreMain/include/OgreVector.h
+++ b/OgreMain/include/OgreVector.h
@@ -65,7 +65,7 @@ namespace Ogre
         T* ptr() { return data; }
         const T* ptr() const { return data; }
         /** to help make VectorBase enum-like */
-        template<std::size_t N> T get() { 
+        template<std::size_t N> T get() {
             static_assert(N < dims);
             return data[N];
         }
@@ -142,7 +142,7 @@ namespace Ogre
         Real* ptr() { return &x; }
         const Real* ptr() const { return &x; }
         template<std::size_t N> Real get() {
-            static_assert(N < 3); 
+            static_assert(N < 3);
             return (&x)[N];
         }
 
@@ -906,9 +906,9 @@ namespace Ogre
 //define the required std features to make VectorBase tuple-like
 //thus allowing structured bindings for Vector.
 namespace std {
-    template<int dims, class T> 
+    template<int dims, class T>
     struct tuple_size<Ogre::VectorBase<dims, T>> : std::integral_constant<std::size_t, dims> {};
-    template<int dims, class T> 
+    template<int dims, class T>
     struct tuple_size<Ogre::Vector<dims, T>> : std::integral_constant<std::size_t, dims> {};
 
     template<int dims, class T, std::size_t N>


### PR DESCRIPTION
It would be nice to be able to write 
```
auto [x,y,z] = myVector;
```
to conveniently pull `myVector` apart into its components for some algorithms. This pull request makes turns `Ogre::Vector` into a tuple-like (as defined in the C++ std library), so that structured binding is supported.  Given that `Ogre::Vector` is a fixed length container, it is in many ways an specialized alternative to `std::array`, and `std::array` is also a tuple-like.

I invite feedback, particularly since `Ogre::Vector` is such a fundamental part of the Ogre project, and I am venturing into unfamiliar parts of the C++ language with this pull request. 