### PR TITLE
GL3Plus: offset mesh SSBO binding by 3

### DIFF
--- a/Docs/src/high-level-programs.md
+++ b/Docs/src/high-level-programs.md
@@ -131,7 +131,7 @@ refer to the following table for the location indices and names to use:
 
 ## Buffers in Mesh Shaders {#GLSL-Mesh-Shaders}
 
-With mesh shaders the input assembly stage is skipped and hence the vertex attributes are not available. Instead, %Ogre will bind the vertex buffers as SSBOs to a binding point defined by the Ogre::VertexBufferBinding index.
+With mesh shaders the input assembly stage is skipped and hence the vertex attributes are not available. Instead, %Ogre will bind the vertex buffers as SSBOs to a binding point defined by the Ogre::VertexBufferBinding index, offset by 3.
 
 In the shader you can access the buffer as follows:
 

--- a/RenderSystems/GL3Plus/src/OgreGL3PlusRenderSystem.cpp
+++ b/RenderSystems/GL3Plus/src/OgreGL3PlusRenderSystem.cpp
@@ -1009,7 +1009,7 @@ namespace Ogre {
             for(auto it : op.vertexData->vertexBufferBinding->getBindings())
             {
                 auto buf = it.second->_getImpl<GL3PlusHardwareBuffer>();
-                buf->setGLBufferBinding(it.first, GL_SHADER_STORAGE_BUFFER);
+                buf->setGLBufferBinding(it.first + 3, GL_SHADER_STORAGE_BUFFER);
             }
         }
 

--- a/Samples/Media/materials/programs/GLSL400/MeshProgram.glsl
+++ b/Samples/Media/materials/programs/GLSL400/MeshProgram.glsl
@@ -17,13 +17,13 @@ layout(location=0) out PerVertexData
     vec3 color;
 } v_out[];
 
-#ifdef VULKAN
 layout(binding=0, row_major) uniform OgreUniforms
 {
     mat4 MVP;
     float t;
 };
 
+#ifdef VULKAN
 // SSBOs cannot be used with Vulkan yet
 float data[] = {
     -100, -100, 0,  // pos
@@ -40,13 +40,9 @@ float data[] = {
     0,0
 };
 #else
-// UBOs cannot be used with gl_spirv yet
-layout(location=0) uniform mat4 MVP;
-layout(location=4) uniform float t;
-
 //![vertexbuffer]
 // buffer at index 0, which is expected to contain float data
-layout(binding = 0) buffer VertexDataIn
+layout(binding = 3) readonly buffer VertexDataIn
 {
     float data[];
 };


### PR DESCRIPTION
to give room for meshlet buffers. Also UBOs work now with gl_spirv