### PR TITLE
Fix get current surface for Android if use SDL

### DIFF
--- a/OgreMain/include/OgreRenderSystem.h
+++ b/OgreMain/include/OgreRenderSystem.h
@@ -393,6 +393,7 @@ namespace Ogre
         | externalWlDisplay | wl_display address as an integer | 0 (none) | Wayland display connection | Linux |
         | externalWlSurface | wl_surface address as an integer | 0 (none) | Wayland onscreen surface | Linux |
         | currentGLContext | true, false | false | Use an externally created GL context. (Must be current) | OpenGL |
+        | currentEGLSurface | true, false | false | Use an externally created EGL surface. | Android |
         | minColourBufferSize | Positive integer (usually 16, 32) | 16 | Min total colour buffer size. See EGL_BUFFER_SIZE | OpenGL |
         | windowProc | WNDPROC | DefWindowProc | function that processes window messages | Win 32 |
         | colourDepth | 16, 32 | Desktop depth | Colour depth of the resulting rendering window; only applies if fullScreen | Win32 |

--- a/RenderSystems/GLSupport/src/EGL/Android/OgreAndroidEGLWindow.cpp
+++ b/RenderSystems/GLSupport/src/EGL/Android/OgreAndroidEGLWindow.cpp
@@ -119,9 +119,12 @@ namespace Ogre {
                                 "currentGLContext was specified with no current GL context",
                                 "EGLWindow::create");
                 }
-#if defined(OGRE_BITES_HAVE_SDL) && OGRE_BITES_HAVE_SDL
-                mEglSurface = eglGetCurrentSurface(EGL_DRAW);
-#endif
+
+                if((opt = miscParams->find("currentEGLSurface")) != end)
+                {
+                    mEglSurface = eglGetCurrentSurface(EGL_DRAW);
+                }
+
                 mEglDisplay = eglGetCurrentDisplay();
             }
 

--- a/RenderSystems/GLSupport/src/EGL/Android/OgreAndroidEGLWindow.cpp
+++ b/RenderSystems/GLSupport/src/EGL/Android/OgreAndroidEGLWindow.cpp
@@ -120,7 +120,8 @@ namespace Ogre {
                                 "EGLWindow::create");
                 }
 
-                if((opt = miscParams->find("currentEGLSurface")) != end)
+                if((opt = miscParams->find("currentEGLSurface")) != end &&
+                    StringConverter::parseBool(opt->second))
                 {
                     mEglSurface = eglGetCurrentSurface(EGL_DRAW);
                 }

--- a/RenderSystems/GLSupport/src/EGL/Android/OgreAndroidEGLWindow.cpp
+++ b/RenderSystems/GLSupport/src/EGL/Android/OgreAndroidEGLWindow.cpp
@@ -119,9 +119,9 @@ namespace Ogre {
                                 "currentGLContext was specified with no current GL context",
                                 "EGLWindow::create");
                 }
-    #if OGRE_BITES_HAVE_SDL
+#if defined(OGRE_BITES_HAVE_SDL) && OGRE_BITES_HAVE_SDL
                 mEglSurface = eglGetCurrentSurface(EGL_DRAW);
-    #endif
+#endif
                 mEglDisplay = eglGetCurrentDisplay();
             }
 

--- a/RenderSystems/GLSupport/src/EGL/Android/OgreAndroidEGLWindow.cpp
+++ b/RenderSystems/GLSupport/src/EGL/Android/OgreAndroidEGLWindow.cpp
@@ -119,7 +119,9 @@ namespace Ogre {
                                 "currentGLContext was specified with no current GL context",
                                 "EGLWindow::create");
                 }
-
+    #if OGRE_BITES_HAVE_SDL
+                mEglSurface = eglGetCurrentSurface(EGL_DRAW);
+    #endif
                 mEglDisplay = eglGetCurrentDisplay();
             }
 


### PR DESCRIPTION
On android, i'm using SDL for create window
But without this, app will be crash, because SDL already created surface, so just get the surface from current