### PR TITLE
Allows multi-threading when rendering.

### DIFF
--- a/Components/Bites/include/OgreBites.i
+++ b/Components/Bites/include/OgreBites.i
@@ -1,4 +1,4 @@
-%module(package="Ogre", directors="1") Bites
+%module(package="Ogre", directors="1", threads="1") Bites
 %{
 /* Includes the header in the wrapper code */
 #include "Ogre.h"
@@ -15,6 +15,7 @@
 #include "OgreImGuiInputListener.h"
 %}
 
+%feature("nothreadallow");
 %include std_vector.i
 %include std_string.i
 %include exception.i 

--- a/Docs/src/tutorials/numpy.md
+++ b/Docs/src/tutorials/numpy.md
@@ -59,6 +59,3 @@ def printer():
 threading.Thread(target=printer).start()
 root.startRendering()
 ```
-
-The "printer" Thread will be blocked until the rendering is finished.
-To allow background threads to run, you can use `root.allowPyThread()`, which will release the GIL during swapping, while rendering is waiting for vsync.

--- a/OgreMain/include/Ogre.i
+++ b/OgreMain/include/Ogre.i
@@ -1,4 +1,4 @@
- %module(package="Ogre", directors="1") Ogre
+ %module(package="Ogre", directors="1", threads="1") Ogre
  %{
  /* Includes the header in the wrapper code */
 #include "Ogre.h"
@@ -19,6 +19,7 @@
 #include "OgreDefaultDebugDrawer.h"
 %}
 
+%feature("nothreadallow");
 %include stdint.i
 %include std_shared_ptr.i
 %include std_string.i
@@ -515,6 +516,7 @@ SHARED_PTR(FileHandleDataStream);
 %include "OgreCodec.h"
 %include "OgreSerializer.h"
 %include "OgreScriptLoader.h"
+
 // Listeners
 %feature("director") Ogre::FrameListener;
 %include "OgreFrameListener.h"
@@ -528,6 +530,7 @@ SHARED_PTR(FileHandleDataStream);
 %include "OgreRenderTargetListener.h"
 %feature("director") Ogre::MeshSerializerListener;
 %feature("director") Ogre::ResourceLoadingListener;
+
 // More Data Types
 %ignore Ogre::ColourValue::getHSB; // deprecated
 %include "OgreColourValue.h"
@@ -925,33 +928,10 @@ SHARED_PTR(Mesh);
 %ignore Ogre::Root::createSceneManager(uint16, const String&);
 %ignore Ogre::Root::getMovableObjectFactoryIterator;
 #ifdef SWIGPYTHON
-%{
-class ThreadAllowFrameListener : public Ogre::FrameListener {
-    PyThreadState* _save = 0;
-public:
-    bool frameRenderingQueued(const Ogre::FrameEvent& evt)
-    {
-        if(!_save)
-            _save = PyEval_SaveThread();
-        return true;
-    }
-    bool frameEnded(const Ogre::FrameEvent& evt)
-    {
-        if(_save) {
-            PyEval_RestoreThread(_save);
-            _save = 0;
-        }
-        return true;
-    }
-};
-%}
-%extend Ogre::Root {
-    void allowPyThread()
-    {
-        static ThreadAllowFrameListener listener;
-        $self->addFrameListener(&listener);
-    }
-}
+/* Unlocks SIG when called from python */
+%feature("nothreadallow", "0") Ogre::Root::startRendering;
+%feature("nothreadallow", "0") Ogre::Root::renderOneFrame;
+%feature("nothreadallow", "0") Ogre::Root::_updateAllRenderTargets;
 #endif
 %include "OgreRoot.h"
 // dont wrap: not useful in high level languages

--- a/OgreMain/include/Ogre.i
+++ b/OgreMain/include/Ogre.i
@@ -929,9 +929,9 @@ SHARED_PTR(Mesh);
 %ignore Ogre::Root::getMovableObjectFactoryIterator;
 #ifdef SWIGPYTHON
 /* Unlocks SIG when called from python */
-%feature("nothreadallow", "0") Ogre::Root::startRendering;
-%feature("nothreadallow", "0") Ogre::Root::renderOneFrame;
-%feature("nothreadallow", "0") Ogre::Root::_updateAllRenderTargets;
+%threadallow Ogre::Root::startRendering;
+%threadallow Ogre::Root::renderOneFrame;
+%threadallow Ogre::Root::_updateAllRenderTargets;
 #endif
 %include "OgreRoot.h"
 // dont wrap: not useful in high level languages


### PR DESCRIPTION
SWIG is capable of generating multi-threading code.

We allow locking the GIL when python code is called from C++ through some virtual method. However, we do not automatically allow the GIL to be released when C++ code is called from python, for that would happen in abut 9000 places and the performance penalty would not be negligible.

This is done with `thread="1"` and `%feature("nothreadallow");`.

However, for some selected methods we do release the GIL, allowing multi-threading. This is done with `%threadsallow` only for the methods `Root::startRendering()`, `Root::renderOneFrame()` and `Root::_updateAllRenderTargets`.