### PR TITLE
Main: add debug build guard on Ogre::Root

### DIFF
--- a/OgreMain/include/OgrePrerequisites.h
+++ b/OgreMain/include/OgrePrerequisites.h
@@ -32,6 +32,17 @@ THE SOFTWARE
 #include <string>
 #include <memory>
 
+// extra namespace to trigger LNK2019 on binary incompatible builds
+// instead of crashing at runtime
+#if defined(_MSC_VER) && defined(_DEBUG)
+#define OGRE_DEBUG_NS_BEGIN namespace DEBUG_BUILD_REQUIRED {
+#define OGRE_DEBUG_NS_END }
+namespace Ogre { namespace DEBUG_BUILD_REQUIRED { } using namespace DEBUG_BUILD_REQUIRED; }
+#else
+#define OGRE_DEBUG_NS_BEGIN
+#define OGRE_DEBUG_NS_END
+#endif
+
 namespace Ogre {
     #define OGRE_TOKEN_PASTE_INNER(x, y) x ## y
     #define OGRE_TOKEN_PASTE(x, y) OGRE_TOKEN_PASTE_INNER(x, y)
@@ -211,7 +222,9 @@ namespace Ogre {
     class ResourceGroupManager;
     class ResourceManager;
     class RibbonTrail;
+OGRE_DEBUG_NS_BEGIN
     class Root;
+OGRE_DEBUG_NS_END
     class SceneManager;
     class SceneNode;
     class SceneQuery;

--- a/OgreMain/include/OgreRoot.h
+++ b/OgreMain/include/OgreRoot.h
@@ -55,6 +55,8 @@ namespace Ogre
     /// Scene manager instances, indexed by instance name
     typedef std::map<String, SceneManager*> SceneManagerInstanceMap;
 
+    OGRE_DEBUG_NS_BEGIN
+
     /** The root class of the Ogre system.
 
         The Ogre::Root class represents a starting point for the client
@@ -925,6 +927,7 @@ namespace Ogre
         */
         Real getDefaultMinPixelSize() { return mDefaultMinPixelSize; }
     };
+    OGRE_DEBUG_NS_END
     /** @} */
     /** @} */
 } // Namespace Ogre


### PR DESCRIPTION
triggers LNK2019 on Ogre::DebugBuild::Root

fixes #455 