### PR TITLE
D3D11: _create2DTex() from shared surface.

### DIFF
--- a/OgreMain/include/OgreTexture.h
+++ b/OgreMain/include/OgreTexture.h
@@ -146,6 +146,12 @@ namespace Ogre {
         */
         TextureType getTextureType(void) const { return mTextureType; }
 
+        /** D3D11 only: set a shared surface to use for this texture before loading
+         *
+         * Useful for WPF interop
+         */
+        virtual void _setD3D11Surface(void* surface) {}
+
         /** Gets the number of mipmaps to be used for this texture.
         */
         uint32 getNumMipmaps(void) const {return mNumMipmaps;}

--- a/RenderSystems/Direct3D11/include/OgreD3D11Texture.h
+++ b/RenderSystems/Direct3D11/include/OgreD3D11Texture.h
@@ -94,6 +94,8 @@ namespace Ogre {
         void _create1DTex();
         /// internal method, create a blank normal 2D texture
         void _create2DTex();
+        /// internal method to create a normal 2D texture with an already existing surface
+        void _createShared2DTex();
         /// internal method, create a blank cube texture
         void _create3DTex();
 
@@ -107,6 +109,8 @@ namespace Ogre {
         /// internal method, create D3D11HardwarePixelBuffers for every face and
         /// mipmap level. This method must be called after the D3D texture object was created
         void _createSurfaceList(void);
+
+        void _setD3D11Surface(void* surface) override;
 
         void notifyDeviceLost(D3D11Device* device);
         void notifyDeviceRestored(D3D11Device* device);
@@ -128,6 +132,8 @@ namespace Ogre {
 
         D3D11_SHADER_RESOURCE_VIEW_DESC mSRVDesc;
         bool mAutoMipMapGeneration;
+
+        void* mSurface = NULL;
     };
 
     /// RenderTexture implementation for D3D11


### PR DESCRIPTION
dropped Flush as you can get the device via getCustomAttribute("D3DDEVICE") and flush yourself