### PR TITLE
Fixed Texture::convertToImage mipmap cycle.

### DIFF
--- a/OgreMain/src/OgreTexture.cpp
+++ b/OgreMain/src/OgreTexture.cpp
@@ -394,7 +394,7 @@ namespace Ogre {
 
         for (uint32 face = 0; face < getNumFaces(); ++face)
         {
-            for (uint32 mip = 0; mip < numMips; ++mip)
+            for (uint32 mip = 0; mip <= numMips; ++mip)
             {
                 getBuffer(face, mip)->blitToMemory(destImage.getPixelBox(face, mip));
             }


### PR DESCRIPTION
If the method is called with includeMipMaps = FALSE or if the Texture has only one/primary mipmap in that case numMips = 0. Therefore the code just creates an empty Ogre::Image without filling its content.