### PR TITLE
Force the DDS/DXT stream decompression.

### DIFF
--- a/OgreMain/include/OgreCodec.h
+++ b/OgreMain/include/OgreCodec.h
@@ -134,6 +134,8 @@ namespace Ogre {
         @return A blank string if the magic number was unknown, or a file extension.
         */
         virtual String magicNumberToFileExt(const char *magicNumberPtr, size_t maxbytes) const = 0;
+
+        virtual bool setParameter(const String& name, const String& value) { return false; }
     };
     /** @} */
     /** @} */

--- a/OgreMain/src/OgreDDSCodec.cpp
+++ b/OgreMain/src/OgreDDSCodec.cpp
@@ -160,27 +160,6 @@ namespace {
 }
 
     //---------------------------------------------------------------------
-    // Force the DXT stream decompression
-    //---------------------------------------------------------------------
-    int DDSDecodeEnforcer::mCount = 0;
-
-    DDSDecodeEnforcer::DDSDecodeEnforcer()
-    {
-        ++mCount;
-    }
-
-    DDSDecodeEnforcer::~DDSDecodeEnforcer()
-    {
-        --mCount;
-        assert(mCount >= 0);
-    }
-
-    bool DDSDecodeEnforcer::isEnabled()
-    {
-        return mCount > 0;
-    }
-
-    //---------------------------------------------------------------------
     DDSCodec* DDSCodec::msInstance = 0;
     //---------------------------------------------------------------------
     void DDSCodec::startup(void)
@@ -210,7 +189,8 @@ namespace {
     }
     //---------------------------------------------------------------------
     DDSCodec::DDSCodec():
-        mType("dds")
+        mType("dds"),
+        mDecodeEnforce(false)
     { 
     }
     //---------------------------------------------------------------------
@@ -867,7 +847,7 @@ namespace {
         {
             if (Root::getSingleton().getRenderSystem() == NULL ||
                 !Root::getSingleton().getRenderSystem()->getCapabilities()->hasCapability(RSC_TEXTURE_COMPRESSION_DXT) ||
-                DDSDecodeEnforcer::isEnabled())
+                mDecodeEnforce)
             {
                 // We'll need to decompress
                 decompressDXT = true;
@@ -1085,6 +1065,17 @@ namespace {
 
         return BLANKSTRING;
 
+    }
+    //---------------------------------------------------------------------
+    bool DDSCodec::setParameter(const String& name, const String& value)
+    {
+        if (name == "decode_enforce")
+        {
+            StringConverter::parse(value, mDecodeEnforce);
+            return true;
+        }
+
+        return false;
     }
     
 }

--- a/OgreMain/src/OgreDDSCodec.cpp
+++ b/OgreMain/src/OgreDDSCodec.cpp
@@ -1070,10 +1070,7 @@ namespace {
     bool DDSCodec::setParameter(const String& name, const String& value)
     {
         if (name == "decode_enforce")
-        {
-            StringConverter::parse(value, mDecodeEnforce);
-            return true;
-        }
+            return StringConverter::parse(value, mDecodeEnforce);
 
         return false;
     }

--- a/OgreMain/src/OgreDDSCodec.h
+++ b/OgreMain/src/OgreDDSCodec.h
@@ -44,6 +44,23 @@ namespace Ogre {
     struct DXTExplicitAlphaBlock;
     struct DXTInterpolatedAlphaBlock;
 
+    /** Force the DXT stream decompression.
+
+        The DDSCodec keeps the DXT format if the hardware supports it.
+        However this stack object can enforce the DXT decompression into RGB(A) format.
+    */
+    class _OgreExport DDSDecodeEnforcer
+    {
+    public:
+        DDSDecodeEnforcer();
+        ~DDSDecodeEnforcer();
+
+        static bool isEnabled();
+
+    private:
+        static int mCount;
+    };
+
     /** Codec specialized in loading DDS (Direct Draw Surface) images.
 
         We implement our own codec here since we need to be able to keep DXT
@@ -72,6 +89,7 @@ namespace Ogre {
         DDSCodec();
         virtual ~DDSCodec() { }
 
+        DataStreamPtr encode(const Any& input) const override;
         void encodeToFile(const Any& input, const String& outFileName) const override;
         void decode(const DataStreamPtr& input, const Any& output) const override;
         String magicNumberToFileExt(const char *magicNumberPtr, size_t maxbytes) const override;

--- a/OgreMain/src/OgreDDSCodec.h
+++ b/OgreMain/src/OgreDDSCodec.h
@@ -44,22 +44,6 @@ namespace Ogre {
     struct DXTExplicitAlphaBlock;
     struct DXTInterpolatedAlphaBlock;
 
-    /** Force the DXT stream decompression.
-
-        The DDSCodec keeps the DXT format if the hardware supports it.
-        However this stack object can enforce the DXT decompression into RGB(A) format.
-    */
-    class _OgreExport DDSDecodeEnforcer
-    {
-    public:
-        DDSDecodeEnforcer();
-        ~DDSDecodeEnforcer();
-
-        static bool isEnabled();
-
-    private:
-        static int mCount;
-    };
 
     /** Codec specialized in loading DDS (Direct Draw Surface) images.
 
@@ -70,6 +54,7 @@ namespace Ogre {
     {
     private:
         String mType;
+        bool   mDecodeEnforce;
 
         PixelFormat convertFourCCFormat(uint32 fourcc) const;
         PixelFormat convertDXToOgreFormat(uint32 fourcc) const;
@@ -99,6 +84,8 @@ namespace Ogre {
         static void startup(void);
         /// Static method to shutdown and unregister the DDS codec
         static void shutdown(void);
+
+        bool setParameter(const String& name, const String& value) override;
 
     };
     /** @} */


### PR DESCRIPTION
The DDSCodec keeps the DXT format if the hardware supports it. However using this stack object it is possible to enforce the DXT decompression into RGB(A) format. This is useful e.g. when we have DDS texture without mipmaps and we need them. DirectX11 does not generate mipmaps if the texture is compressed (DirectX9 does it automatically).

Also added support to obtain the DDS stream (not only saving to file).