### PR TITLE
fix: SWIG binding TerrainSlotMap.

### DIFF
--- a/Components/Terrain/include/OgreTerrain.i
+++ b/Components/Terrain/include/OgreTerrain.i
@@ -32,6 +32,7 @@
 %include "OgreTerrainQuadTreeNode.h"
 
 %template(LayerInstanceList) std::vector<Ogre::Terrain::LayerInstance>;
+%template(TerrainSlotMap) std::map<uint32_t, Ogre::TerrainGroup::TerrainSlot*>;
 %template(TerrainRayResult) std::pair<bool, Ogre::Vector3>;
 %ignore Ogre::Terrain::getBlendTextureCount;
 %ignore Ogre::Terrain::getBlendTextureName;

--- a/Components/Terrain/include/OgreTerrain.i
+++ b/Components/Terrain/include/OgreTerrain.i
@@ -32,6 +32,17 @@
 %include "OgreTerrainQuadTreeNode.h"
 
 %template(LayerInstanceList) std::vector<Ogre::Terrain::LayerInstance>;
+#ifdef SWIGPYTHON
+%{
+    // this is a workaround for the following map
+    namespace swig {
+    template<> struct traits<Ogre::TerrainGroup::TerrainSlot> {
+        typedef pointer_category category;
+        static const char* type_name() { return "Ogre::TerrainGroup::TerrainSlot"; }
+    };
+    }
+%}
+#endif
 %template(TerrainSlotMap) std::map<uint32_t, Ogre::TerrainGroup::TerrainSlot*>;
 %template(TerrainRayResult) std::pair<bool, Ogre::Vector3>;
 %ignore Ogre::Terrain::getBlendTextureCount;

--- a/Components/Terrain/include/OgreTerrain.i
+++ b/Components/Terrain/include/OgreTerrain.i
@@ -43,7 +43,9 @@
     }
 %}
 #endif
+#ifndef SWIGJAVA
 %template(TerrainSlotMap) std::map<uint32_t, Ogre::TerrainGroup::TerrainSlot*>;
+#endif
 %template(TerrainRayResult) std::pair<bool, Ogre::Vector3>;
 %ignore Ogre::Terrain::getBlendTextureCount;
 %ignore Ogre::Terrain::getBlendTextureName;


### PR DESCRIPTION
SWIG created a generic type for TerrainSlotMap; this apparently fixes it to the right type.