### PR TITLE
fix: RegionMap, LODBucketList, MaterialBucketMap and GeometryBucketList C# SWIG bindings.

### DIFF
--- a/Components/Terrain/include/OgreTerrain.i
+++ b/Components/Terrain/include/OgreTerrain.i
@@ -32,6 +32,7 @@
 %include "OgreTerrainQuadTreeNode.h"
 
 %template(LayerInstanceList) std::vector<Ogre::Terrain::LayerInstance>;
+%template(TerrainSlotMap) std::map<uint32_t, Ogre::TerrainGroup::TerrainSlot*>;
 %template(TerrainRayResult) std::pair<bool, Ogre::Vector3>;
 %ignore Ogre::Terrain::getBlendTextureCount;
 %ignore Ogre::Terrain::getBlendTextureName;

--- a/Components/Terrain/include/OgreTerrain.i
+++ b/Components/Terrain/include/OgreTerrain.i
@@ -32,6 +32,17 @@
 %include "OgreTerrainQuadTreeNode.h"
 
 %template(LayerInstanceList) std::vector<Ogre::Terrain::LayerInstance>;
+#ifdef SWIGPYTHON
+%{
+    // this is a workaround for the following map
+    namespace swig {
+    template<> struct traits<Ogre::TerrainGroup::TerrainSlot> {
+        typedef pointer_category category;
+        static const char* type_name() { return "Ogre::TerrainGroup::TerrainSlot"; }
+    };
+    }
+%}
+#endif
 %template(TerrainSlotMap) std::map<uint32_t, Ogre::TerrainGroup::TerrainSlot*>;
 %template(TerrainRayResult) std::pair<bool, Ogre::Vector3>;
 %ignore Ogre::Terrain::getBlendTextureCount;

--- a/Components/Terrain/include/OgreTerrain.i
+++ b/Components/Terrain/include/OgreTerrain.i
@@ -43,7 +43,9 @@
     }
 %}
 #endif
+#ifndef SWIGJAVA
 %template(TerrainSlotMap) std::map<uint32_t, Ogre::TerrainGroup::TerrainSlot*>;
+#endif
 %template(TerrainRayResult) std::pair<bool, Ogre::Vector3>;
 %ignore Ogre::Terrain::getBlendTextureCount;
 %ignore Ogre::Terrain::getBlendTextureName;

--- a/OgreMain/include/Ogre.i
+++ b/OgreMain/include/Ogre.i
@@ -882,7 +882,9 @@ SHARED_PTR(Mesh);
     }
 %}
 #endif
+#ifndef SWIGJAVA
 %template(RegionMap) std::map<uint32_t, Ogre::StaticGeometry::Region*>;
+#endif
 #ifdef SWIGPYTHON
 %{
     // this is a workaround for the following map

--- a/OgreMain/include/Ogre.i
+++ b/OgreMain/include/Ogre.i
@@ -871,9 +871,31 @@ SHARED_PTR(Mesh);
 %ignore Ogre::StaticGeometry::Region::getLODIterator;
 %ignore Ogre::StaticGeometry::MaterialBucket::getGeometryIterator;
 %ignore Ogre::StaticGeometry::LODBucket::getMaterialIterator;
+#ifdef SWIGPYTHON
+%{
+    // this is a workaround for the following map
+    namespace swig {
+    template<> struct traits<Ogre::StaticGeometry::Region> {
+        typedef pointer_category category;
+        static const char* type_name() { return "Ogre::StaticGeometry::Region"; }
+    };
+    }
+%}
+#endif
 %template(RegionMap) std::map<uint32_t, Ogre::StaticGeometry::Region*>;
-%template(LODBucketList) std::vector<Ogre::StaticGeometry::LODBucket*>;
+#ifdef SWIGPYTHON
+%{
+    // this is a workaround for the following map
+    namespace swig {
+    template<> struct traits<Ogre::StaticGeometry::MaterialBucket> {
+        typedef pointer_category category;
+        static const char* type_name() { return "Ogre::StaticGeometry::MaterialBucket"; }
+    };
+    }
+%}
+#endif
 %template(MaterialBucketMap) std::map<std::string, Ogre::StaticGeometry::MaterialBucket*>;
+%template(LODBucketList) std::vector<Ogre::StaticGeometry::LODBucket*>;
 %template(GeometryBucketList) std::vector<Ogre::StaticGeometry::GeometryBucket*>;
 %include "OgreStaticGeometry.h"
 %include "OgrePatchSurface.h"

--- a/OgreMain/include/Ogre.i
+++ b/OgreMain/include/Ogre.i
@@ -871,6 +871,10 @@ SHARED_PTR(Mesh);
 %ignore Ogre::StaticGeometry::Region::getLODIterator;
 %ignore Ogre::StaticGeometry::MaterialBucket::getGeometryIterator;
 %ignore Ogre::StaticGeometry::LODBucket::getMaterialIterator;
+%template(RegionMap) std::map<uint32_t, Ogre::StaticGeometry::Region*>;
+%template(LODBucketList) std::vector<Ogre::StaticGeometry::LODBucket*>;
+%template(MaterialBucketMap) std::map<std::string, Ogre::StaticGeometry::MaterialBucket*>;
+%template(GeometryBucketList) std::vector<Ogre::StaticGeometry::GeometryBucket*>;
 %include "OgreStaticGeometry.h"
 %include "OgrePatchSurface.h"
     SHARED_PTR(PatchMesh);


### PR DESCRIPTION
Templates to fix C# swig bindings.