### PR TITLE
Use constexpr for static colour constants

### DIFF
--- a/OgreMain/include/OgreColourValue.h
+++ b/OgreMain/include/OgreColourValue.h
@@ -57,14 +57,14 @@ namespace Ogre {
     class _OgreExport ColourValue
     {
     public:
-        static const ColourValue ZERO;
-        static const ColourValue Black;
-        static const ColourValue White;
-        static const ColourValue Red;
-        static const ColourValue Green;
-        static const ColourValue Blue;
+        static const ColourValue &ZERO;
+        static const ColourValue &Black;
+        static const ColourValue &White;
+        static const ColourValue &Red;
+        static const ColourValue &Green;
+        static const ColourValue &Blue;
 
-        explicit ColourValue( float red = 1.0f,
+        explicit constexpr ColourValue( float red = 1.0f,
                     float green = 1.0f,
                     float blue = 1.0f,
                     float alpha = 1.0f ) : r(red), g(green), b(blue), a(alpha)

--- a/OgreMain/src/OgreColourValue.cpp
+++ b/OgreMain/src/OgreColourValue.cpp
@@ -28,13 +28,21 @@ THE SOFTWARE.
 #include "OgreStableHeaders.h"
 
 namespace Ogre {
+namespace {
+    constexpr ColourValue gColourValueZero(0.0, 0.0, 0.0, 0.0);
+    constexpr ColourValue gColourValueBlack(0.0, 0.0, 0.0);
+    constexpr ColourValue gColourValueWhite(1.0, 1.0, 1.0);
+    constexpr ColourValue gColourValueRed(1.0, 0.0, 0.0);
+    constexpr ColourValue gColourValueGreen(0.0, 1.0, 0.0);
+    constexpr ColourValue gColourValueBlue(0.0, 0.0, 1.0);
+}  // namespace
 
-    const ColourValue ColourValue::ZERO = ColourValue(0.0,0.0,0.0,0.0);
-    const ColourValue ColourValue::Black = ColourValue(0.0,0.0,0.0);
-    const ColourValue ColourValue::White = ColourValue(1.0,1.0,1.0);
-    const ColourValue ColourValue::Red = ColourValue(1.0,0.0,0.0);
-    const ColourValue ColourValue::Green = ColourValue(0.0,1.0,0.0);
-    const ColourValue ColourValue::Blue = ColourValue(0.0,0.0,1.0);
+    const ColourValue &ColourValue::ZERO = gColourValueZero;
+    const ColourValue &ColourValue::Black = gColourValueBlack;
+    const ColourValue &ColourValue::White = gColourValueWhite;
+    const ColourValue &ColourValue::Red = gColourValueRed;
+    const ColourValue &ColourValue::Green = gColourValueGreen;
+    const ColourValue &ColourValue::Blue = gColourValueBlue;
 
     //---------------------------------------------------------------------
 #if OGRE_ENDIAN == OGRE_ENDIAN_BIG

--- a/Samples/ShaderSystemTexturedFog/src/RTShaderSRSTexturedFog.cpp
+++ b/Samples/ShaderSystemTexturedFog/src/RTShaderSRSTexturedFog.cpp
@@ -207,7 +207,6 @@ bool RTShaderSRSTexturedFog::preAddToRenderState(const RenderState* renderState,
         return false;
 
     FogMode fogMode;
-    ColourValue newFogColour;
     Real newFogStart, newFogEnd, newFogDensity;
 
     if (srcPass->getFogOverride())


### PR DESCRIPTION
This fixes the initialization-order-fiasco for static colour constants while preserving API (though breaking ABI) through the following steps:

* Make `constexpr` the OgreColourValue constructor
* Instantiate global constexpr variables in a hidden namespace in `.cpp` file
* Change static class constants to references (ABI break) and assign to global `constexpr` variables

This matches the approach taken with similar static constants in gazebosim/gz-math#283.

Reference:
- https://abseil.io/tips/140
- https://en.cppreference.com/w/cpp/language/initialization