### PR TITLE
Use constexpr for static Vector constants

### DIFF
--- a/OgreMain/include/OgreVector.h
+++ b/OgreMain/include/OgreVector.h
@@ -46,17 +46,17 @@ namespace Ogre
     template <int dims, typename T> struct VectorBase
     {
         VectorBase() {}
-        VectorBase(T _x, T _y)
+        constexpr VectorBase(T _x, T _y)
         {
             static_assert(dims > 1, "must have at least 2 dimensions");
             data[0] = _x; data[1] = _y;
         }
-        VectorBase(T _x, T _y, T _z)
+        constexpr VectorBase(T _x, T _y, T _z)
         {
             static_assert(dims > 2, "must have at least 3 dimensions");
             data[0] = _x; data[1] = _y; data[2] = _z;
         }
-        VectorBase(T _x, T _y, T _z, T _w)
+        constexpr VectorBase(T _x, T _y, T _z, T _w)
         {
             static_assert(dims > 3, "must have at least 4 dimensions");
             data[0] = _x; data[1] = _y; data[2] = _z; data[3] = _w;
@@ -68,7 +68,7 @@ namespace Ogre
     template <> struct _OgreExport VectorBase<2, Real>
     {
         VectorBase() {}
-        VectorBase(Real _x, Real _y) : x(_x), y(_y) {}
+        constexpr VectorBase(Real _x, Real _y) : x(_x), y(_y) {}
         Real x, y;
         Real* ptr() { return &x; }
         const Real* ptr() const { return &x; }
@@ -117,18 +117,18 @@ namespace Ogre
         Radian angleTo(const Vector2& other) const;
 
         // special points
-        static const Vector2 ZERO;
-        static const Vector2 UNIT_X;
-        static const Vector2 UNIT_Y;
-        static const Vector2 NEGATIVE_UNIT_X;
-        static const Vector2 NEGATIVE_UNIT_Y;
-        static const Vector2 UNIT_SCALE;
+        static const Vector2 &ZERO;
+        static const Vector2 &UNIT_X;
+        static const Vector2 &UNIT_Y;
+        static const Vector2 &NEGATIVE_UNIT_X;
+        static const Vector2 &NEGATIVE_UNIT_Y;
+        static const Vector2 &UNIT_SCALE;
     };
 
     template <> struct _OgreExport VectorBase<3, Real>
     {
         VectorBase() {}
-        VectorBase(Real _x, Real _y, Real _z) : x(_x), y(_y), z(_z) {}
+        constexpr VectorBase(Real _x, Real _y, Real _z) : x(_x), y(_y), z(_z) {}
         Real x, y, z;
         Real* ptr() { return &x; }
         const Real* ptr() const { return &x; }
@@ -244,26 +244,26 @@ namespace Ogre
         const Vector3& primaryAxis() const;
 
         // special points
-        static const Vector3 ZERO;
-        static const Vector3 UNIT_X;
-        static const Vector3 UNIT_Y;
-        static const Vector3 UNIT_Z;
-        static const Vector3 NEGATIVE_UNIT_X;
-        static const Vector3 NEGATIVE_UNIT_Y;
-        static const Vector3 NEGATIVE_UNIT_Z;
-        static const Vector3 UNIT_SCALE;
+        static const Vector3 &ZERO;
+        static const Vector3 &UNIT_X;
+        static const Vector3 &UNIT_Y;
+        static const Vector3 &UNIT_Z;
+        static const Vector3 &NEGATIVE_UNIT_X;
+        static const Vector3 &NEGATIVE_UNIT_Y;
+        static const Vector3 &NEGATIVE_UNIT_Z;
+        static const Vector3 &UNIT_SCALE;
     };
 
     template <> struct _OgreExport VectorBase<4, Real>
     {
         VectorBase() {}
-        VectorBase(Real _x, Real _y, Real _z, Real _w) : x(_x), y(_y), z(_z), w(_w) {}
+        constexpr VectorBase(Real _x, Real _y, Real _z, Real _w) : x(_x), y(_y), z(_z), w(_w) {}
         Real x, y, z, w;
         Real* ptr() { return &x; }
         const Real* ptr() const { return &x; }
 
         // special points
-        static const Vector4 ZERO;
+        static const Vector4 &ZERO;
     };
 
     /** Standard N-dimensional vector.
@@ -283,9 +283,9 @@ namespace Ogre
             @note It does <b>NOT</b> initialize the vector for efficiency.
         */
         Vector() {}
-        Vector(T _x, T _y) : VectorBase<dims, T>(_x, _y) {}
-        Vector(T _x, T _y, T _z) : VectorBase<dims, T>(_x, _y, _z) {}
-        Vector(T _x, T _y, T _z, T _w) : VectorBase<dims, T>(_x, _y, _z, _w) {}
+        constexpr Vector(T _x, T _y) : VectorBase<dims, T>(_x, _y) {}
+        constexpr Vector(T _x, T _y, T _z) : VectorBase<dims, T>(_x, _y, _z) {}
+        constexpr Vector(T _x, T _y, T _z, T _w) : VectorBase<dims, T>(_x, _y, _z, _w) {}
 
         // use enable_if as function parameter for VC < 2017 compatibility
         template <int N = dims>

--- a/OgreMain/src/OgreVector.cpp
+++ b/OgreMain/src/OgreVector.cpp
@@ -29,21 +29,41 @@ THE SOFTWARE.
 
 namespace Ogre
 {
-const Vector2 VectorBase<2, Real>::ZERO( 0 );
-const Vector2 VectorBase<2, Real>::UNIT_X( 1, 0);
-const Vector2 VectorBase<2, Real>::UNIT_Y( 0, 1);
-const Vector2 VectorBase<2, Real>::NEGATIVE_UNIT_X( -1,  0);
-const Vector2 VectorBase<2, Real>::NEGATIVE_UNIT_Y(  0, -1);
-const Vector2 VectorBase<2, Real>::UNIT_SCALE( 1 );
+namespace
+{
+constexpr Vector2 gVector2Zero( 0, 0 );
+constexpr Vector2 gVector2UnitX( 1, 0);
+constexpr Vector2 gVector2UnitY( 0, 1);
+constexpr Vector2 gVector2NegativeUnitX( -1,  0);
+constexpr Vector2 gVector2NegativeUnitY(  0, -1);
+constexpr Vector2 gVector2UnitScale( 1, 1 );
 
-const Vector3 VectorBase<3, Real>::ZERO( 0 );
-const Vector3 VectorBase<3, Real>::UNIT_X( 1, 0, 0 );
-const Vector3 VectorBase<3, Real>::UNIT_Y( 0, 1, 0 );
-const Vector3 VectorBase<3, Real>::UNIT_Z( 0, 0, 1 );
-const Vector3 VectorBase<3, Real>::NEGATIVE_UNIT_X( -1,  0,  0 );
-const Vector3 VectorBase<3, Real>::NEGATIVE_UNIT_Y(  0, -1,  0 );
-const Vector3 VectorBase<3, Real>::NEGATIVE_UNIT_Z(  0,  0, -1 );
-const Vector3 VectorBase<3, Real>::UNIT_SCALE( 1 );
+constexpr Vector3 gVector3Zero( 0, 0, 0 );
+constexpr Vector3 gVector3UnitX( 1, 0, 0 );
+constexpr Vector3 gVector3UnitY( 0, 1, 0 );
+constexpr Vector3 gVector3UnitZ( 0, 0, 1 );
+constexpr Vector3 gVector3NegativeUnitX( -1,  0,  0 );
+constexpr Vector3 gVector3NegativeUnitY(  0, -1,  0 );
+constexpr Vector3 gVector3NegativeUnitZ(  0,  0, -1 );
+constexpr Vector3 gVector3UnitScale( 1, 1, 1 );
 
-const Vector4 VectorBase<4, Real>::ZERO( 0 );
+constexpr Vector4 gVector4Zero( 0, 0, 0, 0 );
+}  // namespace
+const Vector2 &VectorBase<2, Real>::ZERO = gVector2Zero;
+const Vector2 &VectorBase<2, Real>::UNIT_X = gVector2UnitX;
+const Vector2 &VectorBase<2, Real>::UNIT_Y = gVector2UnitY;
+const Vector2 &VectorBase<2, Real>::NEGATIVE_UNIT_X = gVector2NegativeUnitX;
+const Vector2 &VectorBase<2, Real>::NEGATIVE_UNIT_Y = gVector2NegativeUnitY;
+const Vector2 &VectorBase<2, Real>::UNIT_SCALE = gVector2UnitScale;
+
+const Vector3 &VectorBase<3, Real>::ZERO = gVector3Zero;
+const Vector3 &VectorBase<3, Real>::UNIT_X = gVector3UnitX;
+const Vector3 &VectorBase<3, Real>::UNIT_Y = gVector3UnitY;
+const Vector3 &VectorBase<3, Real>::UNIT_Z = gVector3UnitZ;
+const Vector3 &VectorBase<3, Real>::NEGATIVE_UNIT_X = gVector3NegativeUnitX;
+const Vector3 &VectorBase<3, Real>::NEGATIVE_UNIT_Y = gVector3NegativeUnitY;
+const Vector3 &VectorBase<3, Real>::NEGATIVE_UNIT_Z = gVector3NegativeUnitZ;
+const Vector3 &VectorBase<3, Real>::UNIT_SCALE = gVector3UnitScale;
+
+const Vector4 &VectorBase<4, Real>::ZERO = gVector4Zero;
 }


### PR DESCRIPTION
This fixes the initialization-order-fiasco for static Vector constants while preserving API (though breaking ABI) through the following steps:

* Make `constexpr` the `VectorBase` and `Vector` constructors
* Instantiate global `constexpr` variables in a hidden namespace in .cpp file
* Change static class constants to references (ABI break) and assign to global `constexpr` variables

This matches the approach taken in #3313. Note that the `Vector(T)` constructor could not be made `constexpr`, so the `ZERO` and `SCALE` variables were constructed with repeated arguments instead of a single argument.