### PR TITLE
Main: AnimationTrack - use integer comparison to avoid overflow

### DIFF
--- a/OgreMain/src/OgreAnimationTrack.cpp
+++ b/OgreMain/src/OgreAnimationTrack.cpp
@@ -192,12 +192,12 @@ namespace Ogre {
         // Pre-allocate memory
         mKeyFrameIndexMap.resize(keyFrameTimes.size());
 
-        size_t i = 0, j = 0;
+        int i = 0, j = 0;
 
-        while (j < keyFrameTimes.size())
+        while (j < int(keyFrameTimes.size()))
         {
             mKeyFrameIndexMap[j] = static_cast<ushort>(i);
-            while (i < (mKeyFrames.size() - 1) && mKeyFrames[i]->getTime() <= keyFrameTimes[j])
+            while (i < (int(mKeyFrames.size()) - 1) && mKeyFrames[i]->getTime() <= keyFrameTimes[j])
             {
                 ++i;
             }


### PR DESCRIPTION
when AnimationTrack has no keyframes. The parent animation can still have keyFrameTimes.

fixes #3354 