### PR TITLE
OgreBullet: Support btCompound shape; collider creation

### DIFF
--- a/Components/Bullet/include/OgreBullet.h
+++ b/Components/Bullet/include/OgreBullet.h
@@ -31,7 +31,8 @@ enum ColliderType
     CT_CYLINDER,
     CT_CAPSULE,
     CT_TRIMESH,
-    CT_HULL
+    CT_HULL,
+    CT_COMPOUND
 };
 
 inline btQuaternion convert(const Quaternion& q) { return btQuaternion(q.x, q.y, q.z, q.w); }
@@ -72,6 +73,12 @@ _OgreBulletExport btBoxShape* createBoxCollider(const MovableObject* mo);
 _OgreBulletExport btCapsuleShape* createCapsuleCollider(const MovableObject* mo);
 /// create capsule collider using ogre provided data
 _OgreBulletExport btCylinderShape* createCylinderCollider(const MovableObject* mo);
+/// create triMesh collider
+_OgreBulletExport btBvhTriangleMeshShape* createTrimeshCollider(const Entity* ent);
+/// create convex hull collider
+_OgreBulletExport btConvexHullShape* createConvexHullCollider(const Entity* ent);
+/// create compound shape
+_OgreBulletExport btCompoundShape* createCompoundShape();
 
 struct _OgreBulletExport CollisionListener
 {

--- a/Components/Bullet/src/OgreBullet.cpp
+++ b/Components/Bullet/src/OgreBullet.cpp
@@ -91,6 +91,12 @@ btCylinderShape* createCylinderCollider(const MovableObject* mo)
     return shape;
 }
 
+/// create compound shape because we can
+btCompoundShape* createCompoundShape()
+{
+	return new btCompoundShape;
+}
+
 struct EntityCollisionListener
 {
     const MovableObject* entity;
@@ -162,6 +168,18 @@ private:
     Vector3 mScale;
 };
 
+/// create trimesh collider using ogre provided data
+btBvhTriangleMeshShape* createTrimeshCollider(const Entity* ent)
+{
+        return VertexIndexToShape(ent).createTrimesh();
+}
+
+/// create convex hull collider using ogre provided data
+btConvexHullShape* createConvexHullCollider(const Entity* ent)
+{
+	return VertexIndexToShape(ent).createConvex();
+}
+
 /// wrapper with automatic memory management
 class CollisionObject
 {
@@ -229,11 +247,14 @@ static btCollisionShape* getCollisionShape(Entity* ent, ColliderType ct)
         cs = createCapsuleCollider(ent);
         break;
     case CT_TRIMESH:
-        cs = VertexIndexToShape(ent).createTrimesh();
+        cs = createTrimeshCollider(ent);
         break;
     case CT_HULL:
-        cs = VertexIndexToShape(ent).createConvex();
+        cs = createConvexHullCollider(ent);
         break;
+    case CT_COMPOUND:
+	cs = createCompoundShape();
+	break;
     }
 
     if (ent->hasSkeleton())


### PR DESCRIPTION
btCompoundShape allows to create more than 1 collider per body. Additionally it is the only way to offset colliders against body.

Additionally allow creation of Trimesh and ConvexHull colliders out of creating RigidBody. This will help filling-up btCompoundShape, for example.

Related to #3358