### PR TITLE
Kinematic motion

### DIFF
--- a/Components/Bullet/include/OgreBullet.h
+++ b/Components/Bullet/include/OgreBullet.h
@@ -139,6 +139,7 @@ public:
     */
     btRigidBody* addRigidBody(float mass, Entity* ent, ColliderType ct, CollisionListener* listener = nullptr,
                               int group = 1, int mask = -1);
+    btRigidBody* addKinematicRigidBody(Entity* ent, ColliderType ct, int group = 1, int mask = -1);
     void attachRigidBody(btRigidBody *rigidBody, Entity *ent, CollisionListener* listener = nullptr,
                               int group = 1, int mask = -1);
     btDynamicsWorld* getBtWorld() const { return static_cast<btDynamicsWorld*>(mBtWorld); }

--- a/Components/Bullet/include/OgreBullet.h
+++ b/Components/Bullet/include/OgreBullet.h
@@ -8,8 +8,10 @@
 
 #include "OgreBulletExports.h"
 
-#include "btBulletDynamicsCommon.h"
+#include "BulletCollision/CollisionDispatch/btGhostObject.h"
 #include "Ogre.h"
+#include "btBulletCollisionCommon.h"
+#include "btBulletDynamicsCommon.h"
 
 namespace Ogre
 {
@@ -121,6 +123,29 @@ public:
     void attachCollisionObject(btCollisionObject *collisionObject, Entity *ent, int group = 1, int mask = -1);
 };
 
+/// helper class for kinematic body motion
+class _OgreBulletExport KinematicMotionSimple : public btActionInterface
+{
+    std::vector<btCollisionShape*> mCollisionShapes;
+    std::vector<btTransform> mCollisionTransforms;
+    btPairCachingGhostObject* mGhostObject;
+    btVector3 mCurrentPosition;
+    btQuaternion mCurrentOrientation;
+    btManifoldArray mManifoldArray;
+    btScalar mMaxPenetrationDepth;
+    Node* mNode;
+    virtual bool needsCollision(const btCollisionObject* body0, const btCollisionObject* body1);
+    void preStep(btCollisionWorld* collisionWorld);
+    void playerStep(btCollisionWorld* collisionWorld, btScalar dt);
+    void setupCollisionShapes(btCollisionObject* body);
+
+public:
+    KinematicMotionSimple(btPairCachingGhostObject* ghostObject, Node* node);
+    ~KinematicMotionSimple();
+    bool recoverFromPenetration(btCollisionWorld* collisionWorld);
+    virtual void updateAction(btCollisionWorld* collisionWorld, btScalar deltaTimeStep) override;
+    virtual void debugDraw(btIDebugDraw* debugDrawer) override;
+};
 /// simplified wrapper with automatic memory management
 class _OgreBulletExport DynamicsWorld : public CollisionWorld
 {

--- a/Components/Bullet/include/OgreBullet.h
+++ b/Components/Bullet/include/OgreBullet.h
@@ -109,9 +109,10 @@ protected:
     std::unique_ptr<btBroadphaseInterface> mBroadphase;
 
     btCollisionWorld* mBtWorld;
+    btGhostPairCallback* mGhostPairCallback;
 
 public:
-    CollisionWorld(btCollisionWorld* btWorld) : mBtWorld(btWorld) {}
+    CollisionWorld(btCollisionWorld* btWorld) : mBtWorld(btWorld), mGhostPairCallback(nullptr) {}
     virtual ~CollisionWorld();
 
     btCollisionObject* addCollisionObject(Entity* ent, ColliderType ct, int group = 1, int mask = -1);

--- a/Components/Bullet/src/OgreBullet.cpp
+++ b/Components/Bullet/src/OgreBullet.cpp
@@ -287,6 +287,17 @@ btRigidBody* DynamicsWorld::addRigidBody(float mass, Entity* ent, ColliderType c
     return rb;
 }
 
+btRigidBody* DynamicsWorld::addKinematicRigidBody(Entity* ent, ColliderType ct, int group, int mask)
+{
+    btRigidBody* rb = addRigidBody(0, ent, ct, nullptr, group, mask);
+    rb->setCollisionFlags(rb->getCollisionFlags()
+                    | btCollisionObject::CF_KINEMATIC_OBJECT
+                    | btCollisionObject::CF_NO_CONTACT_RESPONSE
+                    );
+    rb->setActivationState(DISABLE_DEACTIVATION);
+    return rb;
+}
+
 btCollisionObject* CollisionWorld::addCollisionObject(Entity* ent, ColliderType ct, int group, int mask)
 {
     auto node = ent->getParentSceneNode();

--- a/Components/Bullet/src/OgreBullet.cpp
+++ b/Components/Bullet/src/OgreBullet.cpp
@@ -255,8 +255,8 @@ static btCollisionShape* getCollisionShape(Entity* ent, ColliderType ct)
         cs = createConvexHullCollider(ent);
         break;
     case CT_COMPOUND:
-	cs = createCompoundShape();
-	break;
+        cs = createCompoundShape();
+        break;
     }
 
     if (ent->hasSkeleton())


### PR DESCRIPTION
OgreBullet: This implements kinematic motion for a character-like movable thing.

To use one needs the following code:
```c++
    mGhostObject = new btPairCachingGhostObject();
    mCollisionShape = new btCompoundShape;
    mGhostObject->setCollisionShape(mCollisionShape);

    {
        btVector3 inertia(0, 0, 0);
        btScalar height = 1.0f;
        btScalar radius = 0.3f;
        btCapsuleShape *shape = new btCapsuleShape(radius, 2 * height - 2 * radius);
        btTransform transform;
        transform.setIdentity();
        transform.setOrigin(btVector3(0, 1, 0));
        static_cast<btCompoundShape *>(mCollisionShape)->addChildShape(transform, shape);
        btScalar masses[1] = {0};
        btTransform principal;
        static_cast<btCompoundShape *>(mCollisionShape)->calculatePrincipalAxisTransform(masses, principal, inertia);
    }
    mGhostObject->setCollisionFlags(btCollisionObject::CF_KINEMATIC_OBJECT | btCollisionObject::CF_NO_CONTACT_RESPONSE);
    mGhostObject->setActivationState(DISABLE_DEACTIVATION);
    Ogre::Bullet::KinematicMotionSimple *controller = new Ogre::Bullet::KinematicMotionSimple(mGhostObject, mBodyNode);
    WorldData::get_singleton()->getWorld()->attachCollisionObject(mGhostObject, mBodyEnt, btBroadphaseProxy::AllFilter, btBroadphaseProxy::AllFilter);
    WorldData::get_singleton()->getBtWorld()->addAction(controller);
```
Then you can just move mBodyNode (i.e. via root motion) and the body will follow.
Then if the motion is unsuccessful, the node transformation will be corrected.
To implement gravity just add Vector3(0, -9.8f, 0) * delta to the velocity.
```c++
        /* Kinematic motion */
        Ogre::Quaternion rot = mBodyNode->getOrientation();
        Ogre::Vector3 gravity(0, -9.8, 0);
        Ogre::Vector3 velocity = rot * boneMotion / delta;
        velocity += gravity * delta;
        Ogre::Vector3 rotMotion = velocity * delta;
        mBodyNode->setPosition(mBodyNode->getPosition() + rotMotion);
```
The btCompoundShape is supported, so complex collisions made of several convex shapes are possible.

Addresses #3358