### PR TITLE
OgreBullet: terrain: ensure colliders get destroyed with terrain.

### DIFF
--- a/Components/Bullet/include/OgreBullet.h
+++ b/Components/Bullet/include/OgreBullet.h
@@ -190,6 +190,11 @@ public:
      * @param mask the collision mask
      */
     btRigidBody* addTerrainRigidBody(TerrainGroup* terrainGroup, long x, long y, int group = 1, int mask = -1);
+    /** Add static body for Ogre terrain
+     * @param terrain the terrain
+     * @param group the collision group
+     * @param mask the collision mask
+     */
     btRigidBody* addTerrainRigidBody(Terrain* terrain, int group = 1, int mask = -1);
 
     void attachRigidBody(btRigidBody *rigidBody, Entity *ent, CollisionListener* listener = nullptr,

--- a/Components/Bullet/src/OgreBullet.cpp
+++ b/Components/Bullet/src/OgreBullet.cpp
@@ -361,12 +361,13 @@ btRigidBody* DynamicsWorld::addTerrainRigidBody(TerrainGroup* terrainGroup, long
 }
 btRigidBody* DynamicsWorld::addTerrainRigidBody(Terrain* terrain, int group, int mask)
 {
+#ifdef OGRE_BUILD_COMPONENT_TERRAIN
     btVector3 inertia(0, 0, 0);
     HeightFieldData hfdata;
     btHeightfieldTerrainShape* shape = createHeightfieldTerrainShape(terrain, &hfdata);
     /* FIXME: destroy this node when terrain chunk is destroyed */
-    SceneNode* node =
-        terrain->getSceneManager()->getRootSceneNode()->createChildSceneNode(hfdata.bodyPosition, Quaternion::IDENTITY);
+    Ogre::Vector3 positionOffset = hfdata.bodyPosition - terrain->getPosition();
+    SceneNode* node = terrain->_getRootSceneNode()->createChildSceneNode(positionOffset, Quaternion::IDENTITY);
     RigidBodyState* state = new RigidBodyState(node);
     auto rb = new btRigidBody(0, state, shape, inertia);
     getBtWorld()->addRigidBody(rb, group, mask);
@@ -380,6 +381,10 @@ btRigidBody* DynamicsWorld::addTerrainRigidBody(Terrain* terrain, int group, int
     rb->getWorldTransform().setRotation(convert(Quaternion::IDENTITY));
 
     return rb;
+#else
+    OgreAssert(false, "OGRE must be built with the Terrain component");
+    return nullptr;
+#endif
 }
 
 btCollisionObject* CollisionWorld::addCollisionObject(Entity* ent, ColliderType ct, int group, int mask)


### PR DESCRIPTION
Attach terrain collider's SceneNode to internal terrain's SceneNode.