### PR TITLE
Overlay: update imgui to 1.91.9b

### DIFF
--- a/Components/Overlay/CMakeLists.txt
+++ b/Components/Overlay/CMakeLists.txt
@@ -19,11 +19,11 @@ list(APPEND HEADER_FILES
 file(GLOB SOURCE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
 
 if(OGRE_BUILD_COMPONENT_OVERLAY_IMGUI)
-  set(IMGUI_DIR "${PROJECT_BINARY_DIR}/imgui-1.91.2" CACHE PATH "")
+  set(IMGUI_DIR "${PROJECT_BINARY_DIR}/imgui-1.91.9b" CACHE PATH "")
   if(NOT EXISTS ${IMGUI_DIR})
     message(STATUS "Downloading imgui")
     file(DOWNLOAD
-        https://github.com/ocornut/imgui/archive/v1.91.2.tar.gz
+        https://github.com/ocornut/imgui/archive/v1.91.9b.tar.gz
         ${PROJECT_BINARY_DIR}/imgui.tar.gz)
     execute_process(COMMAND ${CMAKE_COMMAND}
         -E tar xf imgui.tar.gz WORKING_DIRECTORY ${PROJECT_BINARY_DIR})

--- a/Components/Overlay/include/ImGui.i
+++ b/Components/Overlay/include/ImGui.i
@@ -39,6 +39,18 @@
     $1 = true; // actual check in the typemap
 }
 
+%typemap(in) ImTextureRef {
+    size_t argp;
+    int res = SWIG_AsVal_size_t($input, &argp);
+    if(SWIG_IsOK(res))
+        $1 = $ltype((ImTextureID)argp);
+    else
+        %argument_fail(SWIG_TypeError, "size_t", $symname, $argnum);
+}
+%typecheck(SWIG_TYPECHECK_POINTER) ImTextureRef {
+    $1 = true; // actual check in the typemap
+}
+
 %typemap(in) float[4], float[3], float[2] {
     void* argp;
     int res = SWIG_ConvertPtr($input, &argp, $descriptor(ImVec4*), $disown);


### PR DESCRIPTION
and make API compatible with imgui 1.92.
But dont upgrade yet as the visible fallout is too large for Ogre 14.x