### PR TITLE
Vulkan: fix blitFromMemory for non consecutive src

### DIFF
--- a/RenderSystems/Vulkan/src/OgreVulkanTextureGpu.cpp
+++ b/RenderSystems/Vulkan/src/OgreVulkanTextureGpu.cpp
@@ -66,7 +66,7 @@ namespace Ogre
 
     PixelBox VulkanHardwarePixelBuffer::lockImpl(const Box &lockBox,  LockOptions options)
     {
-        PixelBox ret(lockBox, mParent->getFormat());
+        PixelBox ret(lockBox.getWidth(), lockBox.getHeight(), lockBox.getDepth(), mParent->getFormat());
 
         auto textureManager = static_cast<VulkanTextureGpuManager*>(mParent->getCreator());
         VulkanDevice* device = textureManager->getDevice();
@@ -105,7 +105,8 @@ namespace Ogre
             device->mGraphicsQueue.commitAndNextCommandBuffer();
         }
 
-        return PixelBox(lockBox, mParent->getFormat(), mStagingBuffer->lock(options));
+        ret.data = (uchar*)mStagingBuffer->lock(options);
+        return ret;
     }
 
     void VulkanHardwarePixelBuffer::unlockImpl()
@@ -129,16 +130,16 @@ namespace Ogre
             region.imageSubresource.baseArrayLayer = mFace;
             region.imageSubresource.layerCount = 1;
 
-            region.imageOffset.x = mCurrentLock.left;
-            region.imageOffset.y = mCurrentLock.top;
-            region.imageOffset.z = mCurrentLock.front;
-            region.imageExtent.width = mCurrentLock.getWidth();
-            region.imageExtent.height = mCurrentLock.getHeight();
-            region.imageExtent.depth = mCurrentLock.getDepth();
+            region.imageOffset.x = mLockedBox.left;
+            region.imageOffset.y = mLockedBox.top;
+            region.imageOffset.z = mLockedBox.front;
+            region.imageExtent.width = mLockedBox.getWidth();
+            region.imageExtent.height = mLockedBox.getHeight();
+            region.imageExtent.depth = mLockedBox.getDepth();
 
             if (mParent->getTextureType() == TEX_TYPE_2D_ARRAY)
             {
-                region.imageSubresource.baseArrayLayer = mCurrentLock.front;
+                region.imageSubresource.baseArrayLayer = mLockedBox.front;
                 region.imageOffset.z = 0;
             }
 
@@ -155,21 +156,8 @@ namespace Ogre
     void VulkanHardwarePixelBuffer::blitFromMemory(const PixelBox& src, const Box& dstBox)
     {
         OgreAssert(src.getSize() == dstBox.getSize(), "scaling currently not supported");
-        // convert to image native format if necessary
-        if(src.format != mFormat)
-        {
-            std::vector<uint8> buffer;
-            buffer.resize(PixelUtil::getMemorySize(src.getWidth(), src.getHeight(), src.getDepth(), mFormat));
-            PixelBox converted = PixelBox(src.getWidth(), src.getHeight(), src.getDepth(), mFormat, buffer.data());
-            PixelUtil::bulkPixelConversion(src, converted);
-            blitFromMemory(converted, dstBox); // recursive call
-            return;
-        }
-
-        auto ptr = lock(dstBox, HBL_WRITE_ONLY).data;
-
-        memcpy(ptr, src.data, src.getConsecutiveSize());
-
+        lock(dstBox, HBL_WRITE_ONLY);
+        PixelUtil::bulkPixelConversion(src, mCurrentLock);
         unlock();
     }
     void VulkanHardwarePixelBuffer::blitToMemory(const Box& srcBox, const PixelBox& dst)


### PR DESCRIPTION
and simplify