### PR TITLE
Fix OgreRoot segfault on Android if LogManager singleton exists

### DIFF
--- a/OgreMain/src/OgreRoot.cpp
+++ b/OgreMain/src/OgreRoot.cpp
@@ -130,12 +130,12 @@ namespace Ogre {
 #else
             mLogManager->createLog(logFileName, true, true);
 #endif
-        }
 
 #if OGRE_PLATFORM == OGRE_PLATFORM_ANDROID
-        mAndroidLogger.reset(new AndroidLogListener());
-        mLogManager->getDefaultLog()->addListener(mAndroidLogger.get());
+            mAndroidLogger.reset(new AndroidLogListener());
+            mLogManager->getDefaultLog()->addListener(mAndroidLogger.get());
 #endif
+        }
 
         mDynLibManager = std::make_unique<DynLibManager>();
         mArchiveManager = std::make_unique<ArchiveManager>();
@@ -265,7 +265,10 @@ namespace Ogre {
         StringInterface::cleanupDictionary();
 
 #if OGRE_PLATFORM == OGRE_PLATFORM_ANDROID
-        mLogManager->getDefaultLog()->removeListener(mAndroidLogger.get());
+	if(mAndroidLogger)
+	{
+            mLogManager->getDefaultLog()->removeListener(mAndroidLogger.get());
+	}
 #endif
     }
 


### PR DESCRIPTION
If LogManager singleton already exists before OgreRoot constructor is called, mLogManager is not set causing a null pointer dereference when trying to add the AndroidLogListener.
This pull request fixes that by only creating AndroidLogListener when mLogManager is created.

Also enables the user to prevent the creation of the default AndroidLogListener, in case they want to use their own one, in accordance to the usage described in [the documentation](https://ogrecave.github.io/ogre/api/14/class_ogre_1_1_log_manager.html#details)