### PR TITLE
[OgreBullet] Remove heightmap colliders from visualization

### DIFF
--- a/Components/Bullet/include/OgreBullet.h
+++ b/Components/Bullet/include/OgreBullet.h
@@ -188,14 +188,16 @@ public:
      * @param y y coordinate of the terrain slot
      * @param group the collision group
      * @param mask the collision mask
+     * @param debugDraw allow debug drawing
      */
-    btRigidBody* addTerrainRigidBody(TerrainGroup* terrainGroup, long x, long y, int group = 1, int mask = -1);
+    btRigidBody* addTerrainRigidBody(TerrainGroup* terrainGroup, long x, long y, int group = 1, int mask = -1, bool debugDraw = false);
     /** Add static body for Ogre terrain
      * @param terrain the terrain
      * @param group the collision group
      * @param mask the collision mask
+     * @param debugDraw allow debug drawing
      */
-    btRigidBody* addTerrainRigidBody(Terrain* terrain, int group = 1, int mask = -1);
+    btRigidBody* addTerrainRigidBody(Terrain* terrain, int group = 1, int mask = -1, bool debugDraw = false);
 
     void attachRigidBody(btRigidBody *rigidBody, Entity *ent, CollisionListener* listener = nullptr,
                               int group = 1, int mask = -1);

--- a/Components/Bullet/src/OgreBullet.cpp
+++ b/Components/Bullet/src/OgreBullet.cpp
@@ -351,7 +351,7 @@ public:
         delete hfdata.terrainHeights;
     }
 };
-btRigidBody* DynamicsWorld::addTerrainRigidBody(TerrainGroup* terrainGroup, long x, long y, int group, int mask)
+btRigidBody* DynamicsWorld::addTerrainRigidBody(TerrainGroup* terrainGroup, long x, long y, int group, int mask, bool debugDraw)
 {
     Terrain* terrain = nullptr;
 #ifdef OGRE_BUILD_COMPONENT_TERRAIN
@@ -359,7 +359,7 @@ btRigidBody* DynamicsWorld::addTerrainRigidBody(TerrainGroup* terrainGroup, long
 #endif
     return addTerrainRigidBody(terrain, group, mask);
 }
-btRigidBody* DynamicsWorld::addTerrainRigidBody(Terrain* terrain, int group, int mask)
+btRigidBody* DynamicsWorld::addTerrainRigidBody(Terrain* terrain, int group, int mask, bool debugDraw)
 {
 #ifdef OGRE_BUILD_COMPONENT_TERRAIN
     btVector3 inertia(0, 0, 0);
@@ -377,6 +377,8 @@ btRigidBody* DynamicsWorld::addTerrainRigidBody(Terrain* terrain, int group, int
     auto objWrapper = std::make_shared<TerrainRigidBody>(rb, mBtWorld, hfdata);
     node->getUserObjectBindings().setUserAny("BtCollisionObject", objWrapper);
     rb->setCollisionFlags(rb->getCollisionFlags() | btCollisionObject::CF_STATIC_OBJECT);
+    if (!debugDraw)
+        rb->setCollisionFlags(rb->getCollisionFlags() | btCollisionObject::CF_DISABLE_VISUALIZE_OBJECT);
     rb->getWorldTransform().setOrigin(convert(hfdata.bodyPosition));
     rb->getWorldTransform().setRotation(convert(Quaternion::IDENTITY));
 


### PR DESCRIPTION
OgreBullet's debug rendering for physics leaves a lot to be desired regarding performance. Heightmap colliders are dense enough to put whole rendering to crawl and be unusable.

CF_DISABLE_VISUALIZE_OBJECT flag allows to exclude objects from debug rendering which is used here to remove heightmap colliders from being drawn.

By discussion I add parameter which allows enabling heightmap collider
debug anyway while it is being disabled by default.

References #3387
