### PR TITLE
OgreBullet: track floor

### DIFF
--- a/Components/Bullet/include/OgreBullet.h
+++ b/Components/Bullet/include/OgreBullet.h
@@ -149,6 +149,7 @@ class _OgreBulletExport KinematicMotionSimple : public btActionInterface
     btManifoldArray mManifoldArray;
     btScalar mMaxPenetrationDepth;
     Node* mNode;
+    bool mIsOnFloor;
     virtual bool needsCollision(const btCollisionObject* body0, const btCollisionObject* body1);
     void preStep(btCollisionWorld* collisionWorld);
     void playerStep(btCollisionWorld* collisionWorld, btScalar dt);
@@ -160,6 +161,7 @@ public:
     bool recoverFromPenetration(btCollisionWorld* collisionWorld);
     virtual void updateAction(btCollisionWorld* collisionWorld, btScalar deltaTimeStep) override;
     virtual void debugDraw(btIDebugDraw* debugDrawer) override;
+    bool isOnFloor() const { return mIsOnFloor; }
 };
 /// simplified wrapper with automatic memory management
 class _OgreBulletExport DynamicsWorld : public CollisionWorld

--- a/Components/Bullet/src/OgreBullet.cpp
+++ b/Components/Bullet/src/OgreBullet.cpp
@@ -943,6 +943,8 @@ bool KinematicMotionSimple::recoverFromPenetration(btCollisionWorld* collisionWo
 
     mCurrentPosition = mGhostObject->getWorldTransform().getOrigin();
 
+    mIsOnFloor = false;
+
     /* Narrow phase supports btCollisionShape already */
     for (int i = 0; i < mGhostObject->getOverlappingPairCache()->getNumOverlappingPairs(); i++)
     {
@@ -984,6 +986,11 @@ bool KinematicMotionSimple::recoverFromPenetration(btCollisionWorld* collisionWo
                     //	m_touchingNormal = pt.m_normalWorldOnB * directionSign;//??
 
                     //}
+		    btVector3 touchingNormal = pt.m_normalWorldOnB;
+                    if (touchingNormal.y() > 0 && (
+                        touchingNormal.y() > Ogre::Math::Abs(touchingNormal.x()) ||
+                        touchingNormal.y() > Ogre::Math::Abs(touchingNormal.z())))
+                            mIsOnFloor = true;
                     mCurrentPosition += pt.m_normalWorldOnB * directionSign * dist * btScalar(0.2);
                     penetration = true;
                 }
@@ -1084,7 +1091,7 @@ void KinematicMotionSimple::setupCollisionShapes(btCollisionObject* body)
 }
 KinematicMotionSimple::KinematicMotionSimple(btPairCachingGhostObject* ghostObject, Node* node)
     : btActionInterface(), mGhostObject(ghostObject), mMaxPenetrationDepth(0.0f),
-      mNode(node)
+      mNode(node), mIsOnFloor(false)
 {
     btTransform nodeXform;
     nodeXform.setRotation(convert(node->getOrientation()));


### PR DESCRIPTION
To prevent jitter when de-penetrating objects pressed against ground one can check isOnFloor() to zero-out accumulated momentum/velocity.

Please note that as soon as body is de-penetrated, isOnFloor() will be false, which is ok if you use the usual velocity += gravity * delta;
if (obj->isOnFloor())
	velocity.y = 0;
location += velocity * delta;

however if you add constant offsets that might lead to jitter because of de-penetration.

References #3358