### PR TITLE
OgreBullet: handle CF_NO_CONTACT_RESPONSE setting

### DIFF
--- a/Components/Bullet/src/OgreBullet.cpp
+++ b/Components/Bullet/src/OgreBullet.cpp
@@ -953,13 +953,11 @@ bool KinematicMotionSimple::recoverFromPenetration(btCollisionWorld* collisionWo
         btCollisionObject* obj0 = static_cast<btCollisionObject*>(collisionPair->m_pProxy0->m_clientObject);
         btCollisionObject* obj1 = static_cast<btCollisionObject*>(collisionPair->m_pProxy1->m_clientObject);
 
-        /* TODO: implement filtering
-        if ((obj0 && !obj0->hasContactResponse()) || (obj1 && !obj1->hasContactResponse()))
-        {
-            std::cout << "No contact response\n";
+	/* Do not de-penetrate from objects which have no contact response setting.
+	 * However the body itself is de-penetrated regardless of this setting */
+	if ((obj0 != mGhostObject && !obj0->hasContactResponse()) ||
+            (obj1 != mGhostObject && !obj1->hasContactResponse()))
             continue;
-        }
-        */
 
         if (!needsCollision(obj0, obj1))
             continue;


### PR DESCRIPTION
Prevent bodies de-penetrating from collision objects with CF_NO_CONTACT_RESPONSE which are usually trigger bodies. Still allow body itself to have CF_NO_CONTACT_RESPONSE and still de-penetrate.