### PR TITLE
Main: add missing include in OgreSubEntity

### DIFF
--- a/OgreMain/include/OgreSubEntity.h
+++ b/OgreMain/include/OgreSubEntity.h
@@ -30,8 +30,8 @@ THE SOFTWARE.
 
 #include "OgrePrerequisites.h"
 
+#include "OgreEntity.h"
 #include "OgreRenderable.h"
-#include "OgreHardwareBufferManager.h"
 #include "OgreResourceGroupManager.h"
 #include "OgreHeaderPrefix.h"
 


### PR DESCRIPTION
Since commit 8ba535d1485c84d819fb8e6ade0f5b59155e76b4 there is a missing include for OgreEntity.h

Furthermore, remove unused header.

