### PR TITLE
Dx11 HLSL program: fixed bad dealloc

### DIFF
--- a/RenderSystems/Direct3D11/src/OgreD3D11HLSLProgram.cpp
+++ b/RenderSystems/Direct3D11/src/OgreD3D11HLSLProgram.cpp
@@ -126,15 +126,11 @@ namespace Ogre {
 #define READ_NAME(member) {                                 \
     uint16 length = 0;                                      \
     cacheMicrocode->read(&length, sizeof(uint16));          \
-    curItem.member = "";                                    \
-    if(length > 0)                                          \
-    {                                                       \
-        char* str = new char[length + 1];                   \
-        cacheMicrocode->read(str, length);                  \
-        str[length] = '\0';                                 \
-        curItem.member = str;                               \
-    }                                                       \
-        }
+    char* str = new char[length + 1];                       \
+    cacheMicrocode->read(str, length);                      \
+    str[length] = '\0';                                     \
+    curItem.member = str;                                   \
+    }
 
 #define READ_NAME2(member) {                                 \
     uint16 length = 0;                                      \


### PR DESCRIPTION
Cause: `delete[]`-ing a non-heap empty string.
Fix: always assign a heap-string to shader Name param.

Detected by getting a debugbreak from MS VisualStudio debug heap.