### PR TITLE
GL*: Window - use RBP_NONE instead of a dummy depth buffer

### DIFF
--- a/RenderSystems/GL/include/OgreGLRenderSystem.h
+++ b/RenderSystems/GL/include/OgreGLRenderSystem.h
@@ -169,9 +169,6 @@ namespace Ogre {
         DepthBuffer* _createDepthBufferFor( RenderTarget *renderTarget ) override;
 
         MultiRenderTarget * createMultiRenderTarget(const String & name) override;
-        
-
-        void destroyRenderWindow(const String& name) override;
 
         void setNormaliseNormals(bool normalise) override;
 

--- a/RenderSystems/GL/src/OgreGLRenderSystem.cpp
+++ b/RenderSystems/GL/src/OgreGLRenderSystem.cpp
@@ -1025,18 +1025,6 @@ namespace Ogre {
                 mCurrentContext->setInitialized();
         }
 
-        if( win->getDepthBufferPool() != RBP_NONE)
-        {
-            //Unlike D3D9, OGL doesn't allow sharing the main depth buffer, so keep them separate.
-            //Only Copy does, but Copy means only one depth buffer...
-            GLContext *windowContext = dynamic_cast<GLRenderTarget*>(win)->getContext();;
-
-            auto depthBuffer = new GLDepthBufferCommon(this, windowContext, 0, 0, win, true);
-            mDepthBufferPool[depthBuffer->getPoolId()].push_back( depthBuffer );
-
-            win->attachDepthBuffer( depthBuffer );
-        }
-
         return win;
     }
     //---------------------------------------------------------------------
@@ -1110,53 +1098,6 @@ namespace Ogre {
         MultiRenderTarget *retval = new GLFBOMultiRenderTarget(name);
         attachRenderTarget( *retval );
         return retval;
-    }
-
-    //-----------------------------------------------------------------------
-    void GLRenderSystem::destroyRenderWindow(const String& name)
-    {
-        // Find it to remove from list.
-        RenderTarget* pWin = detachRenderTarget(name);
-        OgreAssert(pWin, "unknown RenderWindow name");
-
-        GLContext *windowContext = dynamic_cast<GLRenderTarget*>(pWin)->getContext();
-    
-        //1 Window <-> 1 Context, should be always true
-        assert( windowContext );
-
-        bool bFound = false;
-        //Find the depth buffer from this window and remove it.
-        DepthBufferMap::iterator itMap = mDepthBufferPool.begin();
-        DepthBufferMap::iterator enMap = mDepthBufferPool.end();
-
-        while( itMap != enMap && !bFound )
-        {
-            DepthBufferVec::iterator itor = itMap->second.begin();
-            DepthBufferVec::iterator end  = itMap->second.end();
-
-            while( itor != end )
-            {
-                //A DepthBuffer with no depth & stencil pointers is a dummy one,
-                //look for the one that matches the same GL context
-                auto depthBuffer = static_cast<GLDepthBufferCommon*>(*itor);
-                GLContext *glContext = depthBuffer->getGLContext();
-
-                if( glContext == windowContext &&
-                    (depthBuffer->getDepthBuffer() || depthBuffer->getStencilBuffer()) )
-                {
-                    bFound = true;
-
-                    delete *itor;
-                    itMap->second.erase( itor );
-                    break;
-                }
-                ++itor;
-            }
-
-            ++itMap;
-        }
-
-        delete pWin;
     }
 
     //---------------------------------------------------------------------

--- a/RenderSystems/GL3Plus/include/OgreGL3PlusRenderSystem.h
+++ b/RenderSystems/GL3Plus/include/OgreGL3PlusRenderSystem.h
@@ -139,9 +139,6 @@ namespace Ogre {
         /// @copydoc RenderSystem::createMultiRenderTarget
         MultiRenderTarget * createMultiRenderTarget(const String & name) override;
 
-
-        void destroyRenderWindow(const String& name) override;
-
         // -----------------------------
         // Low-level overridden members
         // -----------------------------

--- a/RenderSystems/GLES2/include/OgreGLES2RenderSystem.h
+++ b/RenderSystems/GLES2/include/OgreGLES2RenderSystem.h
@@ -136,8 +136,6 @@ namespace Ogre {
             MultiRenderTarget * createMultiRenderTarget(const String & name) override;
 
 
-            void destroyRenderWindow(const String& name) override;
-
             // -----------------------------
             // Low-level overridden members
             // -----------------------------
@@ -214,8 +212,6 @@ namespace Ogre {
             /// @copydoc RenderSystem::_setAlphaRejectSettings
             void _setAlphaRejectSettings( CompareFunction func, unsigned char value, bool alphaToCoverage ) override;
 
-            void _destroyDepthBuffer(RenderTarget* pRenderWnd);
-        
             /// @copydoc RenderSystem::beginProfileEvent
             void beginProfileEvent( const String &eventName ) override;
             

--- a/RenderSystems/GLSupport/include/OgreGLRenderSystemCommon.h
+++ b/RenderSystems/GLSupport/include/OgreGLRenderSystemCommon.h
@@ -88,6 +88,8 @@ namespace Ogre {
         */
         void setConfigOption(const String &name, const String &value) override;
 
+        void destroyRenderWindow(const String& name) override;
+
         virtual ~GLRenderSystemCommon() {}
 
         /** @copydoc RenderTarget::copyContentsToMemory */

--- a/RenderSystems/GLSupport/src/OgreGLRenderSystemCommon.cpp
+++ b/RenderSystems/GLSupport/src/OgreGLRenderSystemCommon.cpp
@@ -162,6 +162,15 @@ namespace Ogre {
             refreshConfig();
     }
 
+    //-----------------------------------------------------------------------
+    void GLRenderSystemCommon::destroyRenderWindow(const String& name)
+    {
+        // Find it to remove from list.
+        RenderTarget* pWin = detachRenderTarget(name);
+        OgreAssert(pWin, "unknown RenderWindow name");
+        delete pWin;
+    }
+
     bool GLRenderSystemCommon::checkExtension(const String& ext) const
     {
         return mExtensionList.find(ext) != mExtensionList.end() || mGLSupport->checkExtension(ext);

--- a/RenderSystems/GLSupport/src/OgreGLWindow.cpp
+++ b/RenderSystems/GLSupport/src/OgreGLWindow.cpp
@@ -43,6 +43,8 @@ GLWindow::GLWindow() : mContext(0)
     mHidden = false;
     mVisible = false;
     mVSync = false;
+
+    mDepthBufferPoolId = RBP_NONE;
 }
 
 //-------------------------------------------------------------------------------------------------//


### PR DESCRIPTION
main depth buffer is part of the context