### PR TITLE
DotSceneLoader: Implement prefix to load a .scene file more than once

### DIFF
--- a/PlugIns/DotScene/include/OgreDotSceneLoader.h
+++ b/PlugIns/DotScene/include/OgreDotSceneLoader.h
@@ -78,6 +78,7 @@ protected:
     Ogre::SceneNode* mAttachNode;
     Ogre::String m_sGroupName;
     Ogre::ColourValue mBackgroundColour;
+    Ogre::String mItemPrefix;
 };
 
 class _OgreDotScenePluginExport DotScenePlugin : public Plugin


### PR DESCRIPTION
- DotSceneLoader: implement prefix to load scene more than once. The scenario is to use scene to set up vehicles or characters and still be able to access nodes by name. Entity names are also prefixed.