### PR TITLE
Build Bullet without "_Debug" postfix so find_package finds it

### DIFF
--- a/CMake/Dependencies.cmake
+++ b/CMake/Dependencies.cmake
@@ -198,13 +198,14 @@ if(OGRE_BUILD_DEPENDENCIES AND NOT EXISTS ${OGREDEPS_PATH})
         -DBUILD_ENET=OFF
         -DBUILD_UNIT_TESTS=OFF
         -DCMAKE_RELWITHDEBINFO_POSTFIX= # fixes FindBullet on MSVC
+        -DCMAKE_DEBUG_POSTFIX= # need to remove postfix so default find_package detects Bullet correctly
         -DBUILD_CLSOCKET=OFF
         -DCMAKE_POLICY_VERSION_MINIMUM=3.5
         ${PROJECT_BINARY_DIR}/bullet3-3.25
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/bullet3-3.25)
     execute_process(COMMAND ${CMAKE_COMMAND}
         --build ${PROJECT_BINARY_DIR}/bullet3-3.25 ${BUILD_COMMAND_OPTS})
-    set(BULLET_ROOT ${OGREDEPS_PATH})
+    set(Bullet_ROOT ${OGREDEPS_PATH})
 endif()
 
 #######################################################################


### PR DESCRIPTION
Also got rid of CMAKE warning about using BULLET_ROOT instead of Bullet_ROOT

Fixes #3474 