### PR TITLE
Allow SubMeshes to specify custom shader parameters

### DIFF
--- a/OgreMain/include/OgreRenderable.h
+++ b/OgreMain/include/OgreRenderable.h
@@ -68,6 +68,8 @@ namespace Ogre {
             DEFAULT_PRIORITY = 100
         };
 
+        typedef std::map<size_t, Vector4f> CustomParameterMap;
+
         Renderable()
             : mMaterialLodIndex(0), mPolygonModeOverrideable(true), mUseIdentityProjection(false),
               mUseIdentityView(false)
@@ -261,7 +263,15 @@ namespace Ogre {
         */
         const Vector4f& getCustomParameter(size_t index) const;
 
-        /** Update a custom GpuProgramParameters constant which is derived from 
+        /** Gets all the custom parameters associated with this Renderable.
+        */
+        const CustomParameterMap & getCustomParameters() const;
+
+        /** Sets multiple custom parameters associated with this Renderable.
+        */
+        void setCustomParameters(const CustomParameterMap & paramMap);
+
+        /** Update a custom GpuProgramParameters constant which is derived from
             information only this Renderable knows.
 
             This method allows a Renderable to map in a custom GPU program parameter
@@ -353,7 +363,6 @@ namespace Ogre {
         };
 
     protected:
-        typedef std::map<size_t, Vector4f> CustomParameterMap;
         CustomParameterMap mCustomParameters;
         UserObjectBindings mUserObjectBindings;      /// User objects binding.
         uint16 mMaterialLodIndex;

--- a/OgreMain/include/OgreSubMesh.h
+++ b/OgreMain/include/OgreSubMesh.h
@@ -31,6 +31,7 @@ THE SOFTWARE.
 #include "OgrePrerequisites.h"
 
 #include "OgreRenderOperation.h"
+#include "OgreRenderable.h"
 #include "OgreVertexBoneAssignment.h"
 #include "OgreAnimationTrack.h"
 #include "OgreResourceGroupManager.h"
@@ -152,6 +153,34 @@ namespace Ogre {
         void setMaterial(const MaterialPtr& mat) { mMaterial = mat; }
         const MaterialPtr& getMaterial() const { return mMaterial; }
 
+        /** Sets a custom parameter for this SubMesh, which SubEntities may use or override.
+            @see Renderable::setCustomParameter
+        */
+        void setCustomParameter(size_t index, const Vector4f& value);
+
+        /** Removes a custom value which is associated with this SubMesh at the given index.
+            @see Renderable::removeCustomParameter
+        */
+        void removeCustomParameter(size_t index);
+
+        /** Checks whether a custom value is associated with this SubMesh at the given index.
+            @see Renderable::hasCustomParameter for full details.
+        */
+        bool hasCustomParameter(size_t index) const;
+
+        /** Gets the custom value associated with this SubMesh at the given index.
+            @see Renderable::getCustomParameter for full details.
+        */
+        const Vector4f& getCustomParameter(size_t index) const;
+
+        /** Gets all the custom parameters associated with this Renderable.
+        */
+        const Renderable::CustomParameterMap & getCustomParameters() const;
+
+        /** Sets multiple custom parameters associated with this Renderable.
+        */
+        void setCustomParameters(const Renderable::CustomParameterMap & paramMap);
+
         /** Returns a RenderOperation structure required to render this mesh.
             @param 
                 rend Reference to a RenderOperation structure to populate.
@@ -239,6 +268,8 @@ namespace Ogre {
 
         /// the material this SubMesh uses.
         MaterialPtr mMaterial;
+
+        Renderable::CustomParameterMap mCustomParameters;
 
         VertexBoneAssignmentList mBoneAssignments;
 

--- a/OgreMain/src/OgreEntity.cpp
+++ b/OgreMain/src/OgreEntity.cpp
@@ -1371,6 +1371,7 @@ namespace Ogre {
             SubEntity* subEnt = OGRE_NEW SubEntity(this, subMesh);
             if (subMesh->getMaterial())
                 subEnt->setMaterial(subMesh->getMaterial());
+            subEnt->setCustomParameters(subMesh->getCustomParameters());
             sublist->push_back(subEnt);
         }
     }

--- a/OgreMain/src/OgreRenderable.cpp
+++ b/OgreMain/src/OgreRenderable.cpp
@@ -28,6 +28,19 @@ const Vector4f& Renderable::getCustomParameter(size_t index) const
     }
 }
 
+const Renderable::CustomParameterMap& Renderable::getCustomParameters() const
+{
+    return mCustomParameters;
+}
+
+void Renderable::setCustomParameters(const Renderable::CustomParameterMap& paramMap)
+{
+    for (auto & i : paramMap)
+    {
+        mCustomParameters[i.first] = i.second;
+    }
+}
+
 void Renderable::_updateCustomGpuParameter(const GpuProgramParameters::AutoConstantEntry& constantEntry,
                                            GpuProgramParameters* params) const
 {

--- a/OgreMain/src/OgreSubMesh.cpp
+++ b/OgreMain/src/OgreSubMesh.cpp
@@ -60,6 +60,41 @@ namespace Ogre {
         return mMaterial ? mMaterial->getName() : BLANKSTRING;
     }
     //-----------------------------------------------------------------------
+    void SubMesh::setCustomParameter(size_t index, const Vector4f& value) { mCustomParameters[index] = value; }
+    //-----------------------------------------------------------------------
+    void SubMesh::removeCustomParameter(size_t index) { mCustomParameters.erase(index); }
+    //-----------------------------------------------------------------------
+    bool SubMesh::hasCustomParameter(size_t index) const
+    {
+        return mCustomParameters.find(index) != mCustomParameters.end();
+    }
+    //-----------------------------------------------------------------------
+    const Vector4f& SubMesh::getCustomParameter(size_t index) const
+    {
+        Renderable::CustomParameterMap::const_iterator i = mCustomParameters.find(index);
+        if (i != mCustomParameters.end())
+        {
+            return i->second;
+        }
+        else
+        {
+            OGRE_EXCEPT(Exception::ERR_ITEM_NOT_FOUND, "Parameter at the given index was not found.");
+        }
+    }
+    //-----------------------------------------------------------------------
+    const Renderable::CustomParameterMap& SubMesh::getCustomParameters() const
+    {
+        return mCustomParameters;
+    }
+    //-----------------------------------------------------------------------
+    void SubMesh::setCustomParameters(const Renderable::CustomParameterMap& paramMap)
+    {
+        for (auto & i : paramMap)
+        {
+            mCustomParameters[i.first] = i.second;
+        }
+    }
+    //-----------------------------------------------------------------------
     void SubMesh::_getRenderOperation(RenderOperation& ro, ushort lodIndex)
     {
         if (lodIndex > 0 && static_cast< size_t >( lodIndex - 1 ) < mLodFaceList.size())


### PR DESCRIPTION
SubMeshes can specify a default Material that SubEntities may use or override. The SubMesh's default Material can have shader programs that take custom parameters as inputs. SubMeshes should be able to specify default values for those custom parameters that SubEntites may use or override.

While the parameters can be set at the Program level, the Material/Pass level, and the SubEntity level, I have a situation where a parameter is calculated during the procedural generation of a Mesh/SubMeshes and that would be the most natural place to stick the value.

I made a draft but am open to feedback. Specifically, I wasn't sure about exposing the Renderable::CustomParameterMap implementation and including its header in SubMesh.h