### PR TITLE
RTSS: fix CookTorranceLighting::copyFrom: sampler must also be copied

### DIFF
--- a/Components/RTShaderSystem/src/OgreShaderCookTorranceLighting.cpp
+++ b/Components/RTShaderSystem/src/OgreShaderCookTorranceLighting.cpp
@@ -157,6 +157,7 @@ void CookTorranceLighting::copyFrom(const SubRenderState& rhs)
 {
     const CookTorranceLighting& rhsLighting = static_cast<const CookTorranceLighting&>(rhs);
     mMetalRoughnessMapName = rhsLighting.mMetalRoughnessMapName;
+    mSampler = rhsLighting.mSampler;
     mLightCount = rhsLighting.mLightCount;
 }
 


### PR DESCRIPTION
Fixes commit 9b4f969d003b27b930650cfd1802cca7eaa99ec8.