### PR TITLE
D3D11: reapply scissor rects, when switching render target

### DIFF
--- a/RenderSystems/Direct3D11/src/OgreD3D11RenderSystem.cpp
+++ b/RenderSystems/Direct3D11/src/OgreD3D11RenderSystem.cpp
@@ -1574,6 +1574,12 @@ namespace Ogre
             mDevice.GetImmediateContext()->ClearState();
             CHECK_DEVICE_ERROR("Clear State");
             _setRenderTargetViews();
+            if(mRasterizerDesc.ScissorEnable)
+            {
+                // Reapply scissor rects
+                mDevice.GetImmediateContext()->RSSetScissorRects(1, &mScissorRect);
+                CHECK_DEVICE_ERROR("set scissor rects");
+            }
         }
     }
 


### PR DESCRIPTION
fixes terrain composite map