### PR TITLE
Samples: Deferred - workaround for deleted passes in render queue

### DIFF
--- a/OgreMain/src/OgreRenderQueueSortingGrouping.cpp
+++ b/OgreMain/src/OgreRenderQueueSortingGrouping.cpp
@@ -365,10 +365,6 @@ namespace {
             // cluster by submesh
             for(auto& it : mGrouped)
             {
-                // FIXME: pass is already deleted, but still present in map..
-                if(it.second.empty())
-                    continue;
-
                 auto instanced = it.first->hasVertexProgram() && it.first->getVertexProgram()->isInstancingIncluded();
                 if (!instanced)
                     continue;

--- a/Samples/DeferredShading/include/DeferredShadingDemo.h
+++ b/Samples/DeferredShading/include/DeferredShadingDemo.h
@@ -234,6 +234,9 @@ protected:
     // Just override the mandatory create scene method
     void setupContent(void) override
     {
+        // otherwise we get deleted passes in the render queue when toggling deferred shading
+        Root::getSingleton().setRemoveRenderQueueStructuresOnClear(true);
+
         mCameraMan->setTopSpeed(20.0);
         mSystem = 0;
 


### PR DESCRIPTION
This reverts commit dd56cf7c89237c8133291664bedcc88b8003a63f.

The problem is less general then anticipated.
We should not mask dead passes, so we can investigate later.