### PR TITLE
Add LoongArch64 support with LSX SIMD optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,102 @@
-# OGRE LoongArch64 LSX Optimizations
+[![GitHub release](https://img.shields.io/github/release/ogrecave/ogre.svg)](https://github.com/OGRECave/ogre/releases/latest)
+[![CI Build](https://github.com/OGRECave/ogre/actions/workflows/ci-build.yml/badge.svg)](https://github.com/OGRECave/ogre/actions/workflows/ci-build.yml)
+[![Downloads](https://static.pepy.tech/badge/ogre-python)](https://pepy.tech/project/ogre-python)
+[![Join the chat at https://gitter.im/OGRECave/ogre](https://badges.gitter.im/OGRECave/ogre.svg)](https://gitter.im/OGRECave/ogre?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Patreon](https://img.shields.io/badge/patreon-donate-blue.svg)](https://www.patreon.com/ogre1)
 
-This branch (`loongarch-lsx-support`) contains optimizations for LoongArch64 architecture, specifically targeting Loongson 3B6000M series processors.
+![](Other/ogre_header.svg)
 
-## Changes Made
+## OGRE - scene-oriented, flexible 3D engine
 
-### CMakeLists.txt (Lines 121-147)
+**OGRE (Object-Oriented Graphics Rendering Engine)** is a powerful, open-source 3D rendering engine that empowers you to create stunning games, simulations, and visualizations without getting bogged down in low-level graphics APIs.
 
-Added LoongArch64-specific compiler optimizations in the CMake configuration:
+Focus on creating your world, not on boilerplate code. OGRE's scene-oriented approach and clean C++ architecture provide an intuitive framework, abstracting the complexities of Direct3D and OpenGL so you can be more productive.
 
-```cmake
-elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "loongarch|LoongArch|LOONGARCH")
-  # LoongArch specific optimizations
-  include(CheckCXXCompilerFlag)
-  # Check for LoongArch SIMD extensions (LSX/ LASX)
-  check_cxx_compiler_flag(-march=loongarch64 OGRE_LOONGARCH_HAS_ARCH)
-  if (OGRE_LOONGARCH_HAS_ARCH)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=loongarch64")
-  endif ()
-  # Check for LoongArch SIMD (LSX) - supported on 3B6000 series
-  check_cxx_compiler_flag(-mlsx OGRE_LOONGARCH_HAS_LSX)
-  if (OGRE_LOONGARCH_HAS_LSX)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mlsx")
-  endif ()
-  # Note: LASX is not enabled as it's not supported on Loongson-3B6000M
-  # Loongson-3B6000M only supports LSX, not LASX
+[Get Started](#get-started-now) -
+[Tutorials](https://ogrecave.github.io/ogre/api/latest/tutorials.html) -
+[Documentation](https://ogrecave.github.io/ogre/api/latest/manual.html) -
+[Community Support](http://forums.ogre3d.org/) -
+[What's New?](Docs/14-Notes.md)
+
+
+## Features
+
+OGRE provides the tools you need to build immersive experiences, from advanced lighting and shadow effects to complex character animations and rich particle systems.
+
+| Physically Based Shading | Dynamic Shadows |
+|----|----|
+| ![](Other/screenshots/pbr.webp) | ![](Other/screenshots/shadows.jpg) |
+| Achieve stunning surfaces with PBR workflows | Stencil and texture-based shadows for any environment |
+
+| Character Animation| Particle Effects |
+|----|----|
+| ![](Other/screenshots/skeletal.jpg) | ![](Other/screenshots/particle.jpg) |
+| Hardware & software skeletal animation support | Flexible particle systems for fire, smoke, sparks & more. |
+
+| Advanced Compositor Pipeline | Terrain Rendering |
+|----|----|
+| ![](Other/screenshots/compositor.jpg) | ![](Other/screenshots/terrain.jpg) |
+| Streamline post-processing like bloom and HDR | Multi-layered, textured landscapes with LOD |
+
+| UI Toolkit | Physics Engine Integration |
+|----|----|
+| ![](Other/screenshots/imgui.jpg) | ![](Other/screenshots/bullet.webp) |
+| Seamless integration with [Dear ImGui](https://github.com/ocornut/imgui) for in-game UI | Use [Bullet Physics](https://pybullet.org/) for rigid body dynamics |
+
+| Realistic Surface Details | Volumetric Rendering |
+|----|----|
+| ![](Other/screenshots/bumpmap.webp) | ![](Other/screenshots/volume.jpg) |
+| Bump and offset mapping for enhanced textures | With CSG and triplanar texturing |
+
+For a complete list of capabilities, see our [features page](http://www.ogre3d.org/about/features).
+
+## Get started now
+
+Ready to try OGRE? You can be up and running in minutes.
+
+* **Try it Online:** [Launch the Emscripten Demo](https://ogrecave.github.io/ogre/emscripten/) right in your browser.
+* **Download for Windows:** [Get the latest SDK](https://dl.cloudsmith.io/public/ogrecave/ogre/raw/versions/master/ogre-sdk-master-msvc142-x64.zip) with pre-compiled demos.
+* **Install on Linux:** Use our [Snap Package](https://snapcraft.io/ogre) for easy installation.
+* **Get it on Android:** Find our sample browser on [F-Droid](https://f-droid.org/packages/org.ogre.browser/).
+
+
+For detailed instructions on compiling from source, see our [**Building OGRE guide**](https://ogrecave.github.io/ogre/api/latest/building-ogre.html).
+
+## Who is using it?
+
+Trusted by both open-source communities and commercial studios:
+
+**Open Source & Research**
+- [Stunt Rally 2.x - 3D Racing Game with Track Editor](https://github.com/stuntrally/stuntrally/)
+- [Rigs of Rods - Soft Body Physics Simulator](https://rigsofrods.org/)
+- [Gazebo - Robot simulation](http://gazebosim.org/)
+- [OpenCV OVIS visualization module](https://docs.opencv.org/master/d2/d17/group__ovis.html)
+- [ROS 3D visualization tool](http://wiki.ros.org/rviz)
+- [Surgical Image Toolkit](https://github.com/IRCAD/sight#applications)
+
+**Commercial Games**
+- [Hob](http://store.steampowered.com/app/404680/Hob/)
+- [Torchlight II](http://store.steampowered.com/app/200710/Torchlight_II/)
+- [Battlezone 98 Redux](http://store.steampowered.com/app/301650/Battlezone_98_Redux/)
+
+## Join Our Community
+We believe in the power of collaboration. Whether you're a seasoned developer or just starting, you are welcome in the OGRE community.
+
+* **Ask a question** in our [Forums](http://forums.ogre3d.org/) or on [Gitter](https://gitter.im/OGRECave/ogre).
+* **Contribute to the engine** by creating a [pull request](https://github.com/OGRECave/ogre/pulls). We welcome everything from bug fixes and documentation to new features.
+* **Support the project** via [Patreon](https://www.patreon.com/ogre1) to help fund continued development.
+
+## Licensing
+OGRE is licensed under the **MIT License**. Please see the [full license documentation](Docs/License.md) for details.
+
+## Citing OGRE in Research
+If you use OGRE in your academic work, please cite it:
+
+```bibtex
+  @misc{rojtberg2024ogre,
+    author = "{Rojtberg, Pavel and Rogers, David and Streeting, Steve and others}",
+    title = "OGRE scene-oriented, flexible 3D engine",
+    year = "2001 -- 2024",
+    howpublished = "\url{https://www.ogre3d.org/}",
+  }
 ```
-
-## What These Optimizations Do
-
-1. **Architecture Detection**: Automatically detects LoongArch64 processors
-2. **Base Architecture**: Enables `-march=loongarch64` for optimal instruction set usage
-3. **LSX SIMD**: Enables `-mlsx` to utilize Loongson SIMD extensions for improved vector operations
-4. **Compatibility**: Specifically designed for Loongarch series (supports LSX but not LASX)
-
-## Benefits
-
-- Improved performance for vector mathematics operations
-- Better matrix transformation performance
-- Enhanced texture processing capabilities
-- Optimized geometry calculations
-


### PR DESCRIPTION
This PR adds native support for the LoongArch64 architecture (Loongson processors) with automatic detection and LSX SIMD optimizations.
﻿
Key changes:
1.In CMakeLists.txt: Detect LoongArch64 via CMAKE_SYSTEM_PROCESSOR and enable `-march=loongarch64` and `-mlsx` where supported.
2.LASX is intentionally not enabled for broader compatibility (e.g., Loongson chips series use LA364E  only supports LSX).
﻿
Tested on Loongnix GNU/Linux with Loongson-3B6000M:
1.Successfully built with Release mode and samples enabled.
2.SampleBrowser runs  at ~60 FPS in  scenes.
﻿
Detailed build instructions, documentation, and screenshot available in my fork:
https://github.com/ycsqwan/ogre-loongarch64-lsx/tree/loongarch64-lsx
﻿
Thanks to @paroj for the guidance on clean commits and upstream contribution!

This is merely a rough attempt using rather crude techniques on my part – I apologize for any shortcomings in the implementation. I'm very open to feedback and happy to iterate to improve it.