### PR TITLE
ADD: Ogre.Bites support for joysick buttons and joystick hat.

### DIFF
--- a/Components/Bites/include/OgreInput.h
+++ b/Components/Bites/include/OgreInput.h
@@ -45,7 +45,8 @@ enum EventType {
     CONTROLLERAXISMOTION,
     CONTROLLERBUTTONDOWN,
     CONTROLLERBUTTONUP,
-    JOYAXISMOTION
+    JOYAXISMOTION,
+    JOYHATMOTION
 };
 
 typedef int Keycode;
@@ -97,6 +98,12 @@ struct ButtonEvent {
     int which;
     unsigned char button;
 };
+struct HatEvent {
+    int type;
+    int which;
+    short hat;      // joystick hat index
+    short value; 	// hat position
+};
 
 union Event
 {
@@ -109,6 +116,7 @@ union Event
     TextInputEvent text;
     AxisEvent axis;
     ButtonEvent cbutton;
+    HatEvent hat;
 };
 
 // SDL compat
@@ -185,6 +193,7 @@ struct _OgreBitesExport InputListener {
     virtual bool mouseReleased(const MouseButtonEvent& evt) { return false; }
     virtual bool textInput(const TextInputEvent& evt) { return false; }
     virtual bool axisMoved(const AxisEvent& evt) { return false; }
+    virtual bool hatMoved(const HatEvent& evt) { return false; }
     virtual bool buttonPressed(const ButtonEvent& evt) { return false; }
     virtual bool buttonReleased(const ButtonEvent& evt) { return false; }
 };

--- a/Components/Bites/src/OgreApplicationContextBase.cpp
+++ b/Components/Bites/src/OgreApplicationContextBase.cpp
@@ -482,6 +482,9 @@ void ApplicationContextBase::_fireInputEvent(const Event& event, uint32_t window
         case CONTROLLERAXISMOTION:
             l.axisMoved(event.axis);
             break;
+        case JOYHATMOTION:
+            l.hatMoved(event.hat);
+            break;
         case CONTROLLERBUTTONDOWN:
             l.buttonPressed(event.cbutton);
             break;

--- a/Components/Bites/src/SDLInputMapping.h
+++ b/Components/Bites/src/SDLInputMapping.h
@@ -74,6 +74,21 @@ namespace {
             out.axis.axis = in.jaxis.axis;
             out.axis.value = in.jaxis.value;
             break;
+        case SDL_JOYBUTTONDOWN:
+            out.type = OgreBites::CONTROLLERBUTTONDOWN;
+            OGRE_FALLTHROUGH;
+        case SDL_JOYBUTTONUP:
+            if(!out.type)
+                out.type = OgreBites::CONTROLLERBUTTONUP;
+            out.cbutton.which = in.jbutton.which;
+            out.cbutton.button = in.jbutton.button;
+            break;
+        case SDL_JOYHATMOTION:
+            out.type = OgreBites::JOYHATMOTION;
+            out.hat.which = in.jhat.which;
+            out.hat.hat = in.jhat.hat;
+            out.hat.value = in.jhat.value;
+            break;
         case SDL_CONTROLLERAXISMOTION:
             out.type = OgreBites::CONTROLLERAXISMOTION;
             out.axis.which = in.caxis.which;


### PR DESCRIPTION
`Ogre.Bite` support for missing joystick buttons (`SDL_JOYBUTTONUP/DOWN` events) with a forward to the controller button event.

Also add support for joystick hat control (`SDL_JOYHATMOTION` event) with a new `HatEvent`

I successfully tested them in my game  with a linux build. 

Would be nice if they can come upstream. 

Please tell me if I can help if there is something unclear or if you need some changes or more content.

Thanks in advance.