### PR TITLE
Prevent page unload crash

### DIFF
--- a/Components/Paging/include/OgrePage.h
+++ b/Components/Paging/include/OgrePage.h
@@ -59,6 +59,8 @@ namespace Ogre
         bool mModified;
 
         SceneNode* mDebugNode;
+        bool mInUnload;
+
         void updateDebugDisplay();
 
         struct PageData : public PageAlloc

--- a/Components/Paging/src/OgrePage.cpp
+++ b/Components/Paging/src/OgrePage.cpp
@@ -53,6 +53,7 @@ namespace Ogre
         , mDeferredProcessInProgress(false)
         , mModified(false)
         , mDebugNode(0)
+        , mInUnload(false)
     {
         touch();
     }
@@ -171,6 +172,7 @@ namespace Ogre
         {
             destroyAllContentCollections();
             mDeferredProcessInProgress = true;
+            mInUnload = false;
 
             if(synchronous)
             {
@@ -195,6 +197,7 @@ namespace Ogre
     //---------------------------------------------------------------------
     void Page::unload()
     {
+        mInUnload = true;
         destroyAllContentCollections();
     }
     //---------------------------------------------------------------------
@@ -225,7 +228,7 @@ namespace Ogre
         PageResponse pres = any_cast<PageResponse>(res->getData());
 
         // final loading behaviour
-        if (res->succeeded())
+        if (res->succeeded() && !mInUnload)
         {
             if(!pres.pageData->collectionsToAdd.empty())
                 std::swap(mContentCollections, pres.pageData->collectionsToAdd);


### PR DESCRIPTION
If page load is in progress, page load can
crash as the load finaliser is executed after unload.

To test the reproduction I create ImGui Button which runs WorldPartition's unloadPage with PageID calculated using current camera position. Before this change it resulted in the following backtrace in unlucky case:

	Thread 1 "Editor" received signal SIGSEGV, Segmentation fault.
	0x00007ffff7f00f91 in Ogre::Page::handleResponse (this=0x5555586a96d0, res=0x7fffe8006900, srcQ=0x0) at /media/slapin/library/ogre3/ogre/Components/Paging/src/OgrePage.cpp:233
	233	            loadImpl();
	(gdb) bt

	#0  0x00007ffff7f00f91 in Ogre::Page::handleResponse (this=0x5555586a96d0, res=0x7fffe8006900, srcQ=0x0) at /media/slapin/library/ogre3/ogre/Components/Paging/src/OgrePage.cpp:233
	#1  0x00007ffff7f00aa0 in operator() (__closure=0x7fffffffd830) at /media/slapin/library/ogre3/ogre/Components/Paging/src/OgrePage.cpp:186
	#2  0x00007ffff7f02476 in std::__invoke_impl<void, Ogre::Page::load(bool)::<lambda()>::<lambda()>&>(std::__invoke_other, struct {...} &) (__f=...) at /usr/include/c++/11/bits/invoke.h:61
	#3  0x00007ffff7f02208 in std::__invoke_r<void, Ogre::Page::load(bool)::<lambda()>::<lambda()>&>(struct {...} &) (__fn=...) at /usr/include/c++/11/bits/invoke.h:154
	#4  0x00007ffff7f01ff6 in std::_Function_handler<void(), Ogre::Page::load(bool)::<lambda()>::<lambda()> >::_M_invoke(const std::_Any_data &) (__functor=...) at /usr/include/c++/11/bits/std_function.h:290
	#5  0x00007ffff7173b42 in std::function<void ()>::operator()() const (this=0x7fffffffd830) at /usr/include/c++/11/bits/std_function.h:590
	#6  0x00007ffff7173565 in Ogre::DefaultWorkQueueBase::processMainThreadTasks (this=0x5555562b0ff0) at /media/slapin/library/ogre3/ogre/OgreMain/src/OgreWorkQueue.cpp:176
	#7  0x00007ffff701aaf3 in Ogre::Root::_fireFrameEnded (this=0x5555562acfe0, evt=...) at /media/slapin/library/ogre3/ogre/OgreMain/src/OgreRoot.cpp:685
	#8  0x00007ffff701ac11 in Ogre::Root::_fireFrameEnded (this=0x5555562acfe0) at /media/slapin/library/ogre3/ogre/OgreMain/src/OgreRoot.cpp:712
	#9  0x00007ffff701b162 in Ogre::Root::renderOneFrame (this=0x5555562acfe0) at /media/slapin/library/ogre3/ogre/OgreMain/src/OgreRoot.cpp:792
	#10 0x00007ffff701b089 in Ogre::Root::startRendering (this=0x5555562acfe0) at /media/slapin/library/ogre3/ogre/OgreMain/src/OgreRoot.cpp:779
	#11 0x00005555555c341e in main () at /media/slapin/library/ogre3/ogre-projects/world2/src/editor/main.cpp:835

Closes: #3530