### PR TITLE
Update Dependencies.cmake to use modern FindPython3

### DIFF
--- a/CMake/Dependencies.cmake
+++ b/CMake/Dependencies.cmake
@@ -289,8 +289,7 @@ macro_log_feature(OPENEXR_FOUND "OpenEXR" "Load High dynamic range images" "http
 
 # Python
 set(Python_ADDITIONAL_VERSIONS 3.4) # allows using python3 on Ubuntu 14.04
-find_package(PythonInterp)
-find_package(PythonLibs)
+find_package(Python3)
 macro_log_feature(PYTHONLIBS_FOUND "Python" "Language bindings to use OGRE from Python" "http://www.python.org/")
 
 # SWIG


### PR DESCRIPTION
As of cmake CMake 3.12 FindPythonInterp and FindPythinLibs are deprecated and as of 3.27 the modules are not included.

https://cmake.org/cmake/help/latest/policy/CMP0148.html

The replacement for these id FindPython3, FindPython2 and FindPython.