### PR TITLE
Main: Profiler - fixed repeated `setEnabled(true)` causing shutdown.

### DIFF
--- a/OgreMain/src/OgreProfiler.cpp
+++ b/OgreMain/src/OgreProfiler.cpp
@@ -158,13 +158,12 @@ namespace Ogre {
 
             mInitialized = true;
         }
-        else if (mInitialized)
+        else if (mInitialized && !enabled)
         {
             for(auto & l : mListeners)
                 l->finializeSession();
 
             mInitialized = false;
-            mEnabled = false;
         }
         // We store this enable/disable request until the frame ends
         // (don't want to screw up any open profiles!)


### PR DESCRIPTION
I ran into this while integrating the profiler into Rigs of Rods: https://github.com/RigsOfRods/rigs-of-rods/pull/3418#issuecomment-4318481665.