### PR TITLE
Metal: export the RenderSystem include directories on the target

### DIFF
--- a/RenderSystems/Metal/CMakeLists.txt
+++ b/RenderSystems/Metal/CMakeLists.txt
@@ -26,6 +26,10 @@ include_directories(
 
 add_definitions(${OGRE_VISIBILITY_FLAGS})
 add_library(RenderSystem_Metal ${OGRE_LIB_TYPE} ${HEADER_FILES} ${SOURCE_FILES})
+target_include_directories(RenderSystem_Metal PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/Windowing/${OS}>"
+    $<INSTALL_INTERFACE:include/OGRE/RenderSystems/Metal>)
 if (APPLE_IOS)
 target_link_libraries(RenderSystem_Metal OgreMain "-framework Metal" "-framework QuartzCore")
 else()


### PR DESCRIPTION
### What

Adds the `target_include_directories(... PUBLIC $<BUILD_INTERFACE:...>
$<INSTALL_INTERFACE:...>)` declaration to `RenderSystem_Metal`, exactly
mirroring what `RenderSystem_GL3Plus`, `RenderSystem_Vulkan` and the other
render systems already do. Both `include/` and `include/Windowing/${OS}` are
exported, matching what the render system compiles against.

### Why

Without it, the installed `OgreTargets.cmake` carries no
`INTERFACE_INCLUDE_DIRECTORIES` for `RenderSystem_Metal`, so a static-build
consumer that links the exported target cannot
`#include <OgreMetalPlugin.h>` to register the plugin via
`Root::installPlugin()` - the header is installed but not on the include
path. Every other render system exports its include directory; Metal is the
odd one out.

### How tested

macOS 15 / Apple Silicon, OGRE 14.5.2 built static through vcpkg with this
patch applied: an external CMake project linking `RenderSystem_Metal` from
the installed `OGREConfig.cmake` compiles `#include <OgreMetalPlugin.h>` and
registers the plugin; without the patch the include fails. (In production use
in the Orkige engine's vcpkg overlay port since the Metal port milestone.)

Applies cleanly to both v14.5.2 and current master (the file is unchanged
between the two).
