### PR TITLE
Vulkan: call base RenderSystem::shutdown()

### DIFF
--- a/RenderSystems/Vulkan/src/OgreVulkanRenderSystem.cpp
+++ b/RenderSystems/Vulkan/src/OgreVulkanRenderSystem.cpp
@@ -271,29 +271,12 @@ namespace Ogre
             return;
 
         mDevice->stall();
-#if 0
-        {
-            // Remove all windows.
-            // (destroy primary window last since others may depend on it)
-            RenderWindow *primary = 0;
-            WindowSet::const_iterator itor = mWindows.begin();
-            WindowSet::const_iterator endt = mWindows.end();
 
-            while( itor != endt )
-            {
-                if( !primary && ( *itor )->isPrimary() )
-                    primary = *itor;
-                else
-                    OGRE_DELETE *itor;
-
-                ++itor;
-            }
-
-            OGRE_DELETE primary;
-            mWindows.clear();
-        }
-#endif
-        _cleanupDepthBuffers();
+        // destroys the depth buffers and render targets (incl. windows) like
+        // the other render systems do - their Vulkan resources (e.g. the
+        // VMA-backed window depth texture) must be released while the device
+        // and its allocator are still alive
+        RenderSystem::shutdown();
 
         mAutoParamsBuffer.reset();
 


### PR DESCRIPTION
### What

`VulkanRenderSystem::shutdown()` is the only render system shutdown that
never calls the base `RenderSystem::shutdown()` (the window-destruction block
it would need instead is `#if 0`'d out). This PR adds the base call right
after the device stall - matching GL3Plus, D3D11 and Metal - and drops the
now-redundant local `_cleanupDepthBuffers()` call plus the dead `#if 0`
block.

### Why

Because the windows are never destroyed during shutdown, `VulkanWindow`
outlives the `VulkanDevice`:

- the window's VMA-backed depth texture is still allocated when
  `~VulkanDevice` runs `vmaDestroyAllocator()`, which trips the VMA debug
  assertion `"Some allocations were not freed before destruction of this
  memory block!"` and aborts every debug build on exit;
- the window is then torn down by the base `~RenderSystem` long after its
  device was deleted (`destroySwapchain()` dereferences the dangling
  `mDevice`).

With the base call, windows release their Vulkan resources while the device
and allocator are still alive.

### How tested

macOS 15 / Apple Silicon, MoltenVK 1.4.1, OGRE 14.5.2 debug build (VMA
asserts active): before the patch every run aborts on exit with the VMA
assertion; after it, clean exit and unchanged rendering. Soaked through
three app suites (demo, scene player, editor self-check) under ctest.
Found while porting an engine to the Vulkan RS, but the bug is
platform-independent - any debug build with an attached window hits the
assert on shutdown.
