### PR TITLE
ZipArchive: fix zip_entry_open call in the non-strict lookup fallback

### DIFF
--- a/OgreMain/src/OgreZip.cpp
+++ b/OgreMain/src/OgreZip.cpp
@@ -173,7 +173,7 @@ namespace {
             {
                 Ogre::FileInfo info = fileNfo->at(0);
                 lookUpFileName = info.path + info.basename;
-                open = zip_entry_open(mZipFile, lookUpFileName.c_str(), OGRE_RESOURCEMANAGER_STRICT) == 0;
+                open = zip_entry_open(mZipFile, lookUpFileName.c_str()) == 0;
             }
         }
 #endif


### PR DESCRIPTION
The `OGRE_RESOURCEMANAGER_STRICT=0` fallback lookup in `ZipArchive::open` (introduced with the non-recursive matching fix in 835def15b) calls `zip_entry_open` with three arguments, but the bundled zip library declares the two-argument form — the case-sensitive variant is the separate `zip_entry_opencasesensitive`.

Because strict builds preprocess this branch out entirely, CI never compiles it; only non-strict configurations reach it, and they fail with a compile error.

Inside this `#else` branch `OGRE_RESOURCEMANAGER_STRICT` is 0 by definition, so the two-argument (case-insensitive) call preserves the intended behavior exactly — a one-line, behavior-identical fix.

Found building OGRE master in a non-strict configuration (vcpkg defaults).