### PR TITLE
Main: tolerate the null renderable manualRender documents

### DIFF
--- a/OgreMain/src/OgreAutoParamDataSource.cpp
+++ b/OgreMain/src/OgreAutoParamDataSource.cpp
@@ -107,10 +107,9 @@ namespace Ogre {
     //-----------------------------------------------------------------------------
     void AutoParamDataSource::setCurrentRenderable(const Renderable* rend)
     {
-        OgreAssertDbg(rend, "Cannot set a null renderable");
         mGpuParamsDirty |= GPV_PER_OBJECT;
 
-        bool useIdentityView = rend->getUseIdentityView();
+        bool useIdentityView = rend && rend->getUseIdentityView();
         if (mCurrentUseIdentityView != useIdentityView)
         {
             mCurrentUseIdentityView = useIdentityView;
@@ -120,7 +119,7 @@ namespace Ogre {
             mGpuParamsDirty |= GPV_GLOBAL;
         }
 
-        bool useIdentityProj = rend->getUseIdentityProjection();
+        bool useIdentityProj = rend && rend->getUseIdentityProjection();
         if (mCurrentUseIdentityProj != useIdentityProj)
         {
             mCurrentUseIdentityProj = useIdentityProj;


### PR DESCRIPTION
### What

`SceneManager::manualRender(RenderOperation*, ...)` resets the auto-param state with `setCurrentRenderable(0)` — the documented "no renderable, matrices supplied explicitly" contract that `AutoParamDataSource::getViewMatrix()`/`getProjectionMatrix()` honor with their `mCurrentRenderable` null checks. The recent GpuParamsDirty refactor moved the identity-view/projection handling into `setCurrentRenderable` and dereferences the renderable unconditionally, so every `manualRender(RenderOperation*)` call now trips the new debug assertion (and would null-deref in a release build).

This PR treats a null renderable as "no identity view/projection" — exactly what the null-tolerant accessors already computed before the refactor — and drops the assertion, since null is a documented input on this path.

### How tested

macOS 15 / Apple Silicon, OGRE master (7d25ffc3d) built static through vcpkg, debug (assertions active): an engine that draws its 2D/UI layer through `manualRender(RenderOperation*)` asserts on the first draw without the patch and renders identically to 14.5.2 with it. Soaked through three app suites (demo, scene player, editor self-check) under ctest on GL3Plus and Vulkan.