### PR TITLE
Android: keep the internal cpufeatures target off the installed export

### DIFF
--- a/OgreMain/CMakeLists.txt
+++ b/OgreMain/CMakeLists.txt
@@ -226,7 +226,7 @@ endif ()
 target_link_libraries(OgreMain PUBLIC ${PLATFORM_LIBS} PRIVATE ${LIBRARIES} ${CMAKE_DL_LIBS})
 
 if(ANDROID)
-  target_link_libraries(OgreMain PRIVATE cpufeatures log z)
+  target_link_libraries(OgreMain PRIVATE $<BUILD_INTERFACE:cpufeatures> log z)
 endif()
 
 # specify a precompiled header to use


### PR DESCRIPTION
### What

On Android, `OgreMain` links the NDK's source-only `cpufeatures` module as a plain internal CMake target (`target_link_libraries(OgreMain PRIVATE cpufeatures log z)`). For a **static** build that PRIVATE dependency is recorded on the installed export's link interface as `$<LINK_ONLY:cpufeatures>` — and since the `cpufeatures` target is never exported/installed, every consumer of the installed `OgreTargets.cmake` ends up with a bare `-lcpufeatures` on its link line. The NDK ships cpufeatures as a *source* module (`sources/android/cpufeatures/cpu-features.c`), not a library, so the link fails:

```
ld.lld: error: unable to find library -lcpufeatures
```

This PR wraps the dependency in `$<BUILD_INTERFACE:...>`: OGRE's own tree (samples etc.) links exactly as before, while the installed export returns to the long-standing contract — the consumer compiles `cpu-features.c` itself, the same way OGRE's own Android application macros do (`add_ndk_cpufeatures_library`). `log` and `z` stay as-is; they are real system libraries the NDK linker resolves.

### How tested

OGRE master (7d25ffc3d) built static for Android (NDK 27, API 28) through vcpkg with this patch: an external engine linking the installed `OgreTargets` produces its player `libmain.so` cleanly and runs on an emulator; without the patch the link fails with the error above. 14.5.2 consumers (where this line did not exist) are unaffected either way.