### PR TITLE
Assimp: fix keyframe predecessor search and interpolation factor units

### DIFF
--- a/PlugIns/Assimp/src/AssimpLoader.cpp
+++ b/PlugIns/Assimp/src/AssimpLoader.cpp
@@ -154,9 +154,12 @@ template <int _i>
 void GetInterpolationIterators(KeyframesMap& keyframes, KeyframesMap::iterator it,
                                KeyframesMap::reverse_iterator& front, KeyframesMap::iterator& back)
 {
+    // reverse_iterator(it) already refers to the element BEFORE it, so the
+    // search starts there: advancing first would skip the immediate
+    // predecessor, and a channel with a single leading key (a constant
+    // glTF track) would then find no key at all - the caller falls back
+    // to zero, which reads as the inverse bind pose leaking into the track
     front = KeyframesMap::reverse_iterator(it);
-
-    front++;
     for (; front != keyframes.rend(); front++)
     {
         if (std::get<_i>(front->second) != NULL)
@@ -206,8 +209,11 @@ aiVector3D getTranslate(aiNodeAnim* node_anim, KeyframesMap& keyframes, Keyframe
         // got 2 keys can interpolate
         if (frontKey && backKey)
         {
-            float prop = (float)(Math::inverseLerp<double>(frontKey->mTime, backKey->mTime, it->first));
-            prop /= ticksPerSecond;
+            // key times are in TICKS while the merged map's times are in
+            // SECONDS: convert the lookup time to ticks for the lerp factor
+            // (the old form also divided the finished factor by ticksPerSecond
+            // again, shrinking it to ~0 - interpolated keys held the front key)
+            float prop = (float)(Math::inverseLerp<double>(frontKey->mTime, backKey->mTime, it->first * ticksPerSecond));
             vect = Math::lerp(frontKey->mValue, backKey->mValue, prop);
         }
 
@@ -254,8 +260,11 @@ aiQuaternion getRotate(aiNodeAnim* node_anim, KeyframesMap& keyframes, Keyframes
         // got 2 keys can interpolate
         if (frontKey && backKey)
         {
-            float prop = (float)(Math::inverseLerp<double>(frontKey->mTime, backKey->mTime, it->first));
-            prop /= ticksPerSecond;
+            // key times are in TICKS while the merged map's times are in
+            // SECONDS: convert the lookup time to ticks for the lerp factor
+            // (the old form also divided the finished factor by ticksPerSecond
+            // again, shrinking it to ~0 - interpolated keys held the front key)
+            float prop = (float)(Math::inverseLerp<double>(frontKey->mTime, backKey->mTime, it->first * ticksPerSecond));
             aiQuaternion::Interpolate(rot, frontKey->mValue, backKey->mValue, prop);
         }
 
@@ -302,8 +311,11 @@ aiVector3D getScale(aiNodeAnim* node_anim, KeyframesMap& keyframes, KeyframesMap
         // got 2 keys can interpolate
         if (frontKey && backKey)
         {
-            float prop = (float)(Math::inverseLerp<double>(frontKey->mTime, backKey->mTime, it->first));
-            prop /= ticksPerSecond;
+            // key times are in TICKS while the merged map's times are in
+            // SECONDS: convert the lookup time to ticks for the lerp factor
+            // (the old form also divided the finished factor by ticksPerSecond
+            // again, shrinking it to ~0 - interpolated keys held the front key)
+            float prop = (float)(Math::inverseLerp<double>(frontKey->mTime, backKey->mTime, it->first * ticksPerSecond));
             vect = Math::lerp(frontKey->mValue, backKey->mValue, prop);
         }
 


### PR DESCRIPTION
### What

Two related fixes in the Assimp plugin's keyframe resampling (`PlugIns/Assimp/src/AssimpLoader.cpp`):

1. **`GetInterpolationIterators` skips the immediate predecessor key.** `KeyframesMap::reverse_iterator(it)` already refers to the element *before* `it`, so the extra `front++` starts the backward search one element too early. For a channel with a single leading key (a constant track — common in glTF exports) the search then finds no front key at all, the caller falls back to a zero transform, and the missing translation/rotation reads as the inverse bind pose leaking into the track: skinned meshes whose constant-track bones collapse toward the origin (a "fused blob" instead of an articulated character).

2. **The interpolation factor mixes seconds with ticks.** The merged keyframe map is keyed in *seconds* (`mTime / ticksPerSecond`, built above), while the raw keys' `mTime` are in *ticks*. `inverseLerp(frontTicks, backTicks, seconds)` therefore produces a near-zero factor, which the next line then divides by `ticksPerSecond` a second time. The net effect is that every interpolated key holds the front neighbour's value — animation between authored keys snaps instead of interpolating. The fix converts the lookup time to ticks for the lerp (`it->first * ticksPerSecond`) and drops the extra divide, in all three of the translate/rotate/scale helpers.

### How tested

Built through vcpkg against master `7d25ffc3d` (this diff also applies cleanly to current master). Consumer is a game engine loading a generated 8-bone glTF mannequin with a walk clip that mixes single-key (constant) channels with sparse interpolated keys:

- before: the mesh collapsed into a fused blob at the bind origin (fix 1) and the animated bones snapped between keys (fix 2);
- after: the clip plays articulated and smooth, and passes a bone-world-transform pose probe (leg separation and arm-above-leg assertions at mid-clip) that matches the engine's second, independent glTF import path.
