### PR TITLE
Assimp: fix stray scale keyframe times and keyless-track fallback

### DIFF
--- a/PlugIns/Assimp/src/AssimpLoader.cpp
+++ b/PlugIns/Assimp/src/AssimpLoader.cpp
@@ -665,7 +665,11 @@ void AssimpLoader::parseAnimation(const aiScene* mScene, int index, aiAnimation*
                 }
                 else
                 {
-                    keyframes[(Real)node_anim->mRotationKeys[j].mTime / mTicksPerSecond] =
+                    // A scale key with no coincident pos/rot keyframe must key
+                    // the merged map by its OWN scaling time; keying it by the
+                    // rotation time inserts garbage times and reads out of
+                    // bounds when the channel has fewer rotation than scale keys.
+                    keyframes[(Real)node_anim->mScalingKeys[j].mTime / mTicksPerSecond] =
                         KeyframeData(NULL, NULL, &(node_anim->mScalingKeys[j]));
                 }
             }
@@ -685,6 +689,20 @@ void AssimpLoader::parseAnimation(const aiScene* mScene, int index, aiAnimation*
 
                     aiVector3D aiScale = getScale(node_anim, keyframes, it, mTicksPerSecond);
                     Vector3 scale(aiScale.x, aiScale.y, aiScale.z);
+
+                    // Each keyframe is composed into a full local transform and
+                    // premultiplied by the inverse bind pose, so a component
+                    // whose channel carries NO keys at all must fall back to the
+                    // bone's BIND-pose value, not the getX helpers' neutral
+                    // (0,0,0)/identity/(1,1,1): a neutral placeholder bakes the
+                    // inverse bind in as drift (missing tracks would collapse the
+                    // bone to the origin and sink its descendants).
+                    if (node_anim->mNumPositionKeys == 0)
+                        trans = bone->getPosition();
+                    if (node_anim->mNumRotationKeys == 0)
+                        rot = bone->getOrientation();
+                    if (node_anim->mNumScalingKeys == 0)
+                        scale = bone->getScale();
 
                     Vector3 transCopy = trans;
 


### PR DESCRIPTION
### What

Two more fixes in the Assimp plugin's skeletal keyframe merge (`PlugIns/Assimp/src/AssimpLoader.cpp`), both exposed once an animation channel carries an independent SCALE track:

1. **Stray scale keys are inserted at the rotation key's time.** In the scale-merge loop, a scale key with no coincident position/rotation keyframe is inserted into the merged map keyed by `mRotationKeys[j].mTime` instead of `mScalingKeys[j].mTime` — a copy-paste from the rotation loop above. The scale key lands at a garbage time (collapsing distinct scale keys onto one bogus keyframe), and the read goes out of bounds whenever the channel has fewer rotation keys than scaling keys.

2. **Keyless tracks fall back to a neutral placeholder instead of the bind pose.** When a channel carries NO keys of one kind at all, `getTranslate`/`getRotate`/`getScale` return (0,0,0) / identity / (1,1,1). Each keyframe is composed into a full local transform and premultiplied by the bone's inverse bind pose (`defBonePoseInv`), so a neutral placeholder bakes the inverse bind in as drift: the bone's rest translation collapses to the origin and its descendants sink with it. The fix adds three call-site guards that fall a keyless component back to the bone's bind value (`bone->getPosition()` / `getOrientation()` / `getScale()`), leaving the helper signatures untouched. (Assimp's glTF2 importer usually synthesizes a single bind-value key for omitted tracks, but other importers/pipelines deliver genuinely keyless tracks, and the guard is the correct fallback either way.)

Follow-up to #3680 (same resampling code), but independent — applies to master with or without it.

### How tested

Built through vcpkg against master `7d25ffc3d` (applies cleanly to current master). Consumer is a game engine with a second, independent glTF import path used as ground truth, on a generated 12-bone test rig with scale-only, mixed, and misaligned-track clips:

- before: a bone with a varying scale track never scales (frozen at bind) and sinks toward its parent's origin together with its subtree; worst-case bone world-transform divergence vs the reference importer: 0.76 position / 20° rotation / 0.30 scale;
- after: all scale-track clips converge to exact agreement with the reference importer (0 / 0 / 0 within 1e-3), and a walk clip mixing rotation channels with a scale-pulse channel passes bone-world-transform assertions on both import paths.
