### PR TITLE
Main: const Node::convert functions and helper functions to get Pose indices from Mesh

### DIFF
--- a/OgreMain/include/OgreMesh.h
+++ b/OgreMain/include/OgreMesh.h
@@ -920,6 +920,10 @@ namespace Ogre {
         Pose* getPose(size_t index) const { return mPoseList.at(index); }
         /** Retrieve an existing Pose by name.*/
         Pose* getPose(const String& name) const;
+        /** Retrieve an existing Pose's index by name.*/
+        size_t getPoseIndex(const String& name) const;
+        /** Retrieve an existing Pose's index.*/
+        size_t getPoseIndex(const Pose* pose) const;
         /** Destroy a pose by index.
         @note
             This will invalidate any animation tracks referring to this pose or those after it.

--- a/OgreMain/include/OgreNode.h
+++ b/OgreMain/include/OgreNode.h
@@ -590,11 +590,11 @@ namespace Ogre {
         const Vector3& getInitialPosition(void) const { return mInitialPosition; }
 
         /** Gets the local position, relative to this node, of the given world-space position */
-        Vector3 convertWorldToLocalPosition( const Vector3 &worldPos );
+        Vector3 convertWorldToLocalPosition( const Vector3 &worldPos ) const;
 
         /** Gets the world position of a point in the node local space
             useful for simple transforms that don't require a child node.*/
-        Vector3 convertLocalToWorldPosition( const Vector3 &localPos );
+        Vector3 convertLocalToWorldPosition( const Vector3 &localPos ) const;
 
         /** Gets the local direction, relative to this node, of the
             given world-space direction
@@ -603,7 +603,7 @@ namespace Ogre {
         @param useScale determines if this node or it's parents' scale affects
             the magnitude of the returned worldDir vector.
         */
-        Vector3 convertWorldToLocalDirection( const Vector3 &worldDir, bool useScale );
+        Vector3 convertWorldToLocalDirection( const Vector3 &worldDir, bool useScale ) const;
 
         /** Gets the world direction of a point in the node local space
             useful for simple transforms that don't require a child node.
@@ -612,14 +612,14 @@ namespace Ogre {
         @param useScale determines if this node or it's parents' scale affects
             the magnitude of the returned localDir vector.
         */
-        Vector3 convertLocalToWorldDirection( const Vector3 &localDir, bool useScale );
+        Vector3 convertLocalToWorldDirection( const Vector3 &localDir, bool useScale ) const;
 
         /** Gets the local orientation, relative to this node, of the given world-space orientation */
-        Quaternion convertWorldToLocalOrientation( const Quaternion &worldOrientation );
+        Quaternion convertWorldToLocalOrientation( const Quaternion &worldOrientation ) const;
 
         /** Gets the world orientation of an orientation in the node local space
             useful for simple transforms that don't require a child node.*/
-        Quaternion convertLocalToWorldOrientation( const Quaternion &localOrientation );
+        Quaternion convertLocalToWorldOrientation( const Quaternion &localOrientation ) const;
 
         /** Gets the initial orientation of this node, see setInitialState for more info. */
         const Quaternion& getInitialOrientation(void) const { return mInitialOrientation; }

--- a/OgreMain/src/OgreMesh.cpp
+++ b/OgreMain/src/OgreMesh.cpp
@@ -2278,6 +2278,35 @@ namespace Ogre {
 
     }
     //---------------------------------------------------------------------
+    size_t Mesh::getPoseIndex(const String& name) const
+    {
+        for (size_t i = 0; i < mPoseList.size(); ++i)
+        {
+            if (mPoseList[i]->getName() == name)
+                return i;
+        }
+        StringStream str;
+        str << "No pose called " << name << " found in Mesh " << mName;
+        OGRE_EXCEPT(Exception::ERR_ITEM_NOT_FOUND,
+            str.str(),
+            "Mesh::getPoseIndex");
+
+    }
+    //---------------------------------------------------------------------
+    size_t Mesh::getPoseIndex(const Pose* pose) const
+    {
+        for (size_t i = 0; i < mPoseList.size(); ++i)
+        {
+            if (mPoseList[i] == pose)
+                return i;
+        }
+        StringStream str;
+        str << "Pose not found in Mesh " << mName;
+        OGRE_EXCEPT(Exception::ERR_ITEM_NOT_FOUND,
+            str.str(),
+            "Mesh::getPoseIndex");
+    }
+    //---------------------------------------------------------------------
     void Mesh::removePose(ushort index)
     {
         OgreAssert(index < mPoseList.size(), "");

--- a/OgreMain/src/OgreMesh.cpp
+++ b/OgreMain/src/OgreMesh.cpp
@@ -224,8 +224,7 @@ namespace Ogre {
 
         if (!data) {
             OGRE_EXCEPT(Exception::ERR_INVALID_STATE,
-                        "Data doesn't appear to have been prepared in " + mName,
-                        "Mesh::loadImpl()");
+                        "Data doesn't appear to have been prepared in " + mName);
         }
 
         String baseName, strExt;
@@ -1200,8 +1199,7 @@ namespace Ogre {
     {
         SubMeshNameMap::const_iterator i = mSubMeshNameMap.find(name) ;
         if (i == mSubMeshNameMap.end())
-            OGRE_EXCEPT(Exception::ERR_ITEM_NOT_FOUND, "No SubMesh named " + name + " found.",
-                "Mesh::_getSubMeshIndex");
+            OGRE_EXCEPT(Exception::ERR_ITEM_NOT_FOUND, "No SubMesh named " + name + " found.");
 
         return i->second;
     }
@@ -2105,8 +2103,7 @@ namespace Ogre {
                         OGRE_EXCEPT(Exception::ERR_INVALIDPARAMS,
                             "Animation tracks for shared vertex data on mesh "
                             + mName + " try to mix vertex animation types, which is "
-                            "not allowed.",
-                            "Mesh::_determineAnimationTypes");
+                            "not allowed.");
                     }
                     mSharedVertexDataAnimationType = track->getAnimationType();
                     if (track->getAnimationType() == VAT_MORPH)
@@ -2127,8 +2124,7 @@ namespace Ogre {
                             "Animation tracks for dedicated vertex data "
                             + StringConverter::toString(handle-1) + " on mesh "
                             + mName + " try to mix vertex animation types, which is "
-                            "not allowed.",
-                            "Mesh::_determineAnimationTypes");
+                            "not allowed.");
                     }
                     sm->mVertexAnimationType = track->getAnimationType();
                     if (track->getAnimationType() == VAT_MORPH)
@@ -2150,8 +2146,7 @@ namespace Ogre {
         {
             OGRE_EXCEPT(
                 Exception::ERR_DUPLICATE_ITEM,
-                "An animation with the name " + name + " already exists",
-                "Mesh::createAnimation");
+                "An animation with the name " + name + " already exists");
         }
 
         Animation* ret = OGRE_NEW Animation(name, length);
@@ -2173,8 +2168,7 @@ namespace Ogre {
         if (!ret)
         {
             OGRE_EXCEPT(Exception::ERR_ITEM_NOT_FOUND,
-                "No animation entry found named " + name,
-                "Mesh::getAnimation");
+                "No animation entry found named " + name);
         }
 
         return ret;
@@ -2223,8 +2217,7 @@ namespace Ogre {
 
         if (i == mAnimationsList.end())
         {
-            OGRE_EXCEPT(Exception::ERR_ITEM_NOT_FOUND, "No animation entry found named " + name,
-                "Mesh::getAnimation");
+            OGRE_EXCEPT(Exception::ERR_ITEM_NOT_FOUND, "No animation entry found named " + name);
         }
 
         OGRE_DELETE i->second;
@@ -2270,12 +2263,8 @@ namespace Ogre {
             if (i->getName() == name)
                 return i;
         }
-        StringStream str;
-        str << "No pose called " << name << " found in Mesh " << mName;
         OGRE_EXCEPT(Exception::ERR_ITEM_NOT_FOUND,
-            str.str(),
-            "Mesh::getPose");
-
+                    StringUtil::format("No pose called %s found in Mesh %s", name.c_str(), mName.c_str()));
     }
     //---------------------------------------------------------------------
     size_t Mesh::getPoseIndex(const String& name) const
@@ -2285,12 +2274,8 @@ namespace Ogre {
             if (mPoseList[i]->getName() == name)
                 return i;
         }
-        StringStream str;
-        str << "No pose called " << name << " found in Mesh " << mName;
         OGRE_EXCEPT(Exception::ERR_ITEM_NOT_FOUND,
-            str.str(),
-            "Mesh::getPoseIndex");
-
+                    StringUtil::format("No pose called %s found in Mesh %s", name.c_str(), mName.c_str()));
     }
     //---------------------------------------------------------------------
     size_t Mesh::getPoseIndex(const Pose* pose) const
@@ -2300,11 +2285,8 @@ namespace Ogre {
             if (mPoseList[i] == pose)
                 return i;
         }
-        StringStream str;
-        str << "Pose not found in Mesh " << mName;
         OGRE_EXCEPT(Exception::ERR_ITEM_NOT_FOUND,
-            str.str(),
-            "Mesh::getPoseIndex");
+                    StringUtil::format("Pose not found in Mesh %s", mName.c_str()));
     }
     //---------------------------------------------------------------------
     void Mesh::removePose(ushort index)
@@ -2328,11 +2310,8 @@ namespace Ogre {
                 return;
             }
         }
-        StringStream str;
-        str << "No pose called " << name << " found in Mesh " << mName;
         OGRE_EXCEPT(Exception::ERR_ITEM_NOT_FOUND,
-            str.str(),
-            "Mesh::removePose");
+                    StringUtil::format("No pose called %s found in Mesh %s", name.c_str(), mName.c_str()));
     }
     //---------------------------------------------------------------------
     void Mesh::removeAllPoses(void)

--- a/OgreMain/src/OgreNode.cpp
+++ b/OgreMain/src/OgreNode.cpp
@@ -475,7 +475,7 @@ namespace Ogre {
         return mDerivedScale;
     }
     //-----------------------------------------------------------------------
-    Vector3 Node::convertWorldToLocalPosition( const Vector3 &worldPos )
+    Vector3 Node::convertWorldToLocalPosition( const Vector3 &worldPos ) const
     {
         if (mNeedParentUpdate)
         {
@@ -488,7 +488,7 @@ namespace Ogre {
 #endif
     }
     //-----------------------------------------------------------------------
-    Vector3 Node::convertLocalToWorldPosition( const Vector3 &localPos )
+    Vector3 Node::convertLocalToWorldPosition( const Vector3 &localPos ) const
     {
         if (mNeedParentUpdate)
         {
@@ -497,7 +497,7 @@ namespace Ogre {
         return _getFullTransform() * localPos;
     }
     //-----------------------------------------------------------------------
-    Vector3 Node::convertWorldToLocalDirection( const Vector3 &worldDir, bool useScale )
+    Vector3 Node::convertWorldToLocalDirection( const Vector3 &worldDir, bool useScale ) const
     {
         if (mNeedParentUpdate)
         {
@@ -514,7 +514,7 @@ namespace Ogre {
 #endif
     }
     //-----------------------------------------------------------------------
-    Vector3 Node::convertLocalToWorldDirection( const Vector3 &localDir, bool useScale )
+    Vector3 Node::convertLocalToWorldDirection( const Vector3 &localDir, bool useScale ) const
     {
         if (mNeedParentUpdate)
         {
@@ -523,7 +523,7 @@ namespace Ogre {
         return useScale ? _getFullTransform().linear() * localDir : mDerivedOrientation * localDir;
     }
     //-----------------------------------------------------------------------
-    Quaternion Node::convertWorldToLocalOrientation( const Quaternion &worldOrientation )
+    Quaternion Node::convertWorldToLocalOrientation( const Quaternion &worldOrientation ) const
     {
         if (mNeedParentUpdate)
         {
@@ -532,7 +532,7 @@ namespace Ogre {
         return mDerivedOrientation.Inverse() * worldOrientation;
     }
     //-----------------------------------------------------------------------
-    Quaternion Node::convertLocalToWorldOrientation( const Quaternion &localOrientation )
+    Quaternion Node::convertLocalToWorldOrientation( const Quaternion &localOrientation ) const
     {
         if (mNeedParentUpdate)
         {


### PR DESCRIPTION
Makes some functions on Node const.

Adds helper functions to get Pose indices from Mesh. Can't add them to an animation by name or pointer so we need to go through the Mesh's PoseList to find the indices.