### PR TITLE
Fix Skybox material invalidation

### DIFF
--- a/OgreMain/src/OgreSkyRenderer.cpp
+++ b/OgreMain/src/OgreSkyRenderer.cpp
@@ -173,7 +173,7 @@ void SceneManager::SkyBoxRenderer::create(
     mSceneNode->attachObject(mSkyBoxObj.get());
 
     mSkyBoxObj->setRenderQueueGroup(renderQueue);
-    mSkyBoxObj->begin(materialName, RenderOperation::OT_TRIANGLE_STRIP, groupName);
+    mSkyBoxObj->begin(m, RenderOperation::OT_TRIANGLE_STRIP);
 
     // rendering cube, only using 14 vertices
     const Vector3 cube_strip[14] = {

--- a/OgreMain/src/OgreSkyRenderer.cpp
+++ b/OgreMain/src/OgreSkyRenderer.cpp
@@ -153,8 +153,10 @@ void SceneManager::SkyBoxRenderer::create(
     if(valid)
     {
         Pass* pass = m->getBestTechnique()->getPass(0);
-        valid = valid && pass->getNumTextureUnitStates() &&
-                pass->getTextureUnitState(0)->getTextureType() == TEX_TYPE_CUBE_MAP;
+        if (pass->getNumTextureUnitStates())
+        {
+            valid = valid && pass->getTextureUnitState(0)->getTextureType() == TEX_TYPE_CUBE_MAP;
+        }
     }
 
     if (!valid)


### PR DESCRIPTION
The code looked wrong. I think this is what was intended.

Possible remaining issue is that it first disables the depth-writing on the provided material but then might switch to the default material and use it without disabling depth-writing. I don't think we want to modify the default material. Would anything bad happen if we just used the provided material even if it doesn't have cube map texture (and still issue a warning)?