### PR TITLE
Update zlib version from 1.3.1 to 1.3.2

### DIFF
--- a/CMake/Dependencies.cmake
+++ b/CMake/Dependencies.cmake
@@ -147,17 +147,17 @@ if(OGRE_BUILD_DEPENDENCIES AND NOT EXISTS ${OGREDEPS_PATH})
     if(MSVC OR MINGW OR SKBUILD) # other platforms dont need this
       message(STATUS "Building zlib") # only needed for Assimp
       file(DOWNLOAD
-          https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz
-          ${PROJECT_BINARY_DIR}/zlib-1.3.1.tar.gz
-          EXPECTED_HASH SHA256=9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23)
+          https://github.com/madler/zlib/releases/download/v1.3.2/zlib-1.3.2.tar.gz
+          ${PROJECT_BINARY_DIR}/zlib-1.3.2.tar.gz
+          EXPECTED_HASH SHA256=bb329a0a2cd0274d05519d61c667c062e06990d72e125ee2dfa8de64f0119d16)
       execute_process(COMMAND ${CMAKE_COMMAND}
-          -E tar xf zlib-1.3.1.tar.gz WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
+          -E tar xf zlib-1.3.2.tar.gz WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
       execute_process(COMMAND ${BUILD_COMMAND_COMMON}
           -DBUILD_SHARED_LIBS=${OGREDEPS_SHARED}
-          ${PROJECT_BINARY_DIR}/zlib-1.3.1
-          WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/zlib-1.3.1)
+          ${PROJECT_BINARY_DIR}/zlib-1.3.2
+          WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/zlib-1.3.2)
       execute_process(COMMAND ${CMAKE_COMMAND}
-          --build ${PROJECT_BINARY_DIR}/zlib-1.3.1 ${BUILD_COMMAND_OPTS})
+          --build ${PROJECT_BINARY_DIR}/zlib-1.3.2 ${BUILD_COMMAND_OPTS})
 
       message(STATUS "Building Assimp")
       file(DOWNLOAD


### PR DESCRIPTION
Address the findings of the just-completed [7ASecurity audit](https://7asecurity.com/blog/2026/02/zlib-7asecurity-audit/)
Completely rewrite the cmake support 
Support non-blocking devices with the gz* functions
Many other enhancements, fixes, and portability improvements

https://github.com/madler/zlib/releases/tag/v1.3.2