### PR TITLE
Main: Root - make sure first frame updates animation and controllers

### DIFF
--- a/OgreMain/src/OgreRoot.cpp
+++ b/OgreMain/src/OgreRoot.cpp
@@ -99,7 +99,7 @@ namespace Ogre {
         const String& logFileName)
       : mQueuedEnd(false)
       , mCurrentSceneManager(NULL)
-      , mNextFrame(0)
+      , mNextFrame(1)
       , mFrameSmoothingTime(0.0f)
       , mRemoveQueueStructuresOnClear(false)
       , mDefaultMinPixelSize(0)


### PR DESCRIPTION
SceneManagers and ControllerManager, etc. initialize their frame number to 0 and only perform their updates when the Root's frame number is different. But the Root also initializes its frame number to 0 and doesn't increment it until after the first frame, so animations (etc.) are not applied until the second frame, causing visible glitches on the first frame.