### PR TITLE
Main: Node - make _setDerived functions always work

### DIFF
--- a/OgreMain/src/OgreNode.cpp
+++ b/OgreMain/src/OgreNode.cpp
@@ -434,6 +434,8 @@ namespace Ogre {
         //find where the node would end up in parent's local space
         if(mParent)
             setPosition( mParent->convertWorldToLocalPosition( pos ) );
+        else
+            setPosition( pos );
     }
     //-----------------------------------------------------------------------
     void Node::_setDerivedOrientation( const Quaternion& q )
@@ -441,6 +443,8 @@ namespace Ogre {
         //find where the node would end up in parent's local space
         if(mParent)
             setOrientation( mParent->convertWorldToLocalOrientation( q ) );
+        else
+            setOrientation( q );
     }
 
     //-----------------------------------------------------------------------


### PR DESCRIPTION
When a Node does not have a parent Node, the _getDerived, convertWorldToLocal and convertLocalToWorld functions behave as if the Node's transform constitutes the entire derived transform. This makes intuitive sense and allows the user to be agnostic to the Node's rank in the scene graph.

In contrast, the _setDerived functions quietly do nothing, requiring the user to test the Node for a parent and call different functions. Since the test is performed in _setDerived anyway, it might as well provide the intuitive and consistent fallback behavior.