### PR TITLE
Install bundled Bullet headers regardless of OGRE_INSTALL_DEPENDENCIES

### DIFF
--- a/CMake/InstallDependencies.cmake
+++ b/CMake/InstallDependencies.cmake
@@ -80,6 +80,17 @@ macro(copy_release INPUT)
   endif ()
 endmacro ()
 
+# The bundled Bullet headers are part of the exported OgreBullet target's
+# interface ($<INSTALL_INTERFACE:include/bullet>), so they must be installed
+# whenever the component was built against the bundled Bullet - regardless of
+# OGRE_INSTALL_DEPENDENCIES, which defaults to OFF outside Windows/Apple.
+# Otherwise the installed package config advertises a non-existent include
+# directory and any project that links OGRE_LIBRARIES after find_package(OGRE)
+# fails to configure.
+if(OGRE_BUILD_DEPENDENCIES AND OGRE_BUILD_COMPONENT_BULLET)
+  install(DIRECTORY ${OGRE_DEP_DIR}/include/bullet DESTINATION include)
+endif()
+
 if (OGRE_INSTALL_DEPENDENCIES)
   if (OGRE_STATIC)
     # for static builds, projects must link against all Ogre dependencies themselves, so copy full include and lib dir
@@ -106,10 +117,6 @@ if (OGRE_INSTALL_DEPENDENCIES)
       install(DIRECTORY ${OGRE_DEP_DIR}/bin/ DESTINATION ${OGRE_BIN_DIRECTORY})
     endif ()
   endif ()
-
-  if(OGRE_BUILD_DEPENDENCIES AND OGRE_BUILD_COMPONENT_BULLET)
-    install(DIRECTORY ${OGRE_DEP_DIR}/include/bullet DESTINATION include)
-  endif()
 
   if(WIN32)
     if(OGRE_BUILD_SAMPLES OR OGRE_BUILD_TESTS)


### PR DESCRIPTION
## What

When Ogre is built with `OGRE_BUILD_DEPENDENCIES=ON` and the Bullet component, the exported `OgreBullet` target advertises `$<INSTALL_INTERFACE:include/bullet>` (`Components/Bullet/CMakeLists.txt`). The matching header install in `CMake/InstallDependencies.cmake` sits inside `if (OGRE_INSTALL_DEPENDENCIES)` — an option that defaults to **OFF** outside Windows/Apple/Emscripten and is described as "Install dependency libs needed for samples".

So a default Linux `make install` produces a package config whose `OgreBullet` imported target points at a directory that does not exist. Because `OGREConfig.cmake` appends every built component to `OGRE_LIBRARIES`, any downstream project that does `find_package(OGRE CONFIG)` and links `${OGRE_LIBRARIES}` fails at generate time:

```
CMake Error: Imported target "OgreBullet" includes non-existent path
  ".../include/bullet" in its INTERFACE_INCLUDE_DIRECTORIES.
```

(Observed in the wild with CEGUI's Ogre renderer module; the usual workaround people find is `-DOGRE_BUILD_COMPONENT_BULLET=OFF`.)

## Fix

Move the bundled-Bullet header install out of the `OGRE_INSTALL_DEPENDENCIES` block: those headers are part of the exported target's public interface (`OgreBullet.h` includes them), not optional sample baggage. The install stays conditional on `OGRE_BUILD_DEPENDENCIES AND OGRE_BUILD_COMPONENT_BULLET`, so nothing changes for system-Bullet or component-off builds.

## Verified

On Linux with `OGRE_BUILD_DEPENDENCIES=ON` + `OGRE_BUILD_COMPONENT_BULLET=ON` (bundled bullet 3.25): a downstream `find_package(OGRE)` + link `${OGRE_LIBRARIES}` configure reproduces the error before this change and generates cleanly after, with `include/bullet` present in the install prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
