### PR TITLE
Main: SkeletonInstance - remove broken overrides and pass info to ctor

### DIFF
--- a/OgreMain/include/OgreResource.h
+++ b/OgreMain/include/OgreResource.h
@@ -161,8 +161,8 @@ namespace Ogre {
     protected:
         /** Protected unnamed constructor to prevent default construction. 
         */
-        Resource() 
-            : mCreator(0), mHandle(0), mLoadingState(LOADSTATE_UNLOADED), 
+        Resource(const String& name, ResourceHandle handle, const String& group)
+            : mCreator(0), mName(name), mGroup(group), mHandle(handle), mLoadingState(LOADSTATE_UNLOADED),
               mIsBackgroundLoaded(0), mIsManual(0), mSize(0), mLoader(0), mStateCount(0)
         { 
         }

--- a/OgreMain/include/OgreSkeleton.h
+++ b/OgreMain/include/OgreSkeleton.h
@@ -84,7 +84,7 @@ namespace Ogre {
         friend class SkeletonInstance;
     private:
         /// Internal constructor for use by SkeletonInstance only
-        Skeleton();
+        Skeleton(const String& name, ResourceHandle handle, const String& group);
 
     public:
         /** Constructor, don't call directly, use SkeletonManager.

--- a/OgreMain/include/OgreSkeletonInstance.h
+++ b/OgreMain/include/OgreSkeletonInstance.h
@@ -111,13 +111,6 @@ namespace Ogre {
         /// @copydoc Skeleton::_refreshAnimationState
         void _refreshAnimationState(AnimationStateSet* animSet) override;
 
-        /// @copydoc Resource::getName
-        const String& getName(void) const;
-        /// @copydoc Resource::getHandle
-        ResourceHandle getHandle(void) const;
-        /// @copydoc Resource::getGroup
-        const String& getGroup(void) const;
-
     private:
         /// Pointer back to master Skeleton
         SkeletonPtr mSkeleton;

--- a/OgreMain/src/OgreSkeleton.cpp
+++ b/OgreMain/src/OgreSkeleton.cpp
@@ -37,8 +37,8 @@ THE SOFTWARE.
 namespace Ogre {
 
     //---------------------------------------------------------------------
-    Skeleton::Skeleton()
-        : Resource(),
+    Skeleton::Skeleton(const String& name, ResourceHandle handle, const String& group)
+        : Resource(name, handle, group),
         mBlendState(ANIMBLEND_AVERAGE),
         mManualBonesDirty(false)
     {

--- a/OgreMain/src/OgreSkeletonInstance.cpp
+++ b/OgreMain/src/OgreSkeletonInstance.cpp
@@ -33,7 +33,7 @@ THE SOFTWARE.
 namespace Ogre {
     //-------------------------------------------------------------------------
     SkeletonInstance::SkeletonInstance(const SkeletonPtr& masterCopy)
-        : Skeleton()
+        : Skeleton(masterCopy->getName(), masterCopy->getHandle(), masterCopy->getGroup())
         , mSkeleton(masterCopy)
     {
     }
@@ -222,24 +222,6 @@ namespace Ogre {
 
             mFreeTagPoints.splice(mFreeTagPoints.end(), mActiveTagPoints, it);
         }
-    }
-    //-------------------------------------------------------------------------
-    const String& SkeletonInstance::getName(void) const
-    {
-        // delegate
-        return mSkeleton->getName();
-    }
-    //-------------------------------------------------------------------------
-    ResourceHandle SkeletonInstance::getHandle(void) const
-    {
-        // delegate
-        return mSkeleton->getHandle();
-    }
-    //-------------------------------------------------------------------------
-    const String& SkeletonInstance::getGroup(void) const
-    {
-        // delegate
-        return mSkeleton->getGroup();
     }
 
 }


### PR DESCRIPTION
Commit c285df6 de-virtualised Resource::getName(), getHandle(), and getGroup(), which broke SkeletonInstance’s overrides of those (when called virtually). SkeletonInstance just delegated those to its master Skeleton. It can instead grab the info in its constructor and pass it to Skeleton’s private constructor and Resource’s protected constructor which exist only for SkeletonInstance anyway.

Potential drawback: if lots of instances and strings are big, could waste a little memory.