### PR TITLE
Add platform-specific thread naming in worker threads

### DIFF
--- a/OgreMain/src/OgreDefaultWorkQueueStandard.cpp
+++ b/OgreMain/src/OgreDefaultWorkQueueStandard.cpp
@@ -64,7 +64,15 @@ namespace Ogre
         mNumThreadsRegisteredWithRS = 0;
         for (size_t i = 0; i < mWorkerThreadCount; ++i)
         {
-            OGRE_THREAD_CREATE(t, [this]() { _threadMain(); });
+            OGRE_THREAD_CREATE(t, [this]() {
+#  if OGRE_PLATFORM == OGRE_PLATFORM_WIN32
+                // std::wstring wname(name.begin(), name.end());
+                // SetThreadDescription(static_cast<HANDLE>(t.native_handle()), wname.c_str());
+#  elif OGRE_PLATFORM == OGRE_PLATFORM_LINUX || OGRE_PLATFORM == OGRE_PLATFORM_APPLE_IOS || OGRE_PLATFORM == OGRE_PLATFORM_ANDROID
+                pthread_setname_np(pthread_self(), mName.substr(0, 15).c_str());
+#  endif
+                _threadMain();
+            });
             mWorkers.push_back(t);
         }
 

--- a/OgreMain/src/OgreDefaultWorkQueueStandard.cpp
+++ b/OgreMain/src/OgreDefaultWorkQueueStandard.cpp
@@ -71,7 +71,7 @@ namespace Ogre
 #  elif OGRE_PLATFORM == OGRE_PLATFORM_LINUX || OGRE_PLATFORM == OGRE_PLATFORM_ANDROID
                 pthread_setname_np(pthread_self(), mName.substr(0, 15).c_str());
 #  elif OGRE_PLATFORM == OGRE_PLATFORM_APPLE_IOS || OGRE_PLATFORM == OGRE_PLATFORM_APPLE
-                pthread_setname_np(name.c_str());
+                pthread_setname_np(mName.c_str());
 #  endif
                 _threadMain();
             });

--- a/OgreMain/src/OgreDefaultWorkQueueStandard.cpp
+++ b/OgreMain/src/OgreDefaultWorkQueueStandard.cpp
@@ -68,8 +68,10 @@ namespace Ogre
 #  if OGRE_PLATFORM == OGRE_PLATFORM_WIN32
                 // std::wstring wname(name.begin(), name.end());
                 // SetThreadDescription(static_cast<HANDLE>(t.native_handle()), wname.c_str());
-#  elif OGRE_PLATFORM == OGRE_PLATFORM_LINUX || OGRE_PLATFORM == OGRE_PLATFORM_APPLE_IOS || OGRE_PLATFORM == OGRE_PLATFORM_ANDROID
+#  elif OGRE_PLATFORM == OGRE_PLATFORM_LINUX || OGRE_PLATFORM == OGRE_PLATFORM_ANDROID
                 pthread_setname_np(pthread_self(), mName.substr(0, 15).c_str());
+#  elif OGRE_PLATFORM == OGRE_PLATFORM_APPLE_IOS || OGRE_PLATFORM == OGRE_PLATFORM_APPLE
+                pthread_setname_np(name.c_str());
 #  endif
                 _threadMain();
             });

--- a/OgreMain/src/OgreDefaultWorkQueueStandard.cpp
+++ b/OgreMain/src/OgreDefaultWorkQueueStandard.cpp
@@ -64,17 +64,18 @@ namespace Ogre
         mNumThreadsRegisteredWithRS = 0;
         for (size_t i = 0; i < mWorkerThreadCount; ++i)
         {
-            OGRE_THREAD_CREATE(t, [this]() {
+            auto threadProc = [this]() {
 #  if OGRE_PLATFORM == OGRE_PLATFORM_WIN32
-                // std::wstring wname(name.begin(), name.end());
-                // SetThreadDescription(static_cast<HANDLE>(t.native_handle()), wname.c_str());
+                // std::wstring wname(mName.begin(), mName.end());
+                // SetThreadDescription(GetCurrentThread(), wname.c_str());
 #  elif OGRE_PLATFORM == OGRE_PLATFORM_LINUX || OGRE_PLATFORM == OGRE_PLATFORM_ANDROID
                 pthread_setname_np(pthread_self(), mName.substr(0, 15).c_str());
 #  elif OGRE_PLATFORM == OGRE_PLATFORM_APPLE_IOS || OGRE_PLATFORM == OGRE_PLATFORM_APPLE
                 pthread_setname_np(mName.c_str());
 #  endif
                 _threadMain();
-            });
+            };
+            OGRE_THREAD_CREATE(t, threadProc);
             mWorkers.push_back(t);
         }
 


### PR DESCRIPTION
Set thread names based on platform in worker thread creation. Currently windows is researching, so implement some os first.